### PR TITLE
feat: bounded JS1 evaluator and trusted verification

### DIFF
--- a/.github/workflows/js1-smolvm.yml
+++ b/.github/workflows/js1-smolvm.yml
@@ -1,0 +1,60 @@
+name: js1-smolvm
+
+# JS1 × SmolVM guest lane (pilot). docs/JS1_SMOLVM_CI.md is the authority.
+#
+# Dispatch semantics: workflow_dispatch ONLY — this lane never runs on push
+# or pull_request, so it can never gate a merge, and .github/workflows/
+# tests.yml is untouched. A red conclusion here means "refused, see the
+# receipt" (e.g. the guest pack is not provisioned on the runner yet); it
+# is a honest signal, not a blocked pipeline.
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this dispatch (recorded in the run receipt)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# One VM lane per runner fleet at a time; never cancel a run mid-VM —
+# teardown must complete.
+concurrency:
+  group: js1-smolvm
+  cancel-in-progress: false
+
+jobs:
+  guest-evidence:
+    name: JS1 evidence in a pinned SmolVM guest
+    # Self-hosted runner with Linux, x86_64, and /dev/kvm. The pinned
+    # smolvm 1.7.5 launcher and the built guest pack are runner
+    # provisioning, verified by digest in the producer gate — never
+    # fetched at run time.
+    runs-on: [self-hosted, linux, x64, kvm]
+    timeout-minutes: 45
+    env:
+      # Every explicit work dir of the harness lives here — runner-owned,
+      # never host /tmp. One run id shared by all three stages.
+      JS1_SMOLVM_CI_DIR: ${{ runner.temp }}/js1-smolvm
+      JS1_SMOLVM_RUN_ID: "gha-${{ github.run_id }}-${{ github.run_attempt }}"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight (platform, KVM, tooling, stale-machine sweep)
+        run: ci/js1-smolvm/preflight.sh
+
+      - name: Producer pin and inventory gates
+        run: ci/js1-smolvm/producer-gate.sh
+
+      - name: Consumer run (network-disabled guest, read-only source)
+        run: ci/js1-smolvm/consumer-run.sh
+
+      - name: Upload receipts and bounded logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: js1-smolvm-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.JS1_SMOLVM_CI_DIR }}
+          if-no-files-found: warn
+          retention-days: 14

--- a/artifacts/js1-evidence.edn
+++ b/artifacts/js1-evidence.edn
@@ -1,9 +1,9 @@
 ;; JS1 closure evidence. Passing deterministic gates do not imply cutover.
 {:js1/decision :revise
- :js1/record-date "2026-08-24"
+ :js1/record-date "2026-08-25"
  :js1/baseline
  {:samizdat {:branch "js1-bounded-samizdat"
-             :revision "db1226f"
+             :revision "8995e113"
              :recovery-base "321661649e174bb748adeb6970dad6c166003343"
              :upstream-base "dae78547a66c80f31fa7a78d0f9483186a2b0af9"
              :closure-changes :committed}
@@ -31,16 +31,32 @@
   "controlled actual OS-process recovery with helper persistence and no repeated observation/edit"
   "fail-closed runtime/spec/pending-history recovery"
   "single-player JS1 multi-branch refusal"
-  "structured verifier with scrubbed environment, bounded streams, redact-before-render, and fail-closed availability"]
+  "structured verifier with scrubbed environment, bounded streams, redact-before-render, and fail-closed availability"
+  "live bounded-model RED/SIGKILL/fresh-resume/helper-reconstruction/repair/GREEN dogfood"
+  "frozen bbagent A3c comparison for bounded programming and no-repeat replay"]
+ :js1/live-dogfood
+ {:provider :local
+  :model "Qwen3.6-27B-MTP-GGUF"
+  :endpoint "http://localhost:13305/v1"
+  :run-id "709e2b2d-c0af-40e6-9d3e-0d9624217a2b"
+  :artifact-dir "~/.local/share/samizdat/js1-dogfood/run-1787629704126-ad047d12-b837-4330-b1ba-7e162c0034f0/artifacts"
+  :red-turn 10
+  :start-exit 137
+  :resume-exit 0
+  :semantic-counts {:project/list 2 :project/search 2 :project/read 4
+                    :project/stat 2 :project/edit 2}}
+ :js1/a3c-comparison
+ {:bbagent "bbagent-a3c / fc5e5b9"
+  :bb4t "bb4t-a3c / 227d3854"
+  :result "bounded programming and no-repeat replay retained; guest isolation unclaimed"}
  :js1/remaining-pass-gates
- ["real-model red-repair-green dogfood"
-  "frozen bbagent A3c comparison"
-  "live controller-owned budget proof"
-  "pinned SmolVM guest boot and clean-consumer execution (unexecuted: guest pack :unbuilt)"]
+ ["trusted authenticated controller budget-extension authority"
+  "atomic durable retained budget-extension audit"
+  "actual cancellation proof for a timed-out controller turn"]
  :js1/non-claims
  ["no self-hosting canary"
   "no project/run, generic shell, network, Git mutation, JS2, or multi-agent evaluator binding"
   "plain-JVM and non-Linux/platform lanes unexecuted"
-  "controlled recovery harness is not a live-model resume loop"
   "no performance claim"
+  "A3c guest execution isolation and clean-consumer SmolVM remain unclaimed (guest pack :unbuilt)"
   "turn rows do not carry evaluator identity; computational history is authoritative in the eval store and binding journal"]}

--- a/artifacts/js1-evidence.edn
+++ b/artifacts/js1-evidence.edn
@@ -2,19 +2,25 @@
 {:js1/decision :revise
  :js1/record-date "2026-08-24"
  :js1/baseline
- {:samizdat {:branch "js1-bounded-samizdat" :rebased-on "d083eeb"}
-  :jolt {:revision "619ef19685460af847654e22cf6beda904d052fb"
-         :branch "js0-functional-sci-upstream"
-         :js0-freeze "04dd42db"
-         :js0-freeze-tag "js0-functional-sci-upstream-freeze"}
+ {:samizdat {:branch "js1-bounded-samizdat"
+             :recovery-base "321661649e174bb748adeb6970dad6c166003343"
+             :upstream-base "dae78547a66c80f31fa7a78d0f9483186a2b0af9"
+             :closure-changes :pending-commit}
+  :jolt {:revision "279bca18bbf50f37b8574a4e6998dee40313cd26"
+         :branch "js1-runtime-current-upstream"
+         :upstream-base "edda7aec"
+         :historical-js0-freeze "04dd42db"
+         :historical-post-js0-runtime "619ef196"}
   :sci {:revision "32d62a5136ad3dc148588752f5bcc4cc30b14752"
         :version "0.13.53"}}
  :js1/executed-gates
- {:full-suite "1000 tests / 3316 assertions / 0 failures / 0 errors"
+ {:full-suite "1047 tests / 3658 assertions / 0 failures / 0 errors"
   :bounded-sandbox "28 tests / 268 assertions / 0 failures / 0 errors"
   :eval-store "18 tests / 78 assertions / 0 failures / 0 errors"
   :os-process-boundary "1 test / 30 assertions / 0 failures / 0 errors"
-  :static-smolvm-harness "12 tests / 156 assertions / 0 failures / 0 errors"}
+  :static-smolvm-harness "12 tests / 156 assertions / 0 failures / 0 errors"
+  :jolt-current-gates "manifest/selfhost/scievaluator/testbin all pass"
+  :verifier-hardening "injection/env-scrub/redaction/scoped-cleanup pass"}
  :js1/evidenced
  ["versioned runtime/spec/binding/receipt identity"
   "strict operation receipts and bounded rendering of arbitrary SCI final values"
@@ -23,12 +29,13 @@
   "zero real semantic operations during replay"
   "controlled actual OS-process recovery with helper persistence and no repeated observation/edit"
   "fail-closed runtime/spec/pending-history recovery"
-  "single-player JS1 multi-branch refusal"]
+  "single-player JS1 multi-branch refusal"
+  "structured verifier with scrubbed environment, bounded streams, redact-before-render, and fail-closed availability"]
  :js1/remaining-pass-gates
  ["real-model red-repair-green dogfood"
   "frozen bbagent A3c comparison"
   "live controller-owned budget proof"
-  "pinned SmolVM guest boot and clean-consumer execution"]
+  "pinned SmolVM guest boot and clean-consumer execution (unexecuted: guest pack :unbuilt)"]
  :js1/non-claims
  ["no self-hosting canary"
   "no project/run, generic shell, network, Git mutation, JS2, or multi-agent evaluator binding"

--- a/artifacts/js1-evidence.edn
+++ b/artifacts/js1-evidence.edn
@@ -1,0 +1,97 @@
+;; JS1 cutover evidence — decision-first REVISE record
+;;
+;; DECISION: REVISE.  JS1 is not approved to merge.  This record leads with the
+;; decision, lists exactly which gates executed and which PASS criteria remain
+;; unmet, and preserves the standing non-claims verbatim.  Passing gates are not
+;; approval.
+
+{:js1/decision :revise
+
+ :js1/record-date "2026-08-23"
+
+ :js1/baseline
+ {:samizdat {:ref "main" :revision "b93d601" :committed? false
+             :note "ALL JS1 work is uncommitted (working tree only)"}
+  :jolt-upstream {:js0-revision "04dd42db"
+                  :js0-branch "js0-functional-sci-upstream"
+                  :frozen-tag "js0-functional-sci-upstream-freeze"
+                  :upstream-baseline "c4547b5e"
+                  :sci "32d62a51"}
+  :upstream-action {:pr? false :push? false}}
+
+ :js1/executed-gates
+ {:full-suite "946 tests / 2998 assertions"
+  :direct-sandbox "14 / 111 (offline -Scp invocation)"
+  :eval-store "13 / 58 (samizdat.store.evals)"
+  :wiring-require "guarded samizdat.agent.sandbox require; non-JS1 path bears no dependency cost"
+  :model-tool-surface "#{eval doc complete done} (closed set)"
+  :host-capability-authority
+  {:enforcement-point "tools/base.clj phase-refusal — single point, before dispatch"
+   :flag-authority "trusted config/workflow only, never model input"
+   :allowed-tools #{"eval" "doc" "complete" "done"}}
+  :replay
+  {:journal-event ":js1-binding-created"
+   :journal-fields [:profile :binding-id :instance-id :spec-coordinate :preset]
+   :durable-receipts "store/evals: ordered {op args result|error}, consumed in order at replay"}
+  :evaluator-binding-seam
+  {:coordinates [:evaluator-spec :instance :binding]
+   :ctx-key ":js1/binding"
+   :check-order "eval/doc/complete check :js1/binding FIRST"
+   :js1-route "sandbox/evaluate! on the persistent binding"
+   :non-js1-route "repl/eval-code on :repl-session (live JVM, unchanged)"}
+  :upstream-pr-push {:pr? false :push? false}}
+
+ :js1/unmet-pass-criteria
+ ["no real model dogfood task"
+  "no actual process terminate/restart/resume evidence"
+  "no frozen bbagent A3c comparison"
+  "no live controller budget proof"
+  "no cross-platform run"]
+
+ :js1/durable-restart
+ {:claimed? false
+  :reason "only fail-closed resume POLICY is implemented; no actual terminate → restart → resume cycle executed"}
+
+ :js1/files
+ {:modified
+  ["resources/prompts/system.md"
+   "src/samizdat/agent/beam.clj"
+   "src/samizdat/agent/files.clj"
+   "src/samizdat/agent/resume.clj"
+   "src/samizdat/agent/tools.clj"
+   "src/samizdat/agent/tools/base.clj"
+   "src/samizdat/agent/tools/repl.clj"
+   "src/samizdat/store/migrations.clj"
+   "src/samizdat/workflow.clj"
+   "test/samizdat/test_runner.clj"]
+  :new-untracked
+  ["src/samizdat/agent/sandbox.clj"
+   "src/samizdat/store/evals.clj"
+   "test/samizdat/evals_test.clj"
+   "test/samizdat/sandbox_test.clj"
+   "docs/JS1_FINDINGS.md"
+   "artifacts/js1-evidence.edn"]}
+
+ :js1/claimed
+ ["phase-refusal gate rejects tools outside the closed vocabulary before dispatch"
+  "with :js1/binding present, eval/doc/complete route to the sandbox binding and never touch samizdat.repl"
+  "with :js1/binding absent, tools behave exactly as before (bit-for-bit unchanged path)"
+  "resume of a JS1-profiled run fails closed when SCI is unavailable"
+  "the JS1 profile flag is set only from trusted config/workflow code, never from model input"
+  "nREPL, developer REPL, and all non-JS1 workflows are unaffected"]
+
+ :js1/non-claimed
+ ["Evaluator spec/instance/binding IDs in durable eval calls: the existing runs/start-run! API in store/runs.clj does not expose sandbox binding identity. The journal :js1-binding-created event carries the binding/spec/instance IDs for resume, but these are NOT incorporated into the eval turn rows themselves (the turns table schema was not editable). Documented as an integration blocker."
+  "SCI availability on plain JVM: the sandbox requires jolt.sandbox and SCI, which are jolt-only. New-run fallback is logged; resume is fail-closed. Platform constraint, not a code defect."
+  "JS1 doc/complete fidelity: SCI ns-publics and resolve/meta provide a subset of the live REPL's introspection; core var metadata may be stripped by jolt. Metadata-dependent features (arglists from core) may be degraded."
+  "Beam multi-branch JS1 isolation: all branches share the :main instance; per-branch isolation requires a distinct :instance/key, not done automatically."
+  "Performance: no measurement of JS1 eval latency vs. live REPL has been made."]
+
+ :js1/integration-blocker
+ {:description (str "runs/start-run! and the turns table schema carry no sandbox "
+                    "binding metadata (evaluator spec, instance ID, binding ID); "
+                    "the journal event records them for resume but the individual "
+                    "eval turn rows have no column for them")
+  :authority "journal :js1-binding-created event"
+  :remediation "schema migration (excluded by file fence) or join table"
+  :status "not attempted"}}

--- a/artifacts/js1-evidence.edn
+++ b/artifacts/js1-evidence.edn
@@ -1,97 +1,38 @@
-;; JS1 cutover evidence — decision-first REVISE record
-;;
-;; DECISION: REVISE.  JS1 is not approved to merge.  This record leads with the
-;; decision, lists exactly which gates executed and which PASS criteria remain
-;; unmet, and preserves the standing non-claims verbatim.  Passing gates are not
-;; approval.
-
+;; JS1 closure evidence. Passing deterministic gates do not imply cutover.
 {:js1/decision :revise
-
- :js1/record-date "2026-08-23"
-
+ :js1/record-date "2026-08-24"
  :js1/baseline
- {:samizdat {:ref "main" :revision "b93d601" :committed? false
-             :note "ALL JS1 work is uncommitted (working tree only)"}
-  :jolt-upstream {:js0-revision "04dd42db"
-                  :js0-branch "js0-functional-sci-upstream"
-                  :frozen-tag "js0-functional-sci-upstream-freeze"
-                  :upstream-baseline "c4547b5e"
-                  :sci "32d62a51"}
-  :upstream-action {:pr? false :push? false}}
-
+ {:samizdat {:branch "js1-bounded-samizdat" :rebased-on "d083eeb"}
+  :jolt {:revision "619ef19685460af847654e22cf6beda904d052fb"
+         :branch "js0-functional-sci-upstream"
+         :js0-freeze "04dd42db"
+         :js0-freeze-tag "js0-functional-sci-upstream-freeze"}
+  :sci {:revision "32d62a5136ad3dc148588752f5bcc4cc30b14752"
+        :version "0.13.53"}}
  :js1/executed-gates
- {:full-suite "946 tests / 2998 assertions"
-  :direct-sandbox "14 / 111 (offline -Scp invocation)"
-  :eval-store "13 / 58 (samizdat.store.evals)"
-  :wiring-require "guarded samizdat.agent.sandbox require; non-JS1 path bears no dependency cost"
-  :model-tool-surface "#{eval doc complete done} (closed set)"
-  :host-capability-authority
-  {:enforcement-point "tools/base.clj phase-refusal — single point, before dispatch"
-   :flag-authority "trusted config/workflow only, never model input"
-   :allowed-tools #{"eval" "doc" "complete" "done"}}
-  :replay
-  {:journal-event ":js1-binding-created"
-   :journal-fields [:profile :binding-id :instance-id :spec-coordinate :preset]
-   :durable-receipts "store/evals: ordered {op args result|error}, consumed in order at replay"}
-  :evaluator-binding-seam
-  {:coordinates [:evaluator-spec :instance :binding]
-   :ctx-key ":js1/binding"
-   :check-order "eval/doc/complete check :js1/binding FIRST"
-   :js1-route "sandbox/evaluate! on the persistent binding"
-   :non-js1-route "repl/eval-code on :repl-session (live JVM, unchanged)"}
-  :upstream-pr-push {:pr? false :push? false}}
-
- :js1/unmet-pass-criteria
- ["no real model dogfood task"
-  "no actual process terminate/restart/resume evidence"
-  "no frozen bbagent A3c comparison"
-  "no live controller budget proof"
-  "no cross-platform run"]
-
- :js1/durable-restart
- {:claimed? false
-  :reason "only fail-closed resume POLICY is implemented; no actual terminate → restart → resume cycle executed"}
-
- :js1/files
- {:modified
-  ["resources/prompts/system.md"
-   "src/samizdat/agent/beam.clj"
-   "src/samizdat/agent/files.clj"
-   "src/samizdat/agent/resume.clj"
-   "src/samizdat/agent/tools.clj"
-   "src/samizdat/agent/tools/base.clj"
-   "src/samizdat/agent/tools/repl.clj"
-   "src/samizdat/store/migrations.clj"
-   "src/samizdat/workflow.clj"
-   "test/samizdat/test_runner.clj"]
-  :new-untracked
-  ["src/samizdat/agent/sandbox.clj"
-   "src/samizdat/store/evals.clj"
-   "test/samizdat/evals_test.clj"
-   "test/samizdat/sandbox_test.clj"
-   "docs/JS1_FINDINGS.md"
-   "artifacts/js1-evidence.edn"]}
-
- :js1/claimed
- ["phase-refusal gate rejects tools outside the closed vocabulary before dispatch"
-  "with :js1/binding present, eval/doc/complete route to the sandbox binding and never touch samizdat.repl"
-  "with :js1/binding absent, tools behave exactly as before (bit-for-bit unchanged path)"
-  "resume of a JS1-profiled run fails closed when SCI is unavailable"
-  "the JS1 profile flag is set only from trusted config/workflow code, never from model input"
-  "nREPL, developer REPL, and all non-JS1 workflows are unaffected"]
-
- :js1/non-claimed
- ["Evaluator spec/instance/binding IDs in durable eval calls: the existing runs/start-run! API in store/runs.clj does not expose sandbox binding identity. The journal :js1-binding-created event carries the binding/spec/instance IDs for resume, but these are NOT incorporated into the eval turn rows themselves (the turns table schema was not editable). Documented as an integration blocker."
-  "SCI availability on plain JVM: the sandbox requires jolt.sandbox and SCI, which are jolt-only. New-run fallback is logged; resume is fail-closed. Platform constraint, not a code defect."
-  "JS1 doc/complete fidelity: SCI ns-publics and resolve/meta provide a subset of the live REPL's introspection; core var metadata may be stripped by jolt. Metadata-dependent features (arglists from core) may be degraded."
-  "Beam multi-branch JS1 isolation: all branches share the :main instance; per-branch isolation requires a distinct :instance/key, not done automatically."
-  "Performance: no measurement of JS1 eval latency vs. live REPL has been made."]
-
- :js1/integration-blocker
- {:description (str "runs/start-run! and the turns table schema carry no sandbox "
-                    "binding metadata (evaluator spec, instance ID, binding ID); "
-                    "the journal event records them for resume but the individual "
-                    "eval turn rows have no column for them")
-  :authority "journal :js1-binding-created event"
-  :remediation "schema migration (excluded by file fence) or join table"
-  :status "not attempted"}}
+ {:full-suite "1000 tests / 3316 assertions / 0 failures / 0 errors"
+  :bounded-sandbox "28 tests / 268 assertions / 0 failures / 0 errors"
+  :eval-store "18 tests / 78 assertions / 0 failures / 0 errors"
+  :os-process-boundary "1 test / 30 assertions / 0 failures / 0 errors"
+  :static-smolvm-harness "12 tests / 156 assertions / 0 failures / 0 errors"}
+ :js1/evidenced
+ ["versioned runtime/spec/binding/receipt identity"
+  "strict operation receipts and bounded rendering of arbitrary SCI final values"
+  "commit-only SCI state with rollback after failed or interrupted evaluation"
+  "whole-history replay into one fresh SCI context"
+  "zero real semantic operations during replay"
+  "controlled actual OS-process recovery with helper persistence and no repeated observation/edit"
+  "fail-closed runtime/spec/pending-history recovery"
+  "single-player JS1 multi-branch refusal"]
+ :js1/remaining-pass-gates
+ ["real-model red-repair-green dogfood"
+  "frozen bbagent A3c comparison"
+  "live controller-owned budget proof"
+  "pinned SmolVM guest boot and clean-consumer execution"]
+ :js1/non-claims
+ ["no self-hosting canary"
+  "no project/run, generic shell, network, Git mutation, JS2, or multi-agent evaluator binding"
+  "plain-JVM and non-Linux/platform lanes unexecuted"
+  "controlled recovery harness is not a live-model resume loop"
+  "no performance claim"
+  "turn rows do not carry evaluator identity; computational history is authoritative in the eval store and binding journal"]}

--- a/artifacts/js1-evidence.edn
+++ b/artifacts/js1-evidence.edn
@@ -3,9 +3,10 @@
  :js1/record-date "2026-08-24"
  :js1/baseline
  {:samizdat {:branch "js1-bounded-samizdat"
+             :revision "db1226f"
              :recovery-base "321661649e174bb748adeb6970dad6c166003343"
              :upstream-base "dae78547a66c80f31fa7a78d0f9483186a2b0af9"
-             :closure-changes :pending-commit}
+             :closure-changes :committed}
   :jolt {:revision "279bca18bbf50f37b8574a4e6998dee40313cd26"
          :branch "js1-runtime-current-upstream"
          :upstream-base "edda7aec"

--- a/bin/js1
+++ b/bin/js1
@@ -31,12 +31,30 @@
 set -eu
 
 # ── The pinned JS1 runtime stack (docs/JS1_RUNTIME.md § Pins) ────────────────
-# casselc/jolt @ js0-functional-sci-upstream — "sci: trusted inert
-# language-surface API with versioned coordinate", the jolt.sandbox
-# language-surface/0 and language-coordinate/0 the JS1 doc/complete surface
+# casselc/jolt @ js1-runtime-current-upstream, tip 279bca18, rebased onto
+# current upstream edda7aec. The rebase moved the SCI host-seam
+# follow-ups upstream (private map/newline compat vars, Thread.getId,
+# Numbers arithmetic statics, restored nested interrupt polling, a
+# persistent-SCI evaluation test — PRs #721–#725), so the branch now
+# carries only: the evaluator re-derivation ("feat: rederive JS1
+# evaluator on current upstream", 13e43418), the scoped Linux process
+# termination commit ("feat: add scoped Linux process termination",
+# a5fb8a3b: ProcessBuilder/Process over posix_spawn with waitpid/kill
+# lifecycle), bounded structured output for that scoped run ("feat:
+# bound scoped process output", 1f859e70: :out-bytes/:err-bytes caps
+# with a poll-bounded, fail-closed drain — the trusted controller
+# process-scope primitive JS1 verification consumes), and the tip
+# ("test: wire current SCI evaluator gates", 279bca18: opt-in make lanes
+# js0sandbox/js0authority/scievaluator plus discriminating Numbers
+# statics rows). jolt.sandbox itself is byte-identical to the previous
+# pin — the sandbox surface did NOT change — and keeps the trusted inert
+# language-surface API — jolt.sandbox/language-surface and
+# jolt.sandbox/language-coordinate, language-surface-version 1, the same
+# 156-symbol reviewed vocabulary, and the js0-lang/v1 language / js0:
+# capability-and-receipt coordinate schemes the JS1 doc/complete surface
 # and RuntimeCoordinate are built on.
-JOLT_SHA=619ef19685460af847654e22cf6beda904d052fb
-JOLT_BRANCH=js0-functional-sci-upstream
+JOLT_SHA=279bca18bbf50f37b8574a4e6998dee40313cd26
+JOLT_BRANCH=js1-runtime-current-upstream
 JOLT_URL=https://github.com/casselc/jolt
 # Its vendor/sci submodule: borkdude/sci 0.13.53.  The version is checked
 # against resources/SCI_VERSION because samizdat.agent.sandbox's

--- a/bin/js1
+++ b/bin/js1
@@ -1,0 +1,257 @@
+#!/bin/sh
+# bin/js1 — the supported JS1 (SCI sandbox) invocation for samizdat.
+#
+# jolt.sandbox — the authority model samizdat.agent.sandbox builds on —
+# loads only when the vendored SCI source and its Maven dependencies are on
+# jolt's source roots, and samizdat's deps.edn deliberately does not
+# declare them.  Ordinary, non-JS1 invocations (`jolt serve`,
+# `jolt -M:test`, `jolt -A:dev …`) never touch this file and are unchanged.
+#
+# This script is the single repository-owned place where the JS1 runtime
+# stack is located, pin-checked, and handed to jolt.  It never composes
+# source or Maven paths itself: it passes jolt a generated -Sdeps alias
+# whose only dependencies are the pinned checkout's vendored SCI
+# (:local/root) and the jolt-crypto coordinate already pinned in deps.edn,
+# and JOLT's own resolver composes the source roots and fetches/extracts
+# the Maven jars into the shared local repository.
+# `bin/js1 path` prints that answer for recording; a recorded classpath
+# replays offline via `jolt -Scp "$(bin/js1 path)" …`.
+#
+# Pins, coordinates, failure modes, and run evidence: docs/JS1_RUNTIME.md.
+#
+# Usage:
+#   bin/js1 check    locate + pin-check the runtime stack, print coordinates
+#   bin/js1 path     print the resolver-composed JS1 source roots
+#                    (':'-joined; record them for an offline -Scp replay)
+#   bin/js1 smoke    run the JS1 seam evidence (test/samizdat/sandbox_test.clj)
+#
+# Jolt is located from $JOLT_HOME, else the sibling checkout ../jolt.
+# JOLT_CHEZ is the jolt launcher's own Chez selector and passes through.
+
+set -eu
+
+# ── The pinned JS1 runtime stack (docs/JS1_RUNTIME.md § Pins) ────────────────
+# casselc/jolt @ js0-functional-sci-upstream — "sci: trusted inert
+# language-surface API with versioned coordinate", the jolt.sandbox
+# language-surface/0 and language-coordinate/0 the JS1 doc/complete surface
+# and RuntimeCoordinate are built on.
+JOLT_SHA=619ef19685460af847654e22cf6beda904d052fb
+JOLT_BRANCH=js0-functional-sci-upstream
+JOLT_URL=https://github.com/casselc/jolt
+# Its vendor/sci submodule: borkdude/sci 0.13.53.  The version is checked
+# against resources/SCI_VERSION because samizdat.agent.sandbox's
+# RuntimeCoordinate names it (sci-implementation = "sci-0.13.53").  SCI's
+# deps are resolved from the submodule's own deps.edn at this commit, so
+# they are stated nowhere in this script.
+SCI_SHA=32d62a5136ad3dc148588752f5bcc4cc30b14752
+SCI_VERSION=0.13.53
+# The sandbox's digest substrate (samizdat.agent.files) computes content
+# coordinates through jolt.crypto's MessageDigest shim, so the JS1
+# classpath additionally needs jolt-crypto's source.  Its coordinate is
+# read from samizdat's deps.edn at run time — the smoke must exercise the
+# same jolt-crypto production resolves, and deps.edn is the single place
+# that pin is stated.
+CRYPTO_LIB=jolt-lang/jolt-crypto
+CRYPTO_URL=https://github.com/jolt-lang/jolt-crypto
+
+SAMIZDAT_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+
+fail() {
+  echo "js1: $*" >&2
+  exit 1
+}
+
+provision_instructions() {
+  cat >&2 <<EOF
+
+Provision the pinned runtime and retry:
+  git clone --branch $JOLT_BRANCH $JOLT_URL <dir>
+  git -C <dir> checkout $JOLT_SHA
+  git -C <dir> submodule update --init vendor/sci
+Then set JOLT_HOME=<dir>, or keep the checkout as samizdat's sibling
+($(dirname "$SAMIZDAT_ROOT")/jolt).
+EOF
+}
+
+# ── Locate (JOLT_HOME, then the sibling checkout) ────────────────────────────
+locate_jolt() {
+  if [ -n "${JOLT_HOME:-}" ]; then
+    if [ ! -d "$JOLT_HOME" ]; then
+      echo "js1: JOLT_HOME=$JOLT_HOME is not a directory." >&2
+      provision_instructions
+      exit 1
+    fi
+    JOLT=$(CDPATH= cd -- "$JOLT_HOME" && pwd -P)
+  elif [ -d "$SAMIZDAT_ROOT/../jolt" ]; then
+    JOLT=$(CDPATH= cd -- "$SAMIZDAT_ROOT/../jolt" && pwd -P)
+  else
+    echo "js1: no Jolt checkout found: JOLT_HOME is unset and $SAMIZDAT_ROOT/../jolt does not exist." >&2
+    provision_instructions
+    exit 1
+  fi
+}
+
+# ── Pin-check (fail closed, with remedies) ───────────────────────────────────
+validate_jolt() {
+  if [ ! -x "$JOLT/bin/jolt" ]; then
+    echo "js1: $JOLT has no executable bin/jolt — not a Jolt checkout." >&2
+    provision_instructions
+    exit 1
+  fi
+  [ -d "$JOLT/.git" ] || fail "$JOLT is not a git checkout, so the runtime pin cannot be verified. The JS1 evidence is only meaningful against the exact pinned tree."
+  command -v git >/dev/null 2>&1 || fail "git is required to verify the Jolt pin but is not on PATH."
+
+  actual=$(git -C "$JOLT" rev-parse HEAD 2>/dev/null) || fail "git -C \"$JOLT\" rev-parse HEAD failed — is the checkout corrupt?"
+  if [ "$actual" != "$JOLT_SHA" ]; then
+    cat >&2 <<EOF
+js1: Jolt checkout is not at the pinned JS1 runtime commit.
+  expected: $JOLT_SHA ($JOLT_URL branch $JOLT_BRANCH)
+  actual:   $actual
+jolt.sandbox's trusted language-surface API exists only at the pin; a
+receipt's runtime coordinate is not meaningful under any other tree.
+EOF
+    provision_instructions
+    exit 1
+  fi
+
+  # A dirty tracked tree voids the pin as a description of the bytes jolt
+  # actually loads (dev source mode reads the working tree), so refuse it.
+  # Untracked files (build output) are fine.
+  dirty=$(git -C "$JOLT" status --porcelain --untracked-files=no --ignore-submodules=all)
+  [ -z "$dirty" ] || fail "Jolt checkout has uncommitted tracked changes, so the pin does not describe the runtime:
+$dirty
+  Commit or stash them, or use a clean clone (see above)."
+
+  # The submodule pin the pinned commit records…
+  tree=$(git -C "$JOLT" ls-tree "$JOLT_SHA" -- vendor/sci)
+  case $tree in
+    "160000 commit $SCI_SHA"*) : ;;
+    *) fail "the pinned Jolt commit records an unexpected vendor/sci submodule: '$tree' (expected commit $SCI_SHA). The runtime pin and this script have drifted — see docs/JS1_RUNTIME.md." ;;
+  esac
+  # …and the submodule actually checked out at it.
+  [ -f "$JOLT/vendor/sci/deps.edn" ] || fail "vendor/sci is not checked out. Run:
+  git -C \"$JOLT\" submodule update --init vendor/sci"
+  sci_actual=$(git -C "$JOLT/vendor/sci" rev-parse HEAD 2>/dev/null || echo missing)
+  [ "$sci_actual" = "$SCI_SHA" ] || fail "vendor/sci is checked out at $sci_actual, expected $SCI_SHA. Run:
+  git -C \"$JOLT\" submodule update --init vendor/sci"
+  sci_dirty=$(git -C "$JOLT/vendor/sci" status --porcelain --untracked-files=no)
+  [ -z "$sci_dirty" ] || fail "vendor/sci has uncommitted tracked changes, so the SCI pin does not describe the source jolt loads:
+$sci_dirty"
+  sci_ver=$(cat "$JOLT/vendor/sci/resources/SCI_VERSION" 2>/dev/null || echo unreadable)
+  [ "$sci_ver" = "$SCI_VERSION" ] || fail "vendor/sci/resources/SCI_VERSION reads '$sci_ver', expected '$SCI_VERSION' — samizdat.agent.sandbox's RuntimeCoordinate names sci-$SCI_VERSION, so the vendored tree must be exactly that release."
+}
+
+# ── The single place any SCI root is constructed ─────────────────────────────
+# A generated alias, merged last via -Sdeps.  :replace-paths/:replace-deps
+# keep every other samizdat :deps coordinate (HTTP, store, nREPL, GUI
+# natives) OUT of the JS1 evidence run: the classpath is samizdat src+test,
+# jolt-crypto's source (the digest substrate, pinned by deps.edn), the
+# vendored SCI source, and exactly the Maven jars SCI's own deps.edn
+# declares at the pinned commit — fetched/extracted by jolt itself into
+# the shared ~/.m2 repository on a cold cache, offline thereafter.  (jolt
+# correctly contributes no root for org.babashka/sci.impl.types: that jar
+# ships a .class, no Clojure source.)
+
+# The jolt-crypto pin, read from samizdat's deps.edn (its single home).
+crypto_sha_from_deps() {
+  awk '
+    /jolt-lang\/jolt-crypto/ {inblock=1}
+    inblock && /:git\/sha/ {
+      if (match($0, /"[0-9a-f]{40}"/)) { print substr($0, RSTART + 1, 40); exit }
+    }' "$SAMIZDAT_ROOT/deps.edn"
+}
+
+require_crypto_sha() {
+  crypto_sha=$(crypto_sha_from_deps)
+  [ -n "$crypto_sha" ] || fail "no $CRYPTO_LIB :git/sha found in $SAMIZDAT_ROOT/deps.edn — the JS1 digest substrate needs that dependency pinned."
+  printf '%s' "$crypto_sha"
+}
+
+js1_sdeps() {
+  case $JOLT in
+    *[\\\"]*) fail "cannot embed a quote or backslash from this Jolt path into EDN: $JOLT" ;;
+  esac
+  crypto_sha=$(require_crypto_sha)
+  printf '%s' "{:aliases {:js1-rt {:replace-paths [\"src\" \"test\"] :replace-deps {borkdude/sci {:local/root \"$JOLT/vendor/sci\"} $CRYPTO_LIB {:git/url \"$CRYPTO_URL\" :git/sha \"$crypto_sha\"}}}}}"
+}
+
+# Run jolt with the JS1 alias selected, from the samizdat root so the
+# alias's relative :replace-paths resolve against it (jolt reads the
+# project dir from JOLT_PWD, which the launcher defaults to its cwd).
+jolt_js1() {
+  cd "$SAMIZDAT_ROOT"
+  "$JOLT/bin/jolt" -Srepro -Sdeps "$(js1_sdeps)" -A:js1-rt "$@"
+}
+
+samizdat_provenance() {
+  if [ -d "$SAMIZDAT_ROOT/.git" ]; then
+    s_head=$(git -C "$SAMIZDAT_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+    s_dirty=$(git -C "$SAMIZDAT_ROOT" status --porcelain --untracked-files=no | wc -l | tr -d ' ')
+    echo "$s_head ($s_dirty tracked file(s) modified)"
+  else
+    echo "unknown (not a git checkout)"
+  fi
+}
+
+usage() {
+  cat <<EOF
+usage: bin/js1 <command>
+
+  check    locate + pin-check the JS1 runtime stack, print coordinates
+  path     print the resolver-composed JS1 source roots (':'-joined)
+  smoke    run the JS1 seam evidence (test/samizdat/sandbox_test.clj)
+
+Jolt is located from \$JOLT_HOME, else the sibling checkout ../jolt, and
+must be $JOLT_URL branch $JOLT_BRANCH at
+$JOLT_SHA with its vendor/sci submodule at
+$SCI_SHA (borkdude/sci $SCI_VERSION).
+
+See docs/JS1_RUNTIME.md.
+EOF
+}
+
+cmd=${1:-}
+case $cmd in
+  check)
+    locate_jolt
+    validate_jolt
+    crypto_sha=$(require_crypto_sha)
+    cat <<EOF
+js1 runtime stack: OK
+  samizdat: $SAMIZDAT_ROOT
+            git $(samizdat_provenance)
+  jolt:     $JOLT
+            $JOLT_SHA ($JOLT_URL branch $JOLT_BRANCH)
+  sci:      $JOLT/vendor/sci
+            $SCI_SHA (borkdude/sci $SCI_VERSION)
+  sci deps: borkdude/edamame 1.5.39, org.babashka/sci.impl.types 0.0.3,
+            borkdude/graal.locking 0.0.2 (+ org.clojure/tools.reader
+            1.5.2 transitively) — composed by jolt from the submodule's
+            own deps.edn at the pinned commit
+  crypto:   $CRYPTO_LIB @ $crypto_sha (digest substrate;
+            pinned by samizdat's deps.edn)
+EOF
+    ;;
+  path)
+    locate_jolt
+    validate_jolt
+    jolt_js1 -Spath
+    ;;
+  smoke)
+    locate_jolt
+    validate_jolt
+    cd "$SAMIZDAT_ROOT"
+    SAMIZDAT_SANDBOX_TEST_RUN=1
+    export SAMIZDAT_SANDBOX_TEST_RUN
+    exec "$JOLT/bin/jolt" -Srepro -Sdeps "$(js1_sdeps)" -A:js1-rt \
+      run "$SAMIZDAT_ROOT/test/samizdat/sandbox_test.clj"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    [ -z "$cmd" ] || echo "js1: unknown command: $cmd" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/ci/js1-smolvm/build-guest-pack.sh
+++ b/ci/js1-smolvm/build-guest-pack.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+# ci/js1-smolvm/build-guest-pack.sh — PRODUCER lane: build the pinned JS1
+# guest pack per guest-recipe.edn. Needs network + KVM. Run deliberately,
+# once per lock/recipe change, on a machine that may reach the network;
+# the consumer lane then runs the pack offline, digest-verified.
+#
+# NOT run by the workflow and not run by any consumer step. On completion
+# it prints the pack sha256 to pin into runtime-lock.edn — a human edits
+# the lock; this script never does.
+#
+# Flow:
+#   1. preflight + producer pin gates (build-lane mode: pack presence is
+#      skipped, every pin-drift and executor gate still runs)
+#   2. fetch + verify (or pin-on-first-build) the alpine minirootfs
+#   3. stage the pinned Chez payload (digest-verified against the recipe)
+#   4. create a BUILD vm from the unpacked rootfs (network ON, build only),
+#      provision: apk packages, baked jolt checkout at the exact pin with
+#      the vendor/sci submodule, warm gitlibs/m2 via the pinned jolt's own
+#      resolver (jolt -P + bin/js1 path against a copy of this checkout)
+#   5. stop, `smolvm pack create --from-vm`, sha256 the pack, emit
+#      pack-manifest.edn, delete the build vm
+#
+# Fail-closed throughout: any pin mismatch aborts; the build VM is always
+# torn down. Nothing here touches the consumer lane's evidence value —
+# the consumer re-verifies the pack digest and re-runs bin/js1's own pin
+# checks inside the sealed guest.
+
+set -eu
+. "$(dirname "$0")/lib-lock.sh"
+
+init_run_dir
+BUILD_DIR="$RUN_DIR/build"
+mkdir -p "$BUILD_DIR"
+LOG="$LOG_DIR/build-guest-pack.log"
+: > "$LOG"
+
+say "producer build lane — needs network + KVM; log: $LOG"
+
+# ── 1. gates (build-lane mode) ────────────────────────────────────────────
+JS1_SMOLVM_BUILD_LANE=1 sh "$JS1CI_SCRIPT_DIR/preflight.sh" >> "$LOG" 2>&1 \
+  || fail "preflight refused — see $LOG"
+JS1_SMOLVM_BUILD_LANE=1 sh "$JS1CI_SCRIPT_DIR/producer-gate.sh" >> "$LOG" 2>&1 \
+  || fail "producer pin gates refused — see $LOG (pin drift is never built over)"
+
+LAUNCHER=${JS1_SMOLVM_LAUNCHER:-"$HOME/$(lock_get :smolvm/launcher-relpath)"}
+PACK=${JS1_SMOLVM_PACK:-"$HOME/$(lock_get :guest-pack/path-relpath)"}
+BUILD_VM="$(lock_get :machine/name-prefix)build-$(cat /proc/sys/kernel/random/uuid 2>/dev/null || echo $$)"
+
+build_teardown() {
+  _rc=$?
+  set +e
+  timeout -s TERM -k 15 120 "$LAUNCHER" machine stop --name "$BUILD_VM" >> "$LOG" 2>&1
+  timeout -s TERM -k 15 120 "$LAUNCHER" machine delete --name "$BUILD_VM" --force >> "$LOG" 2>&1
+  exit "$_rc"
+}
+trap build_teardown EXIT INT TERM
+
+# ── 2. base rootfs: fetch + verify/pin-on-first-build ────────────────────
+BASE_URL=$(grep -E '^ +:url ' "$JS1CI_RECIPE" | head -1 | sed -E 's/^[^"]*"([^"]*)".*/\1/')
+BASE_SHA=$(grep -E '^ +:sha256 ' "$JS1CI_RECIPE" | head -1 | sed -E 's/^ +:sha256 +//; s/[[:space:]]*$//')
+BASE_TAR="$BUILD_DIR/base.tar.gz"
+[ -n "$BASE_URL" ] || fail "guest-recipe.edn :base/:url unreadable"
+command -v curl >/dev/null 2>&1 || fail "curl is required for the producer build"
+say "fetching base rootfs: $BASE_URL"
+curl -fsSL --retry 3 --retry-delay 5 -o "$BASE_TAR" "$BASE_URL" \
+  || fail "base rootfs fetch failed"
+_actual_base=$(sha256sum "$BASE_TAR" | cut -d' ' -f1)
+if [ "$BASE_SHA" = "nil" ]; then
+  warn "recipe :base/sha256 is unpinned (pin-on-first-build)."
+  warn "THIS build's base tarball sha256: $_actual_base"
+  warn "pin it into guest-recipe.edn :base/sha256 before treating any derived pack as locked."
+else
+  [ "$_actual_base" = "$BASE_SHA" ] \
+    || fail "base rootfs sha256 $_actual_base != recipe pin $BASE_SHA — refusing to build"
+  say "base rootfs verified: $_actual_base"
+fi
+
+ROOTFS="$BUILD_DIR/rootfs"
+mkdir -p "$ROOTFS"
+tar -xzf "$BASE_TAR" -C "$ROOTFS"
+
+# ── 3. Chez payload, digest-verified against the recipe ──────────────────
+CHEZ_SHA=$(grep -E '^ +:payload-sha256 ' "$JS1CI_RECIPE" | head -1 | sed -E 's/^[^"]*"([^"]*)".*/\1/')
+CHEZ_TAR="$BUILD_DIR/chez-payload.tar"
+# Deterministic tar: sorted names, zeroed metadata — reproduces the pinned
+# digest byte-for-byte from the build host's /usr/local Chez 10.4.1.
+tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner -cf "$CHEZ_TAR" \
+  -C /usr/local lib/csv10.4.1 bin/scheme bin/petite bin/chez bin/scheme-script \
+  || fail "cannot stage the Chez payload from /usr/local (need a threaded Chez 10.4.1 ta6le install)"
+_actual_chez=$(sha256sum "$CHEZ_TAR" | cut -d' ' -f1)
+[ "$_actual_chez" = "$CHEZ_SHA" ] \
+  || fail "chez payload sha256 $_actual_chez != recipe pin $CHEZ_SHA. The build host's Chez differs from the recipe — do not build; reconcile first."
+mkdir -p "$ROOTFS/usr/local"
+tar -xf "$CHEZ_TAR" -C "$ROOTFS/usr/local" \
+  || fail "cannot extract the Chez payload into the rootfs"
+say "chez payload verified and staged"
+
+# Copy the provisioning script + this repo's dependency pins into the
+# build context dir the build VM mounts.
+CTX="$BUILD_DIR/ctx"
+mkdir -p "$CTX/repo"
+cp "$JS1CI_REPO_ROOT/deps.edn" "$CTX/repo/deps.edn"
+cp -r "$JS1CI_REPO_ROOT/bin" "$CTX/repo/bin"
+# The warm step resolves deps.edn + bin/js1 path only; src/test are not
+# needed to warm caches (jolt -P expands deps without loading sources).
+mkdir -p "$CTX/repo/src" "$CTX/repo/test"
+
+# ── 4. build VM: create from the rootfs, provision, warm ─────────────────
+JOLT_SHA=$(lock_get :jolt/sha)
+JOLT_URL=$(lock_get :jolt/url)
+JOLT_BRANCH=$(lock_get :jolt/branch)
+SCI_SHA=$(lock_get :sci/sha)
+SCI_VERSION=$(lock_get :sci/version)
+GUEST_JOLT=$(lock_get :guest/jolt-home)
+GUEST_HOME=$(lock_get :guest/home)
+
+say "creating build VM $BUILD_VM (network ON — producer build only)"
+timeout -s TERM -k 30 600 "$LAUNCHER" machine create --name "$BUILD_VM" \
+  --image "$ROOTFS" --net --cpus 4 --mem 8192 \
+  -v "$CTX:/build:ro" >> "$LOG" 2>&1 \
+  || fail "build VM create failed — smolvm $(lock_get :smolvm/version) must accept an unpacked rootfs dir as --image (documented for machine run); see $LOG"
+timeout -s TERM -k 30 300 "$LAUNCHER" machine start --name "$BUILD_VM" >> "$LOG" 2>&1 \
+  || fail "build VM start failed — see $LOG"
+
+bx() { # build-vm exec, bounded; output lands in the log AND on stdout
+  _to=$1; shift
+  _out="$BUILD_DIR/.bx-out"
+  if timeout -s TERM -k 30 "$_to" "$LAUNCHER" machine exec --name "$BUILD_VM" \
+    -e HOME="$GUEST_HOME" -e PATH=/usr/local/bin:/usr/bin:/bin -e LC_ALL=C \
+    --timeout "${_to}s" -- "$@" > "$_out" 2>&1; then
+    _rc=0
+  else
+    _rc=$?
+  fi
+  cat "$_out" >> "$LOG"
+  cat "$_out"
+  return "$_rc"
+}
+
+say "provisioning: apk packages"
+bx 300 sh -c 'apk add --no-cache git >> /build-provision.log 2>&1' \
+  || fail "apk provisioning failed — see $LOG"
+
+say "provisioning: jolt checkout at $JOLT_SHA"
+bx 900 sh -c "
+  set -eu
+  git clone --branch $JOLT_BRANCH $JOLT_URL $GUEST_JOLT
+  git -C $GUEST_JOLT checkout $JOLT_SHA
+  git -C $GUEST_JOLT submodule update --init vendor/sci
+" || fail "jolt clone/checkout failed — see $LOG"
+
+# Pin-verify INSIDE the build VM (the consumer re-verifies via bin/js1).
+bx 60 git -C "$GUEST_JOLT" rev-parse HEAD > "$BUILD_DIR/.jolt-head" \
+  || fail "cannot rev-parse the baked jolt checkout"
+grep -q "$JOLT_SHA" "$BUILD_DIR/.jolt-head" \
+  || fail "baked jolt checkout is not at the pin — see $LOG"
+bx 60 git -C "$GUEST_JOLT/vendor/sci" rev-parse HEAD > "$BUILD_DIR/.sci-head" \
+  || fail "cannot rev-parse the baked vendor/sci"
+grep -q "$SCI_SHA" "$BUILD_DIR/.sci-head" \
+  || fail "baked vendor/sci is not at the pin — see $LOG"
+bx 60 cat "$GUEST_JOLT/vendor/sci/resources/SCI_VERSION" > "$BUILD_DIR/.sci-version" \
+  || fail "cannot read the baked SCI_VERSION"
+grep -q "$SCI_VERSION" "$BUILD_DIR/.sci-version" \
+  || fail "baked SCI_VERSION is not $SCI_VERSION — see $LOG"
+
+say "warming caches with the pinned jolt's own resolver"
+bx 300 sh -c "cp -a /build/repo /tmp/warm-repo && mkdir -p /tmp/warm-repo"
+bx 1500 sh -c "
+  set -eu
+  cd /tmp/warm-repo
+  export JOLT_HOME=$GUEST_JOLT JOLT_QUIET=1 JOLT_CHEZ=/usr/local/bin/scheme
+  $GUEST_JOLT/bin/jolt -P
+  ./bin/js1 path
+" || fail "cache warm failed (jolt -P / bin/js1 path) — see $LOG"
+
+# Inventory the warm caches for the manifest.
+bx 120 sh -c "find $GUEST_HOME/.gitlibs $GUEST_HOME/.m2 -type f 2>/dev/null | LC_ALL=C sort | xargs sha256sum" \
+  > "$BUILD_DIR/cache-inventory.sha256" \
+  || warn "cache inventory incomplete — see $LOG"
+
+say "stopping build VM"
+timeout -s TERM -k 30 120 "$LAUNCHER" machine stop --name "$BUILD_VM" >> "$LOG" 2>&1 \
+  || fail "build VM stop failed — see $LOG"
+
+# ── 5. pack + digest + manifest ──────────────────────────────────────────
+mkdir -p "$(dirname "$PACK")"
+timeout -s TERM -k 30 900 "$LAUNCHER" pack create --from-vm "$BUILD_VM" -o "$PACK" >> "$LOG" 2>&1 \
+  || fail "pack create --from-vm failed — see $LOG"
+PACK_ACTUAL=$(sha256sum "$PACK" | cut -d' ' -f1)
+
+MANIFEST="$(dirname "$PACK")/pack-manifest.edn"
+{
+  printf '{:manifest/schema 1\n'
+  printf ' :built-at "%s"\n' "$(now_iso)"
+  printf ' :base {:url "%s" :sha256 "%s" :pinned? %s}\n' "$BASE_URL" "$_actual_base" "$( [ "$BASE_SHA" = "nil" ] && printf 'false' || printf 'true')"
+  printf ' :chez-payload-sha256 "%s"\n' "$CHEZ_SHA"
+  printf ' :jolt "%s"\n' "$JOLT_SHA"
+  printf ' :sci "%s"\n' "$SCI_SHA"
+  printf ' :sci-version "%s"\n' "$SCI_VERSION"
+  printf ' :pack-sha256 "%s"\n' "$PACK_ACTUAL"
+  printf ' :cache-inventory "%s"\n' "$BUILD_DIR/cache-inventory.sha256"
+  printf '}\n'
+} > "$MANIFEST"
+
+receipt_event "$RUN_DIR/build-receipt.edn" "producer-build" "built" \
+  " :guest-pack/path \"$PACK\" :guest-pack/sha256 \"$PACK_ACTUAL\" :base/pinned? $( [ "$BASE_SHA" = "nil" ] && printf 'false' || printf 'true')"
+
+cat <<EOF
+js1-smolvm: pack built: $PACK
+  sha256: $PACK_ACTUAL
+  manifest: $MANIFEST
+
+TO PIN THIS PACK (a human edits the lock — this script never does):
+  1. $([ "$BASE_SHA" = "nil" ] && echo "pin the base sha256 $_actual_base into guest-recipe.edn :base/sha256, then " || true)review $MANIFEST
+  2. set ci/js1-smolvm/runtime-lock.edn :guest-pack/sha256 "$PACK_ACTUAL"
+  3. set :guest-pack/status :built
+The consumer lane refuses until all three are true.
+EOF

--- a/ci/js1-smolvm/consumer-run.sh
+++ b/ci/js1-smolvm/consumer-run.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# ci/js1-smolvm/consumer-run.sh — the clean-consumer lane: boot the pinned
+# guest pack with the samizdat checkout mounted READ-ONLY, network
+# DISABLED, scratch VM-local, and run bin/js1 check, bin/js1 smoke, and
+# the SAMIZDAT_JS1_BOUNDARY_TEST=1 durable-restart suite inside it.
+#
+# Producer/consumer separation: this script performs no pin relaxation and
+# no provisioning — it re-runs preflight.sh and producer-gate.sh and
+# refuses unless both are green. The guest never sees the host checkout
+# writably, never gets a network, and its only durable outputs are the
+# bounded logs + receipts this script captures under the runner-owned CI
+# dir. Teardown (stop + delete --force) runs under a trap, always.
+#
+# Receipts are EDN-lines: one complete map per line, appended as events
+# happen, so a mid-lane failure never leaves an unclosed form.
+#
+# Exit 0: every guest step green. Exit 1: refused (prerequisites) or a
+# step failed — receipts.edn names which.
+
+set -eu
+. "$(dirname "$0")/lib-lock.sh"
+
+init_run_dir
+RECEIPT="$RUN_DIR/receipts.edn"
+
+# ── Prerequisites: compose the gates (fail closed before any VM) ─────────
+if ! sh "$JS1CI_SCRIPT_DIR/preflight.sh" >> "$LOG_DIR/consumer-prereqs.log" 2>&1; then
+  receipt_event "$RECEIPT" "consumer" "refused" " :reason :preflight-not-green"
+  fail "preflight.sh did not pass — refusing to start any guest (see $LOG_DIR/consumer-prereqs.log)"
+fi
+if ! sh "$JS1CI_SCRIPT_DIR/producer-gate.sh" >> "$LOG_DIR/consumer-prereqs.log" 2>&1; then
+  receipt_event "$RECEIPT" "consumer" "refused" " :reason :producer-gate-not-green"
+  fail "producer-gate.sh did not pass — refusing to start any guest (see $LOG_DIR/consumer-prereqs.log)"
+fi
+
+LAUNCHER=${JS1_SMOLVM_LAUNCHER:-"$HOME/$(lock_get :smolvm/launcher-relpath)"}
+PACK=${JS1_SMOLVM_PACK:-"$HOME/$(lock_get :guest-pack/path-relpath)"}
+PACK_SHA=$(lock_get :guest-pack/sha256)
+
+CPUS=$(lock_get :machine/cpus)
+MEM=$(lock_get :machine/mem-mib)
+SRC_RO=$(lock_get :guest/mount-source-ro)
+GUEST_WORK=$(lock_get :guest/work-dir)
+GUEST_JOLT=$(lock_get :guest/jolt-home)
+GUEST_CHEZ=$(lock_get :guest/chez)
+GUEST_HOME=$(lock_get :guest/home)
+
+T_SETUP=$(lock_get :deadline/setup-seconds)
+T_CHECK=$(lock_get :deadline/check-seconds)
+T_SMOKE=$(lock_get :deadline/smoke-seconds)
+T_BOUNDARY=$(lock_get :deadline/boundary-seconds)
+T_TEARDOWN=$(lock_get :deadline/teardown-seconds)
+T_TOTAL=$(lock_get :deadline/total-seconds)
+
+# Guest environment — mirrors guest-recipe.edn :guest-env exactly (the
+# static harness test pins that agreement). Unquoted expansion at the exec
+# site is intentional: each word is one flag, values carry no spaces.
+GUEST_ENV="-e HOME=$GUEST_HOME -e JOLT_HOME=$GUEST_JOLT -e JOLT_CHEZ=$GUEST_CHEZ -e JOLT_QUIET=1 -e PATH=/usr/local/bin:/usr/bin:/bin -e LC_ALL=C -e JS1_GUEST_SRC_RO=$SRC_RO -e JS1_GUEST_WORK=$GUEST_WORK"
+
+# ── Teardown: unconditional, best-effort, bounded ────────────────────────
+MACHINE_CREATED=0
+teardown() {
+  _rc=$?
+  set +e
+  if [ "$MACHINE_CREATED" = "1" ]; then
+    timeout -s TERM -k 15 "$T_TEARDOWN" "$LAUNCHER" machine stop --name "$MACHINE_NAME" \
+      >> "$LOG_DIR/teardown.log" 2>&1
+    _stop=$?
+    timeout -s TERM -k 15 "$T_TEARDOWN" "$LAUNCHER" machine delete --name "$MACHINE_NAME" --force \
+      >> "$LOG_DIR/teardown.log" 2>&1
+    _del=$?
+    _gone=$("$LAUNCHER" machine ls --json 2>/dev/null | tr -d ' \n' \
+            | grep -c "\"$MACHINE_NAME\"" || true)
+    receipt_event "$RECEIPT" "consumer" "teardown" \
+      " :teardown/stop-exit $_stop :teardown/delete-exit $_del :teardown/machine-gone $( [ "$_gone" = "0" ] && printf 'true' || printf 'false')"
+    [ "$_gone" = "0" ] || warn "machine $MACHINE_NAME still listed after delete --force"
+  fi
+  exit "$_rc"
+}
+trap teardown EXIT INT TERM
+
+# guest_exec <logfile> <guest-timeout-s> <step> — one bounded exec in the
+# guest; the step receipt is recorded even when the step fails. The guest
+# --timeout is the workload bound; the host `timeout` wrapper is the hard
+# backstop (+45s margin). Per the verified smolvm 1.7.5 semantics in this
+# ecosystem: exec --timeout is a HOST WAIT (exit 124 + 'command timed out
+# after <N>ms'), the guest process may outlive it — teardown stop+delete
+# is the kill backstop.
+guest_exec() {
+  _log=$1; _to=$2; _step=$3
+  _t0=$(now_epoch)
+  if run_logged "$_log" "$(( _to + 45 ))" \
+    "$LAUNCHER" machine exec --name "$MACHINE_NAME" --workdir / \
+    $GUEST_ENV \
+    --timeout "${_to}s" \
+    -- sh "$SRC_RO/ci/js1-smolvm/guest-setup.sh" "$_step"; then
+    _rc=0
+  else
+    _rc=$?
+  fi
+  _dt=$(( $(now_epoch) - _t0 ))
+  receipt_event "$RECEIPT" "consumer" "step" \
+    " :step :$_step :exit $_rc :seconds $_dt :log \"logs/$(basename "$_log")\" :log-sha256 \"$(sha256sum "$_log" | cut -d' ' -f1)\""
+  return "$_rc"
+}
+
+require_marker() { # <logfile> <marker> <step>
+  grep -qF "$2" "$1" || fail "step $3 exited 0 but its log lacks the success marker '$2' — refusing to claim the step (see $1)"
+}
+
+# ── Source manifest (host side; compared against the guest's) ────────────
+HOST_TREE_SHA=$( ( cd "$JS1CI_REPO_ROOT" \
+  && find . -path ./.git -prune -o -type f -print0 | LC_ALL=C sort -z \
+     | xargs -0 sha256sum ) | tee "$LOG_DIR/source-manifest.sha256" | sha256sum | cut -d' ' -f1 )
+REPO_HEAD=$(git -C "$JS1CI_REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+
+receipt_event "$RECEIPT" "consumer" "begin" \
+  " :machine/name \"$MACHINE_NAME\" :machine/cpus $CPUS :machine/mem-mib $MEM :guest-pack/path \"$PACK\" :guest-pack/sha256 \"$PACK_SHA\" :source/tree-sha256 \"$HOST_TREE_SHA\" :samizdat/head \"$REPO_HEAD\" :network :disabled :source-mount :read-only :scratch :vm-local"
+
+# ── Create + start + status contract ─────────────────────────────────────
+deadline_check "$T_TOTAL" "machine create"
+run_logged "$LOG_DIR/create.log" "$T_SETUP" \
+  "$LAUNCHER" machine create --name "$MACHINE_NAME" --from "$PACK" \
+  -v "$JS1CI_REPO_ROOT:$SRC_RO:ro" --cpus "$CPUS" --mem "$MEM" \
+  || fail "machine create failed (see $LOG_DIR/create.log)"
+MACHINE_CREATED=1
+
+run_logged "$LOG_DIR/start.log" "$T_SETUP" \
+  "$LAUNCHER" machine start --name "$MACHINE_NAME" \
+  || fail "machine start failed (see $LOG_DIR/start.log)"
+
+run_logged "$LOG_DIR/status.log" 60 \
+  "$LAUNCHER" machine status --name "$MACHINE_NAME" --json \
+  || fail "machine status failed (see $LOG_DIR/status.log)"
+_status=$(tr -d ' \n' < "$LOG_DIR/status.log")
+# The exact ready contract for this lane (the status JSON shape verified
+# against smolvm 1.7.5 by the ecosystem's live isolation suites).
+case $_status in *"\"name\":\"$MACHINE_NAME\""*) : ;; *) fail "status contract: name mismatch in: $_status" ;; esac
+case $_status in *'"state":"running"'*) : ;; *) fail "status contract: not running: $_status" ;; esac
+case $_status in *'"network":false'*) : ;; *) fail "status contract: NETWORK ENABLED — refusing the guest: $_status" ;; esac
+case $_status in *'"ports":0'*) : ;; *) fail "status contract: ports exposed — refusing: $_status" ;; esac
+case $_status in *'"mounts":1'*) : ;; *) fail "status contract: expected exactly 1 mount (source RO): $_status" ;; esac
+say "machine $MACHINE_NAME running: network disabled, 0 ports, 1 RO mount"
+receipt_event "$RECEIPT" "consumer" "status-contract" " :status/verified true"
+
+# ── prepare: RO mount → VM-local scratch, manifest agreement ─────────────
+deadline_check "$T_TOTAL" "guest prepare"
+guest_exec "$LOG_DIR/setup.log" "$T_SETUP" "prepare" \
+  || fail "guest prepare failed (see $LOG_DIR/setup.log)"
+require_marker "$LOG_DIR/setup.log" "GUEST-PREPARE-OK" "prepare"
+GUEST_TREE_SHA=$(sed -n 's/^GUEST-MANIFEST \([0-9a-f]\{64\}\).*/\1/p' "$LOG_DIR/setup.log" | head -1)
+[ -n "$GUEST_TREE_SHA" ] || fail "guest printed no GUEST-MANIFEST digest (see $LOG_DIR/setup.log)"
+[ "$GUEST_TREE_SHA" = "$HOST_TREE_SHA" ] \
+  || fail "guest source tree digest $GUEST_TREE_SHA != host $HOST_TREE_SHA — the guest does not see exactly this checkout; refusing evidence"
+say "guest source copy verified against host manifest"
+receipt_event "$RECEIPT" "consumer" "manifest-verified" " :guest/tree-sha256 \"$GUEST_TREE_SHA\""
+
+# ── check: locate + pin-check the baked runtime stack ────────────────────
+deadline_check "$T_TOTAL" "bin/js1 check"
+guest_exec "$LOG_DIR/check.log" "$T_CHECK" "check" \
+  || fail "bin/js1 check failed in the guest (see $LOG_DIR/check.log)"
+require_marker "$LOG_DIR/check.log" "js1 runtime stack: OK" "check"
+require_marker "$LOG_DIR/check.log" "$(lock_get :jolt/sha)" "check"
+require_marker "$LOG_DIR/check.log" "$(lock_get :sci/sha)" "check"
+require_marker "$LOG_DIR/check.log" "$(lock_get :jolt-crypto/sha)" "check"
+
+# ── smoke: the JS1 seam evidence in the guest ────────────────────────────
+deadline_check "$T_TOTAL" "bin/js1 smoke"
+guest_exec "$LOG_DIR/smoke.log" "$T_SMOKE" "smoke" \
+  || fail "bin/js1 smoke failed in the guest (see $LOG_DIR/smoke.log)"
+require_marker "$LOG_DIR/smoke.log" "SANDBOX-TEST OK" "smoke"
+require_marker "$LOG_DIR/smoke.log" "GUEST-SMOKE-OK" "smoke"
+receipt_event "$RECEIPT" "consumer" "smoke-summary" \
+  " :smoke/summary \"$(grep -E '^Ran [0-9]+ tests' "$LOG_DIR/smoke.log" | head -1)\""
+
+# ── boundary: durable restart across OS-process boundaries, in the guest ─
+deadline_check "$T_TOTAL" "js1 boundary suite"
+guest_exec "$LOG_DIR/boundary.log" "$T_BOUNDARY" "boundary" \
+  || fail "js1 boundary suite failed in the guest (see $LOG_DIR/boundary.log)"
+require_marker "$LOG_DIR/boundary.log" "0 failures, 0 errors" "boundary"
+require_marker "$LOG_DIR/boundary.log" "GUEST-BOUNDARY-OK" "boundary"
+receipt_event "$RECEIPT" "consumer" "boundary-summary" \
+  " :boundary/summary \"$(grep -E '^Ran [0-9]+ tests' "$LOG_DIR/boundary.log" | head -1)\""
+
+receipt_event "$RECEIPT" "consumer" "final" " :verdict :pass"
+say "consumer lane PASS — evidence in $RUN_DIR"

--- a/ci/js1-smolvm/guest-recipe.edn
+++ b/ci/js1-smolvm/guest-recipe.edn
@@ -52,8 +52,8 @@
  ;; run of `bin/js1 check` re-verifies all of it (that re-verification is
  ;; the consumer evidence, not a build-time shortcut).
  :jolt-runtime {:url "https://github.com/casselc/jolt"
-                :branch "js0-functional-sci-upstream"
-                :sha "619ef19685460af847654e22cf6beda904d052fb"
+                :branch "js1-runtime-current-upstream"
+                :sha "279bca18bbf50f37b8574a4e6998dee40313cd26"
                 :submodule {:path "vendor/sci"
                             :sha "32d62a5136ad3dc148588752f5bcc4cc30b14752"
                             :version-file "resources/SCI_VERSION"

--- a/ci/js1-smolvm/guest-recipe.edn
+++ b/ci/js1-smolvm/guest-recipe.edn
@@ -1,0 +1,111 @@
+;; JS1 SmolVM guest recipe — the pinned, digest-verifiable definition of
+;; the guest pack the consumer lane boots. Built ONCE per lock change by
+;; ci/js1-smolvm/build-guest-pack.sh (producer lane: needs network + KVM);
+;; consumed offline, network-disabled, by consumer-run.sh.
+;;
+;; Verifiability model: every input below is either digest-pinned here or
+;; carries an explicit pin policy; the producer records what it ACTUALLY
+;; fetched/built into pack-manifest.edn beside the pack; the consumer trust
+;; anchor is the pack's own sha256 in runtime-lock.edn. Nothing is trusted
+;; from a descriptor sitting beside an archive.
+{:recipe/version 1
+ :recipe/name "js1-guest"
+
+ ;; ── Base rootfs ────────────────────────────────────────────────────────
+ ;; Alpine minirootfs, x86_64. The sha256 is pinned on first build
+ ;; (pin-on-first-build): the first producer run records the digest of the
+ ;; tarball it fetched into pack-manifest.edn and REFUSES to proceed until
+ ;; the operator pins it here; every later build verifies against the pin.
+ :base {:kind :alpine-minirootfs
+        :version "3.21.3"
+        :arch "x86_64"
+        :url "https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/x86_64/alpine-minirootfs-3.21.3-x86_64.tar.gz"
+        :sha256 nil
+        :pin-policy :pin-on-first-build}
+
+ ;; ── Guest packages ─────────────────────────────────────────────────────
+ ;; Installed with apk at build time (build lane has network; the consumer
+ ;; lane never does). Versions are resolved once, recorded exactly in
+ ;; pack-manifest.edn, and re-pinned there; apk is always invoked with
+ ;; --no-cache. git is the load-bearing one: bin/js1's pin verification
+ ;; shells out to it in the guest.
+ :packages {:install ["git"]
+            :via "apk --no-cache"
+            :pin-policy :exact-version-in-manifest}
+
+ ;; ── Chez Scheme (jolt's own host requirement) ──────────────────────────
+ ;; Threaded Chez 10.4.1 (ta6le), staged from the build host's /usr/local
+ ;; install. The payload digest is a deterministic tar (sorted names, zeroed
+ ;; mtimes/owners) of lib/csv10.4.1 plus the bin/{scheme,petite,chez,
+ ;; scheme-script} symlinks — build-guest-pack.sh reproduces it byte-for-byte
+ ;; and refuses on mismatch.
+ :chez {:version "10.4.1"
+        :machine "ta6le"
+        :threaded true
+        :provenance :build-host-usr-local
+        :payload-sha256 "610b610a7f3131fbd26615bc98a8f4e9fc314282f419331f2138c3f3a7e1021e"
+        :guest-bin "/usr/local/bin/scheme"}
+
+ ;; ── The pinned JS1 runtime checkout, baked in ──────────────────────────
+ ;; git clone + checkout + submodule, pin-verified with git rev-parse, baked
+ ;; at :guest/path WITH .git intact and the tracked tree clean — the guest
+ ;; run of `bin/js1 check` re-verifies all of it (that re-verification is
+ ;; the consumer evidence, not a build-time shortcut).
+ :jolt-runtime {:url "https://github.com/casselc/jolt"
+                :branch "js0-functional-sci-upstream"
+                :sha "619ef19685460af847654e22cf6beda904d052fb"
+                :submodule {:path "vendor/sci"
+                            :sha "32d62a5136ad3dc148588752f5bcc4cc30b14752"
+                            :version-file "resources/SCI_VERSION"
+                            :version "0.13.53"}
+                :guest-path "/opt/js1-runtime/jolt"
+                :tracked-tree :clean}
+
+ ;; ── Warm dependency caches (the consumer lane is network-disabled) ─────
+ ;; Produced by running the PINNED jolt's own resolver at build time:
+ ;; `jolt -P` (full samizdat resolve — the boundary suite's children run
+ ;; `jolt path` against the full deps.edn) and `bin/js1 path` (the JS1
+ ;; seam resolve). Both resolve only what samizdat's deps.edn and the SCI
+ ;; submodule's own deps.edn pin; this recipe restates no transitive
+ ;; coordinates, so the pins cannot drift. The producer records every
+ ;; fetched artifact's sha256 into pack-manifest.edn.
+ :warm-caches {:gitlibs-home "/root/.gitlibs"
+               :m2-home "/root/.m2"
+               :warm-commands ["jolt -P" "bin/js1 path"]
+               :git-deps
+               {;; samizdat deps.edn pins (full-resolve set)
+                "jolt-lang/http-client" "add8184b819b69dcfed1305b9577eb8794f76409"
+                "jolt-lang/db" "c3ed5b333b5feed615d49c118493a00edc537739"
+                "jolt-lang/nrepl" "10bf63fd19f66b39587f4a5756d0644231b2d4c1"
+                "jolt-lang/jolt-crypto" "1ab72aa5f73be7ec41f01086953ffb43ecd3d84e"
+                "org.clojure/data.json" "94463ffb54482427fd9b31f264b06bff6dcfd557"
+                "jolt-lang/logging" "ec6747e55583118d881faf4ab41e68d7e587ce4c"
+                "jolt-lang/time" "bc85090dae95d103ba04f4ea9687945cf46fb19e"
+                ;; transitive via http-client's own deps.edn (recorded, not
+                ;; restated, at build time; listed because it is a gitlib)
+                "org.clj-commons/clj-http-lite" "5bc2a98969b4926d090787baf9297fd73cea42d0"}
+               ;; The four jars on the JS1 sandbox classpath, digest-pinned
+               ;; (verified against this workspace's ~/.m2, 2026-08-23).
+               :sci-jar-sha256
+               {"borkdude/edamame/1.5.39/edamame-1.5.39.jar"
+                "e83ca0f962c580c5c9c8d00967698b3fd0d002247e37e4f46c3383b9c29d8855"
+                "org/babashka/sci.impl.types/0.0.3/sci.impl.types-0.0.3.jar"
+                "d331dba0e0738c381d737f18525070e75b63f3f67efc88d3450db00c755fe6de"
+                "borkdude/graal.locking/0.0.2/graal.locking-0.0.2.jar"
+                "7859697555c154d72030ceb34534cfbaa70ac4b58984041d37850b53bdf7145e"
+                "org/clojure/tools.reader/1.5.2/tools.reader-1.5.2.jar"
+                "cb96ed0efdf0b8bc362632cb74067ef225f6b03f3f478c8ba44182f6a17a37b6"}}
+
+ ;; ── Guest environment contract (consumer-run.sh passes exactly these) ──
+ :guest-env {"HOME" "/root"
+             "JOLT_HOME" "/opt/js1-runtime/jolt"
+             "JOLT_CHEZ" "/usr/local/bin/scheme"
+             "JOLT_QUIET" "1"
+             "PATH" "/usr/local/bin:/usr/bin:/bin"
+             "LC_ALL" "C"}
+
+ ;; ── Output ─────────────────────────────────────────────────────────────
+ :output {:pack-path-relpath ".smolvm/js1-guest.smolmachine"
+          :manifest "pack-manifest.edn"
+          :pack-command "smolvm pack create --from-vm <provisioned build VM>"
+          :status :unbuilt}}

--- a/ci/js1-smolvm/guest-setup.sh
+++ b/ci/js1-smolvm/guest-setup.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# ci/js1-smolvm/guest-setup.sh — runs INSIDE the SmolVM guest only.
+# Invoked by consumer-run.sh via `smolvm machine exec`; never run on the
+# host. POSIX sh, busybox-compatible (the guest is an Alpine rootfs).
+#
+# Steps:
+#   prepare   copy the read-only source mount to VM-local scratch and
+#             print the tree manifest digest (the host compares it against
+#             its own — proves the guest sees exactly the checkout)
+#   check     bin/js1 check   (locate + pin-check the baked runtime stack)
+#   smoke     bin/js1 smoke   (the JS1 seam evidence, 28/268 at this pin)
+#   boundary  SAMIZDAT_JS1_BOUNDARY_TEST=1 durable-restart suite through
+#             the recorded -Scp classpath replay and the fixture runner
+#
+# Environment is passed explicitly by the consumer (HOME, JOLT_HOME,
+# JOLT_CHEZ, JOLT_QUIET, PATH, LC_ALL per guest-recipe.edn). Scratch is
+# VM-local (/work): nothing here writes to the read-only source mount, and
+# nothing on the host is writable from in here.
+#
+# Guest /tmp is VM-local scratch and destroyed with the machine — the
+# harness never uses HOST temp dirs, and the boundary suite's own phase
+# dirs live in that guest-local scratch.
+
+set -eu
+
+SRC_RO=${JS1_GUEST_SRC_RO:-/opt/samizdat-src}
+WORK=${JS1_GUEST_WORK:-/work}
+PROJ="$WORK/samizdat"
+FIXTURE_RUNNER="test/fixtures/js1/boundary_runner.clj"
+
+# Same manifest discipline as the host side: sorted relative paths,
+# per-file sha256, one tree digest over the whole stream. .git excluded
+# (provenance is recorded separately via git rev-parse on the host).
+tree_manifest_sha() {
+  ( cd "$1" && find . -path ./.git -prune -o -type f -print0 \
+      | LC_ALL=C sort -z | xargs -0 sha256sum ) | sha256sum | cut -d' ' -f1
+}
+
+step=${1:-}
+case $step in
+  prepare)
+    mkdir -p "$PROJ" "$WORK/out"
+    # RO mount → VM-local writable copy. Incidental writes (.cpcache, the
+    # boundary suite's store files) land in scratch, never in the mount.
+    cp -a "$SRC_RO/." "$PROJ/"
+    printf 'GUEST-MANIFEST %s\n' "$(tree_manifest_sha "$PROJ")"
+    printf 'GUEST-PREPARE-OK\n'
+    ;;
+  check)
+    cd "$PROJ"
+    bin/js1 check
+    printf 'GUEST-CHECK-OK\n'
+    ;;
+  smoke)
+    cd "$PROJ"
+    bin/js1 smoke
+    # SANDBOX-TEST OK is printed by the suite itself on success.
+    printf 'GUEST-SMOKE-OK\n'
+    ;;
+  boundary)
+    cd "$PROJ"
+    # The recorded-classpath replay: bin/js1 composes the JS1 roots through
+    # the pinned runtime's own resolver; -Scp replays them with no
+    # dependency expansion (offline, deterministic). The runner fixture
+    # drives samizdat.js1-boundary-test's suite mode, which spawns fresh
+    # OS-process children for record/resume/mismatch/unsettled phases.
+    CP=$(bin/js1 path)
+    SAMIZDAT_JS1_BOUNDARY_TEST=1 \
+    SAMIZDAT_JOLT_BIN="$JOLT_HOME/bin/jolt" \
+    "$JOLT_HOME/bin/jolt" -Scp "$CP" run "$PROJ/$FIXTURE_RUNNER"
+    printf 'GUEST-BOUNDARY-OK\n'
+    ;;
+  *)
+    echo "guest-setup: unknown step '$step' (want: prepare|check|smoke|boundary)" >&2
+    exit 2
+    ;;
+esac

--- a/ci/js1-smolvm/lib-lock.sh
+++ b/ci/js1-smolvm/lib-lock.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# ci/js1-smolvm/lib-lock.sh — shared plumbing for the JS1×SmolVM lane.
+# POSIX sh. Sourced by preflight.sh, producer-gate.sh, consumer-run.sh and
+# build-guest-pack.sh; never executed directly.
+#
+# Owns: lock reads (the lock is one-scalar-per-line EDN so grep and
+# clojure.edn read the SAME bytes), the runner-owned CI dir discipline
+# (this harness never touches host temp dirs), bounded log capture,
+# deadline arithmetic, and EDN receipt emission. Every gate fails CLOSED:
+# a missing pin, a drifted pin, or an unknown shape is a refusal with a
+# remedy, never a skip.
+
+set -eu
+
+# ── Layout ────────────────────────────────────────────────────────────────
+# This file lives at <repo>/ci/js1-smolvm/lib-lock.sh.
+JS1CI_SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+JS1CI_REPO_ROOT=$(CDPATH= cd -- "$JS1CI_SCRIPT_DIR/../.." && pwd -P)
+JS1CI_LOCK="$JS1CI_SCRIPT_DIR/runtime-lock.edn"
+JS1CI_RECIPE="$JS1CI_SCRIPT_DIR/guest-recipe.edn"
+
+say()  { printf '%s\n' "js1-smolvm: $*"; }
+warn() { printf '%s\n' "js1-smolvm: WARNING: $*" >&2; }
+fail() { printf '%s\n' "js1-smolvm: FAIL: $*" >&2; exit 1; }
+
+# ── Lock reads ────────────────────────────────────────────────────────────
+# lock_get <namespaced-key> → the scalar on that line, quotes stripped.
+# The lock keeps exactly one scalar per line; the static test enforces it.
+lock_get() {
+  # One scalar per line; the map's closing brace only ever rides the last
+  # line, and no scalar value ends in '}', so stripping one trailing '}'
+  # after right-trimming is exact for this file (the static test pins the
+  # discipline).
+  _v=$(grep -E "^ $1 " "$JS1CI_LOCK" | head -1 \
+       | sed -E 's/^ [^ ]+ //; s/[[:space:]]*$//; s/}$//; s/[[:space:]]*$//')
+  [ -n "$_v" ] || fail "runtime-lock.edn has no line for $1 — lock is incomplete or format drifted (want: one scalar per line)"
+  case $_v in
+    \"*\") _v=${_v#\"}; _v=${_v%\"} ;;
+  esac
+  printf '%s' "$_v"
+}
+
+# ── CI dir discipline ─────────────────────────────────────────────────────
+# Every explicit host-side work product lives under
+# $JS1_SMOLVM_CI_DIR/<run-id>. The harness never touches host /tmp; the
+# unavoidable exceptions are OS/tooling state (smolvm's own machine store
+# under its state dir, git's own plumbing, /dev/kvm) and are documented in
+# docs/JS1_SMOLVM_CI.md.
+require_ci_dir() {
+  [ -n "${JS1_SMOLVM_CI_DIR:-}" ] || fail "JS1_SMOLVM_CI_DIR is unset.
+  Set it to an absolute, runner-owned directory for this lane's artifacts
+  (the workflow uses \${{ runner.temp }}/js1-smolvm). The harness refuses
+  to guess a location, and never uses host /tmp."
+  case $JS1_SMOLVM_CI_DIR in
+    /*) : ;;
+    *) fail "JS1_SMOLVM_CI_DIR must be absolute, got: $JS1_SMOLVM_CI_DIR" ;;
+  esac
+  case $JS1_SMOLVM_CI_DIR in
+    /tmp|/tmp/*|/var/tmp|/var/tmp/*)
+      fail "JS1_SMOLVM_CI_DIR must not be under /tmp or /var/tmp (got $JS1_SMOLVM_CI_DIR) — every explicit work dir for this lane is runner-owned under the CI artifact dir" ;;
+  esac
+  mkdir -p "$JS1_SMOLVM_CI_DIR" || fail "cannot create JS1_SMOLVM_CI_DIR=$JS1_SMOLVM_CI_DIR"
+}
+
+init_run_dir() {
+  require_ci_dir
+  # Run identity: explicit JS1_SMOLVM_RUN_ID wins (the workflow sets it from
+  # github.run_id); otherwise reuse the run this CI dir started within the
+  # last hour (so the three stages of one local invocation share a run
+  # dir); otherwise mint one.
+  if [ -n "${JS1_SMOLVM_RUN_ID:-}" ]; then
+    RUN_ID=$JS1_SMOLVM_RUN_ID
+  elif [ -f "$JS1_SMOLVM_CI_DIR/.latest-run" ] \
+       && [ $(( $(now_epoch) - $(stat -c %Y "$JS1_SMOLVM_CI_DIR/.latest-run") )) -lt 3600 ]; then
+    RUN_ID=$(cat "$JS1_SMOLVM_CI_DIR/.latest-run")
+  elif [ -f "/proc/sys/kernel/random/uuid" ]; then
+    RUN_ID="run-$(date +%Y%m%dT%H%M%SZ)-$(cat /proc/sys/kernel/random/uuid)"
+  else
+    RUN_ID="run-$(date +%Y%m%dT%H%M%SZ)-$$"
+  fi
+  printf '%s\n' "$RUN_ID" > "$JS1_SMOLVM_CI_DIR/.latest-run.$$"
+  mv "$JS1_SMOLVM_CI_DIR/.latest-run.$$" "$JS1_SMOLVM_CI_DIR/.latest-run"
+  RUN_DIR="$JS1_SMOLVM_CI_DIR/$RUN_ID"
+  LOG_DIR="$RUN_DIR/logs"
+  mkdir -p "$LOG_DIR" || fail "cannot create run dir $RUN_DIR"
+  # Harness-spawned children inherit a runner-owned TMPDIR, not host /tmp.
+  TMPDIR="$RUN_DIR/.tmpdir"
+  mkdir -p "$TMPDIR"
+  export TMPDIR
+  if [ -f "/proc/sys/kernel/random/uuid" ]; then
+    _uuid=$(cat /proc/sys/kernel/random/uuid)
+  else
+    _uuid="$$"
+  fi
+  MACHINE_NAME="$(lock_get :machine/name-prefix)$_uuid"
+  export RUN_ID RUN_DIR LOG_DIR MACHINE_NAME
+}
+
+# ── Time / deadlines ──────────────────────────────────────────────────────
+now_epoch() { date +%s; }
+now_iso()   { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+RUN_T0=$(now_epoch)
+
+# deadline_check <budget-seconds> <stage> — refuse if the total deadline
+# for the lane is already exhausted before starting <stage>.
+deadline_check() {
+  _elapsed=$(( $(now_epoch) - RUN_T0 ))
+  if [ "$_elapsed" -ge "$1" ]; then
+    fail "deadline exhausted before $2 could start (${_elapsed}s >= ${1}s budget)"
+  fi
+  say "deadline: ${_elapsed}s elapsed of ${1}s budget, starting: $2"
+}
+
+# ── Bounded log capture ───────────────────────────────────────────────────
+# cap_log <file> — truncate an oversized step log to head+tail of half the
+# per-step budget each, with a banner replacing the middle. Runs AFTER the
+# step (the guest-side bound is the exec --timeout; this is the artifact
+# bound). Uses only RUN_DIR scratch — never host /tmp.
+cap_log() {
+  _f=$1
+  _max=$(lock_get :log/max-step-bytes)
+  [ -f "$_f" ] || return 0
+  _sz=$(stat -c %s "$_f")
+  if [ "$_sz" -gt "$_max" ]; then
+    _half=$(( _max / 2 ))
+    _tmp="$RUN_DIR/.caplog.tmp"
+    { head -c "$_half" "$_f"
+      printf '\njs1-smolvm: [LOG TRUNCATED: %s bytes total, middle %s bytes elided]\n' "$_sz" "$(( _sz - _max ))"
+      tail -c "$_half" "$_f"
+    } > "$_tmp"
+    mv "$_tmp" "$_f"
+    warn "log $(basename "$_f") truncated to $_max bytes (was $_sz)"
+  fi
+}
+
+# run_logged <logfile> <host-timeout-seconds> <argv...> — run one harness
+# command with a host-side hard timeout, capturing stdout+stderr to the
+# log, then capping it. Returns the command's exit code (124/137 on
+# timeout) without aborting the caller.
+run_logged() {
+  _log=$1; _to=$2; shift 2
+  set +e
+  timeout -s TERM -k 30 "$_to" "$@" > "$_log" 2>&1
+  _rc=$?
+  set -e
+  cap_log "$_log"
+  return "$_rc"
+}
+
+# ── Receipts (EDN-lines) ──────────────────────────────────────────────────
+# One complete EDN map per line, append-only. A mid-lane failure can never
+# leave an unclosed form: every line parses on its own, in order.
+# receipt_event <file> <stage> <event> [extra flat kvs as a pre-formatted
+# string] — values are harness-generated scalars only (paths, digests,
+# fixed keywords, ints), never free-form guest output.
+receipt_event() {
+  _f=$1; _stage=$2; _event=$3; _extra=${4:-}
+  printf '{:receipt/schema 1 :stage "%s" :event "%s" :time "%s" :run/id "%s" :lock/sha256 "%s"%s}\n' \
+    "$_stage" "$_event" "$(now_iso)" "${RUN_ID:-unknown}" \
+    "$(sha256sum "$JS1CI_LOCK" | cut -d' ' -f1)" "$_extra" >> "$_f"
+}
+
+# repo_provenance — "HEAD (N tracked file(s) modified)" for receipts.
+repo_provenance() {
+  if [ -d "$JS1CI_REPO_ROOT/.git" ]; then
+    _h=$(git -C "$JS1CI_REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+    _n=$(git -C "$JS1CI_REPO_ROOT" status --porcelain --untracked-files=no 2>/dev/null | wc -l | tr -d ' ')
+    printf '%s (%s tracked file(s) modified)' "$_h" "$_n"
+  else
+    printf 'unknown (not a git checkout)'
+  fi
+}

--- a/ci/js1-smolvm/preflight.sh
+++ b/ci/js1-smolvm/preflight.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# ci/js1-smolvm/preflight.sh — host gates for the JS1×SmolVM lane.
+#
+# Proves the host is one this lane is defined for (Linux x86_64 with KVM),
+# the runner-owned CI dir is explicit and never host /tmp, the required
+# tooling exists, the pinned smolvm launcher is present, and no stale
+# js1ci-* machines survive from a previous run (any found are deleted and
+# reported — teardown is not optional in this lane).
+#
+# Exit 0: all gates pass (receipt written). Exit 1: refused, actionable
+# reason on stderr (receipt still written when a CI dir is available).
+
+set -eu
+. "$(dirname "$0")/lib-lock.sh"
+
+VERDICT=":pass"
+
+init_run_dir
+REFUSALS="$RUN_DIR/refusals.txt"
+: > "$REFUSALS"
+LOG="$LOG_DIR/preflight.log"
+: > "$LOG"
+
+refuse() {
+  # Record and continue collecting refusals so one run reports them all.
+  printf '%s\n' "js1-smolvm: REFUSE: $*" | tee -a "$REFUSALS" >&2
+}
+
+# ── Platform: Linux x86_64 with KVM ───────────────────────────────────────
+_os=$(uname -s)
+_arch=$(uname -m)
+[ "$_os" = "Linux" ] || refuse "host OS is $_os, need Linux (SmolVM KVM lane). Use the self-hosted linux/x64/kvm runner."
+[ "$_arch" = "x86_64" ] || refuse "host arch is $_arch, need x86_64. The lock declares :platform/arch \"x86_64\"; do not silently retarget."
+_kvm=$(lock_get :platform/kvm-device)
+if [ ! -c "$_kvm" ]; then
+  refuse "$_kvm is not a character device — KVM is unavailable. On the self-hosted runner: load kvm_amd/kvm_intel and udev-export /dev/kvm."
+elif [ ! -r "$_kvm" ] || [ ! -w "$_kvm" ]; then
+  refuse "$_kvm exists but is not rw for $(id -un). Remedy on the runner: usermod -aG kvm <runner-user> (or the equivalent udev rule), then re-dispatch."
+fi
+
+# ── Tooling (host side; the guest side is baked into the pack) ────────────
+for t in git awk sed grep find sort xargs sha256sum timeout date stat head tail cut tr uname id cat; do
+  command -v "$t" >/dev/null 2>&1 || refuse "required tool '$t' is not on PATH"
+done
+
+# ── The pinned smolvm launcher ────────────────────────────────────────────
+LAUNCHER=${JS1_SMOLVM_LAUNCHER:-"$HOME/$(lock_get :smolvm/launcher-relpath)"}
+if [ ! -x "$LAUNCHER" ]; then
+  refuse "smolvm launcher not executable at $LAUNCHER. Provision smolvm $(lock_get :smolvm/version) on the runner (expected layout: \$HOME/$(lock_get :smolvm/launcher-relpath) + smolvm-bin + lib/), or set JS1_SMOLVM_LAUNCHER."
+fi
+
+# ── Repo layout ───────────────────────────────────────────────────────────
+for rel in "$(lock_get :inventory/wrapper)" "$(lock_get :inventory/preflight)" \
+           "$(lock_get :inventory/producer)" "$(lock_get :inventory/consumer)" \
+           "$(lock_get :inventory/guest-setup)" "$(lock_get :inventory/lock)" \
+           "$(lock_get :inventory/recipe)" "$(lock_get :inventory/fixtures)" \
+           "$(lock_get :inventory/boundary-runner)" "$(lock_get :inventory/workflow)"; do
+  [ -e "$JS1CI_REPO_ROOT/$rel" ] || refuse "inventory file missing from the checkout: $rel"
+done
+[ -x "$JS1CI_REPO_ROOT/bin/js1" ] || refuse "bin/js1 is not executable in this checkout"
+
+# ── Stale machine sweep (js1ci-* must not survive between runs) ───────────
+STALE=""
+if [ -x "$LAUNCHER" ]; then
+  STALE=$("$LAUNCHER" machine ls --json 2>/dev/null \
+          | tr -d ' \n' \
+          | grep -o '"name":"'"$(lock_get :machine/name-prefix)"'[^"]*"' \
+          | sed 's/"name":"//; s/"//' || true)
+  for m in $STALE; do
+    warn "stale machine from an earlier run: $m — deleting (teardown is mandatory)"
+    "$LAUNCHER" machine stop --name "$m" >/dev/null 2>&1 || true
+    "$LAUNCHER" machine delete --name "$m" --force >/dev/null 2>&1 \
+      || refuse "could not delete stale machine $m — remove it with: $LAUNCHER machine delete --name $m --force"
+  done
+fi
+
+# ── Verdict + receipt ─────────────────────────────────────────────────────
+{
+  printf 'preflight at %s\n' "$(now_iso)"
+  printf 'os=%s arch=%s kvm=%s\n' "$_os" "$_arch" "$_kvm"
+  printf 'launcher=%s\n' "$LAUNCHER"
+  printf 'run-dir=%s\n' "$RUN_DIR"
+  if [ -s "$REFUSALS" ]; then printf 'refusals:\n'; cat "$REFUSALS"; fi
+} >> "$LOG"
+
+if [ -s "$REFUSALS" ]; then VERDICT=":refused"; fi
+_stale_edn=$( [ -n "$STALE" ] && { for m in $STALE; do printf '"%s" ' "$m"; done | sed 's/ $//'; } || true )
+receipt_event "$RUN_DIR/preflight-receipt.edn" "preflight" "verdict" \
+  " :verdict $VERDICT :preflight/launcher \"$LAUNCHER\" :preflight/stale-swept [$_stale_edn] :samizdat/provenance \"$(repo_provenance)\""
+
+if [ "$VERDICT" != ":pass" ]; then
+  cat "$REFUSALS" >&2
+  fail "preflight refused (see $LOG and $RUN_DIR/preflight-receipt.edn)"
+fi
+say "preflight OK (run dir: $RUN_DIR)"

--- a/ci/js1-smolvm/producer-gate.sh
+++ b/ci/js1-smolvm/producer-gate.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# ci/js1-smolvm/producer-gate.sh — pin and inventory gates for the
+# JS1×SmolVM lane. Producer-side: proves the lock agrees with the repo's
+# own pin authorities (bin/js1, deps.edn), the smolvm executor on this host
+# is exactly the pinned build (version AND the real binary's sha256 — a
+# version string alone is never trusted), the guest pack exists and matches
+# the locked digest, and the repo-side inventory is complete.
+#
+# FAIL CLOSED everywhere: any drift or absence exits 1 with the remedy on
+# stderr and a receipt in the run dir. An absent/unbuilt pack is a
+# :refused verdict — never a fabricated or substituted guest.
+
+set -eu
+. "$(dirname "$0")/lib-lock.sh"
+
+init_run_dir
+REFUSALS="$RUN_DIR/refusals.txt"
+: > "$REFUSALS"
+LOG="$LOG_DIR/producer-gate.log"
+: > "$LOG"
+
+refuse() { printf '%s\n' "js1-smolvm: REFUSE: $*" | tee -a "$REFUSALS" >&2; }
+
+WRAPPER="$JS1CI_REPO_ROOT/bin/js1"
+DEPS="$JS1CI_REPO_ROOT/deps.edn"
+
+# ── Gate 1: lock pins == bin/js1 pins (no restatement drift) ─────────────
+# bin/js1 is the runtime authority; the lock only restates it for CI.
+wrapper_var() { grep -E "^$1=" "$WRAPPER" | head -1 | cut -d= -f2-; }
+
+w_jolt_sha=$(wrapper_var JOLT_SHA)
+w_jolt_branch=$(wrapper_var JOLT_BRANCH)
+w_jolt_url=$(wrapper_var JOLT_URL)
+w_sci_sha=$(wrapper_var SCI_SHA)
+w_sci_version=$(wrapper_var SCI_VERSION)
+
+[ "$w_jolt_sha" = "$(lock_get :jolt/sha)" ] \
+  || refuse "lock :jolt/sha $(lock_get :jolt/sha) != bin/js1 JOLT_SHA $w_jolt_sha. The lock restates the wrapper; fix the lock, never the wrapper from here."
+[ "$w_jolt_branch" = "$(lock_get :jolt/branch)" ] \
+  || refuse "lock :jolt/branch != bin/js1 JOLT_BRANCH ($w_jolt_branch)"
+[ "$w_jolt_url" = "$(lock_get :jolt/url)" ] \
+  || refuse "lock :jolt/url != bin/js1 JOLT_URL ($w_jolt_url)"
+[ "$w_sci_sha" = "$(lock_get :sci/sha)" ] \
+  || refuse "lock :sci/sha $(lock_get :sci/sha) != bin/js1 SCI_SHA $w_sci_sha"
+[ "$w_sci_version" = "$(lock_get :sci/version)" ] \
+  || refuse "lock :sci/version $(lock_get :sci/version) != bin/js1 SCI_VERSION $w_sci_version"
+
+# ── Gate 2: lock crypto pin == deps.edn's jolt-crypto :git/sha ────────────
+# Same extraction discipline as bin/js1's crypto_sha_from_deps.
+deps_crypto_sha=$(awk '
+  /jolt-lang\/jolt-crypto/ {inblock=1}
+  inblock && /:git\/sha/ {
+    if (match($0, /"[0-9a-f]{40}"/)) { print substr($0, RSTART + 1, 40); exit }
+  }' "$DEPS")
+[ -n "$deps_crypto_sha" ] || refuse "no jolt-lang/jolt-crypto :git/sha found in deps.edn — the JS1 digest substrate pin is missing"
+[ "$deps_crypto_sha" = "$(lock_get :jolt-crypto/sha)" ] \
+  || refuse "lock :jolt-crypto/sha $(lock_get :jolt-crypto/sha) != deps.edn pin $deps_crypto_sha. deps.edn is the single place that pin is stated; fix the lock."
+
+# ── Gate 3: smolvm executor — version AND real-binary digest ─────────────
+LAUNCHER=${JS1_SMOLVM_LAUNCHER:-"$HOME/$(lock_get :smolvm/launcher-relpath)"}
+[ -x "$LAUNCHER" ] || refuse "smolvm launcher missing at $LAUNCHER (run preflight.sh for the full remedy)"
+
+ver_out=$("$LAUNCHER" --version 2>/dev/null || echo "unreadable")
+[ "$ver_out" = "smolvm $(lock_get :smolvm/version)" ] \
+  || refuse "smolvm --version reports '$ver_out', need exactly 'smolvm $(lock_get :smolvm/version)'. Do not silently switch executor versions; re-provision the pinned release."
+
+# Resolve the wrapper symlink chain to the real directory, then digest the
+# ACTUAL smolvm-bin — never a descriptor file beside it.
+_launcher_resolved=$(readlink -f "$LAUNCHER")
+_bin="$(dirname "$_launcher_resolved")/$(lock_get :smolvm/bin-relpath)"
+if [ ! -f "$_bin" ]; then
+  refuse "smolvm-bin not found beside the launcher at $_bin — incomplete installation"
+else
+  _bin_sha=$(sha256sum "$_bin" | cut -d' ' -f1)
+  [ "$_bin_sha" = "$(lock_get :smolvm/bin-sha256)" ] \
+    || refuse "smolvm-bin sha256 $_bin_sha != locked $(lock_get :smolvm/bin-sha256). The executor bytes changed; investigate before any guest evidence is trusted."
+fi
+
+# ── Gate 4: guest pack — present, digest-pinned, or REFUSED ──────────────
+# JS1_SMOLVM_BUILD_LANE=1 is set ONLY by build-guest-pack.sh: the build is
+# what produces the pack, so its presence cannot be a precondition. Every
+# other gate (pin drift, executor digest, inventory) still runs, and the
+# build lane re-verifies the finished pack's digest before reporting it.
+PACK=${JS1_SMOLVM_PACK:-"$HOME/$(lock_get :guest-pack/path-relpath)"}
+PACK_STATUS=$(lock_get :guest-pack/status)
+PACK_SHA=$(lock_get :guest-pack/sha256)
+
+if [ "${JS1_SMOLVM_BUILD_LANE:-}" = "1" ]; then
+  say "build lane: guest-pack presence gate skipped (this run produces the pack)"
+elif [ "$PACK_STATUS" != ":built" ] || [ "$PACK_SHA" = "nil" ]; then
+  refuse "the JS1 guest pack is not provisioned under this lock (:guest-pack/status is $PACK_STATUS).
+  Remedy (producer lane, needs network + KVM, ~once per lock change):
+    1. ci/js1-smolvm/build-guest-pack.sh            # builds per guest-recipe.edn, prints the pack sha256
+    2. pin that sha256 into ci/js1-smolvm/runtime-lock.edn :guest-pack/sha256 and set :guest-pack/status :built
+    3. place the pack at $PACK (or set JS1_SMOLVM_PACK)
+  No pack, no guest run — this lane never fabricates one."
+elif [ ! -f "$PACK" ]; then
+  refuse "lock says the pack is built at sha256 $PACK_SHA but $PACK does not exist. Provision the pack artifact for this runner (see docs/JS1_SMOLVM_CI.md § Provisioning)."
+else
+  _actual=$(sha256sum "$PACK" | cut -d' ' -f1)
+  [ "$_actual" = "$PACK_SHA" ] \
+    || refuse "guest pack sha256 $_actual != locked $PACK_SHA. The pack bytes changed — treat as a supply-chain event, not a cache miss."
+fi
+
+# ── Gate 5: repo-side inventory is complete ───────────────────────────────
+for key in :inventory/wrapper :inventory/preflight :inventory/producer \
+           :inventory/consumer :inventory/guest-setup :inventory/lock \
+           :inventory/recipe :inventory/fixtures :inventory/boundary-runner \
+           :inventory/workflow; do
+  rel=$(lock_get "$key")
+  [ -e "$JS1CI_REPO_ROOT/$rel" ] || refuse "inventory file missing: $rel ($key)"
+done
+
+# ── Verdict + receipt ─────────────────────────────────────────────────────
+VERDICT=":pass"
+[ -s "$REFUSALS" ] && VERDICT=":refused"
+{
+  printf 'producer-gate at %s\n' "$(now_iso)"
+  printf 'jolt=%s sci=%s (%s) crypto=%s\n' "$w_jolt_sha" "$w_sci_sha" "$w_sci_version" "$deps_crypto_sha"
+  printf 'smolvm=%s bin-sha256=%s\n' "$ver_out" "${_bin_sha:-unverified}"
+  printf 'pack=%s status=%s\n' "$PACK" "$PACK_STATUS"
+  if [ -s "$REFUSALS" ]; then printf 'refusals:\n'; cat "$REFUSALS"; fi
+} >> "$LOG"
+
+_pack_sha_edn=$( [ "$PACK_SHA" = "nil" ] && printf 'nil' || printf '"%s"' "$PACK_SHA" )
+receipt_event "$RUN_DIR/producer-receipt.edn" "producer-gate" "verdict" \
+  " :verdict $VERDICT :pins/jolt \"$w_jolt_sha\" :pins/sci \"$w_sci_sha\" :pins/sci-version \"$w_sci_version\" :pins/jolt-crypto \"$deps_crypto_sha\" :smolvm/version \"$ver_out\" :smolvm/bin-sha256 \"${_bin_sha:-unverified}\" :guest-pack/path \"$PACK\" :guest-pack/status $PACK_STATUS :guest-pack/sha256 $_pack_sha_edn :samizdat/provenance \"$(repo_provenance)\""
+
+if [ "$VERDICT" != ":pass" ]; then
+  cat "$REFUSALS" >&2
+  fail "producer gate refused (see $LOG and $RUN_DIR/producer-receipt.edn)"
+fi
+say "producer gates OK"

--- a/ci/js1-smolvm/runtime-lock.edn
+++ b/ci/js1-smolvm/runtime-lock.edn
@@ -24,8 +24,8 @@
 
  ;; The pinned JS1 runtime stack (docs/JS1_RUNTIME.md § Pins).
  :jolt/url "https://github.com/casselc/jolt"
- :jolt/branch "js0-functional-sci-upstream"
- :jolt/sha "619ef19685460af847654e22cf6beda904d052fb"
+ :jolt/branch "js1-runtime-current-upstream"
+ :jolt/sha "279bca18bbf50f37b8574a4e6998dee40313cd26"
  :sci/sha "32d62a5136ad3dc148588752f5bcc4cc30b14752"
  :sci/version "0.13.53"
  :jolt-crypto/lib "jolt-lang/jolt-crypto"

--- a/ci/js1-smolvm/runtime-lock.edn
+++ b/ci/js1-smolvm/runtime-lock.edn
@@ -1,0 +1,95 @@
+;; JS1 × SmolVM CI harness — runtime lock.
+;;
+;; THE single source of truth for the pinned JS1-in-SmolVM lane. Read two
+;; ways, deliberately: as EDN (test/samizdat/js1_harness_test.clj) and
+;; line-greppable by the POSIX shell gates (ci/js1-smolvm/lib-lock.sh).
+;; Keep exactly one scalar per line so both reads can never drift apart.
+;;
+;; The JS1 runtime pins here MUST equal the pins bin/js1 enforces and the
+;; jolt-crypto pin deps.edn states; producer-gate.sh refuses the lane
+;; otherwise (no restatement drift, no silent compiler/runtime switch).
+;;
+;; Trust anchors: the smolvm BINARY sha256 below (verified against the real
+;; bytes on every run) and — once built — the guest-pack sha256. A descriptor
+;; fetched from beside an archive is never an independent trust anchor; the
+;; producer build records what it actually fetched into pack-manifest.edn.
+{
+ :lock/version 1
+ :lock/name "js1-smolvm-ci"
+
+ ;; Platform gate: the lane refuses anything else (SmolVM Linux/KVM only).
+ :platform/os "linux"
+ :platform/arch "x86_64"
+ :platform/kvm-device "/dev/kvm"
+
+ ;; The pinned JS1 runtime stack (docs/JS1_RUNTIME.md § Pins).
+ :jolt/url "https://github.com/casselc/jolt"
+ :jolt/branch "js0-functional-sci-upstream"
+ :jolt/sha "619ef19685460af847654e22cf6beda904d052fb"
+ :sci/sha "32d62a5136ad3dc148588752f5bcc4cc30b14752"
+ :sci/version "0.13.53"
+ :jolt-crypto/lib "jolt-lang/jolt-crypto"
+ :jolt-crypto/url "https://github.com/jolt-lang/jolt-crypto"
+ :jolt-crypto/sha "1ab72aa5f73be7ec41f01086953ffb43ecd3d84e"
+
+ ;; SmolVM executor. The launcher path is runner-local (env
+ ;; JS1_SMOLVM_LAUNCHER, default $HOME/<:smolvm/launcher-relpath>); version
+ ;; and the smolvm-bin sha256 are the pinned, always-verified properties.
+ :smolvm/version "1.7.5"
+ :smolvm/launcher-relpath ".smolvm/smolvm"
+ :smolvm/bin-relpath "smolvm-bin"
+ :smolvm/bin-sha256 "88288569c4c4128a0c3893e1a23babb2bdaf5a4b37eeb3e4951f9c75da6bafd8"
+
+ ;; Guest pack. :unbuilt means the pack has never been produced under this
+ ;; lock: every consumer gate must REFUSE with the build remedy rather than
+ ;; fabricate a run. When built, set :status :built and pin the pack sha256.
+ :guest-pack/status :unbuilt
+ :guest-pack/sha256 nil
+ :guest-pack/path-relpath ".smolvm/js1-guest.smolmachine"
+
+ ;; Guest shape (inside the VM). The runtime checkout is baked into the pack
+ ;; at /opt/js1-runtime/jolt with .git and the vendor/sci submodule intact —
+ ;; bin/js1's pin verification runs against it in the guest.
+ :guest/runtime-root "/opt/js1-runtime"
+ :guest/jolt-home "/opt/js1-runtime/jolt"
+ :guest/chez "/usr/local/bin/scheme"
+ :guest/home "/root"
+ :guest/mount-source-ro "/opt/samizdat-src"
+ :guest/work-dir "/work"
+ :guest/source-copy "/work/samizdat"
+
+ ;; Machine bounds. Deliberately modest; the boundary suite spawns fresh
+ ;; jolt children, each with its own deadline, inside the guest.
+ :machine/name-prefix "js1ci-"
+ :machine/cpus 2
+ :machine/mem-mib 4096
+
+ ;; Step deadlines (seconds). :deadline/total-seconds is the hard cap for
+ ;; the whole consumer run; per-step caps are independent and whichever
+ ;; fires first wins. Teardown always gets its own budget.
+ :deadline/preflight-seconds 120
+ :deadline/producer-seconds 300
+ :deadline/setup-seconds 420
+ :deadline/check-seconds 180
+ :deadline/smoke-seconds 900
+ :deadline/boundary-seconds 1500
+ :deadline/teardown-seconds 240
+ :deadline/total-seconds 2400
+
+ ;; Log bounds: per-step capture is truncated to head+tail of half this
+ ;; each when exceeded; the truncation banner replaces the middle.
+ :log/max-step-bytes 8388608
+
+ ;; Producer inventory: repo-side files the lane depends on. The producer
+ ;; gate requires every one to exist; the guest pack content itself is
+ ;; pinned by :guest-pack/sha256 once built.
+ :inventory/wrapper "bin/js1"
+ :inventory/preflight "ci/js1-smolvm/preflight.sh"
+ :inventory/producer "ci/js1-smolvm/producer-gate.sh"
+ :inventory/consumer "ci/js1-smolvm/consumer-run.sh"
+ :inventory/guest-setup "ci/js1-smolvm/guest-setup.sh"
+ :inventory/lock "ci/js1-smolvm/runtime-lock.edn"
+ :inventory/recipe "ci/js1-smolvm/guest-recipe.edn"
+ :inventory/fixtures "test/fixtures/js1/fixtures.edn"
+ :inventory/boundary-runner "test/fixtures/js1/boundary_runner.clj"
+ :inventory/workflow ".github/workflows/js1-smolvm.yml"}

--- a/deps.edn
+++ b/deps.edn
@@ -60,6 +60,15 @@
 
  :nrepl/middleware [nrepl.middleware/default-middleware]
 
+ ;; JS1 (the SCI sandbox seam) is NOT an alias here: it needs the pinned
+ ;; Jolt runtime's vendored SCI on the source roots, and that checkout's
+ ;; location is only known at run time.  bin/js1 owns the whole
+ ;; construction (locate + pin-check the runtime, hand jolt a generated
+ ;; alias so JOLT composes the roots — reading the jolt-crypto pin from
+ ;; :deps above, since the sandbox's digest substrate needs exactly the
+ ;; production coordinate); docs/JS1_RUNTIME.md names the pins.  Nothing
+ ;; below changes: no alias or task under this comment is selected by an
+ ;; ordinary invocation.
  :aliases {:test {:extra-paths ["test" "gui"]
                   :main-opts ["-m" "samizdat.test-runner"]}
            ;; command-line nREPL client, plus the test tree, so the live

--- a/docs/JS1_A3C_COMPARISON.md
+++ b/docs/JS1_A3C_COMPARISON.md
@@ -1,0 +1,30 @@
+# JS1 and Frozen A3c Comparison
+
+## Coordinates
+
+- bbagent A3c evidence: tag `bbagent-a3c` / `fc5e5b9`; runtime evidence was
+  produced at `740d117`.
+- bb4t A3c: tag `bb4t-a3c` / `227d3854`.
+- JS1 live coordinate: Samizdat `8995e113`, Jolt `279bca18`, SCI `0.13.53`.
+
+## Comparable Results
+
+Both systems provide a persistent bounded SCI context, capability discovery,
+digest-anchored project mutation, trusted verification, and durable replay.
+JS1's live run proves process-kill recovery, reconstructed definitions, and
+zero replayed semantic operations at project-operation granularity. Its live
+run used 14 turns / 14 tool calls with one failed `project/search` argument
+order before recovery; the scripted contract then reached RED and GREEN.
+
+## Deliberate Differences and Non-Claims
+
+A3c additionally proves a pinned guest execution boundary and `project/run`.
+JS1 intentionally has neither: it has five read/edit project capabilities and
+a controller-owned scoped verifier, but no model-facing shell, network, or
+execution capability. JS1's SmolVM guest pack is unbuilt, so A3c host-isolation
+and clean-consumer claims are not retained or implied. Latency measurements are
+not comparable: A3c measures guest executions; JS1 records no latency claim.
+
+Conclusion: JS1 retains the bounded-programming and no-repeat replay properties
+that are in its smaller authority surface. It does not claim A3c execution
+isolation or arbitrary-project-code containment.

--- a/docs/JS1_FINDINGS.md
+++ b/docs/JS1_FINDINGS.md
@@ -8,10 +8,9 @@ gates are evidence gaps, not a decision to replace it.
 
 ## Baseline
 
-- Samizdat branch: `js1-bounded-samizdat`, recovery base
-  `321661649e174bb748adeb6970dad6c166003343`, rebased on current upstream
-  `dae78547a66c80f31fa7a78d0f9483186a2b0af9`; deterministic closure changes
-  are pending commit.
+- Samizdat branch: `js1-bounded-samizdat` at
+  `db1226f`, whose recovery base `321661649e174bb748adeb6970dad6c166003343`
+  was rebased on current upstream `dae78547a66c80f31fa7a78d0f9483186a2b0af9`.
 - Current Jolt evaluator runtime:
   `279bca18bbf50f37b8574a4e6998dee40313cd26` on
   `js1-runtime-current-upstream`, rebased on upstream `edda7aec`.

--- a/docs/JS1_FINDINGS.md
+++ b/docs/JS1_FINDINGS.md
@@ -2,96 +2,60 @@
 
 ## Decision
 
-**REVISE.** The JS1 cutover is not approved to merge. Several required PASS
-criteria remain unmet, and nothing should be read into the passing gates as
-approval. This record leads with the decision, then states exactly which gates
-executed and which PASS criteria are unmet, and preserves the standing
-non-claims verbatim.
+**REVISE.** JS1 is not approved for self-hosting or merge approval yet. The
+bounded evaluator architecture remains the intended design; the remaining
+gates are evidence gaps, not a decision to replace it.
 
 ## Baseline
 
-- Samizdat `main` @ `b93d601`. All JS1 work is **uncommitted** (working tree only).
-- Jolt upstream JS0: `04dd42db` on branch `js0-functional-sci-upstream`.
-  - Frozen tag: `js0-functional-sci-upstream-freeze`.
-  - Upstream baseline: `c4547b5e`.
-  - SCI: `32d62a51`.
-- Upstream action: **none** — no Samizdat PR opened, no push made.
+- Samizdat branch: `js1-bounded-samizdat`, rebased on `d083eeb`.
+- Jolt evaluator runtime: `619ef19685460af847654e22cf6beda904d052fb` on
+  `js0-functional-sci-upstream`; the original JS0 freeze remains tagged
+  `js0-functional-sci-upstream-freeze` at `04dd42db`.
+- SCI: `32d62a5136ad3dc148588752f5bcc4cc30b14752` (`0.13.53`).
 
-## Executed Gates (verified)
+## Executed Gates
 
 | Gate | Result |
 |---|---|
-| Full Samizdat Jolt suite | `946` tests / `2998` assertions |
-| Direct sandbox (offline `-Scp` invocation) | `14` / `111` |
-| Eval store (`samizdat.store.evals`) | `13` / `58` |
-| Wiring require | guarded `samizdat.agent.sandbox` require verified; non-JS1 path incurs no dependency cost |
-| Model tool surface | closed set `#{eval doc complete done}` (verified) |
-| Host capability authority | `tools/base.clj` `phase-refusal` — single pre-dispatch enforcement point; profile flag set only from trusted config/workflow, never model input |
-| Replay | journal `:js1-binding-created` carries `profile`, `binding-id`, `instance-id`, `spec-coordinate`, `preset`; `store/evals` durable ordered receipts `{op args result|error}` |
-| Evaluator binding seam | `samizdat.agent.sandbox` `EvaluatorSpec` / `Instance` / `Binding` (three coordinates); `:js1/binding` in ctx checked first by `eval`/`doc`/`complete` → `sandbox/evaluate!` |
-| Upstream PR / push | **none** (no PR, no push) |
+| Full Samizdat Jolt suite | `1000` tests / `3316` assertions, zero failures/errors |
+| Direct bounded SCI sandbox | `28` tests / `268` assertions, zero failures/errors |
+| Durable evaluator store | `18` tests / `78` assertions, zero failures/errors |
+| Controlled OS-process recovery harness | `1` test / `30` assertions, zero failures/errors |
+| Static local SmolVM harness | `12` tests / `156` assertions, zero failures/errors |
 
-## Unmet PASS Criteria (exact)
+## Now Evidenced
 
-- **No real model dogfood task** — no real model has exercised the JS1 tool
-  surface end-to-end.
-- **No actual process terminate / restart / resume evidence** — durable restart
-  is **not** demonstrated.
-- **No frozen bbagent A3c comparison** — the frozen `bbagent` A3c baseline was
-  not produced or compared.
-- **No live controller budget proof** — no demonstration of a live controller
-  budget under JS1.
-- **No cross-platform run** — no non-Jolt / plain-JVM (or any other) platform
-  lane was executed.
+- Runtime, language-surface, capability-catalog, and receipt-protocol
+  coordinates are durable and checked before replay.
+- Receipts remain strict canonical data while arbitrary valid SCI final values
+  are rendered safely rather than incorrectly failing evaluation.
+- Only successful evaluations become persistent computational state; failed or
+  interrupted evaluations rebuild from committed history before reuse.
+- Whole committed history reconstructs into one fresh SCI context with exact
+  receipt consumption and zero repeated semantic world operations.
+- A controlled real OS-process boundary proves helper reconstruction, no replay
+  of an observation/edit, and fail-closed runtime/spec/pending-history cases.
+- JS1 with multi-branch execution is refused; the current policy is one
+  logical persistent `:main` evaluator.
 
-## Durable-restart status
+## Remaining PASS Gates
 
-**Not claimed completed.** Only the fail-closed resume *policy* is implemented;
-no actual terminate → restart → resume cycle has been executed end-to-end.
+- A real-model JS1 red → repair → green dogfood task.
+- Frozen bbagent A3c comparison.
+- Live controller-owned budget proof.
+- SmolVM guest boot and clean-consumer execution. The checked-in local harness
+  is static/producer evidence only until a pinned guest is built and run.
 
-## Files (uncommitted inventory, `main` @ `b93d601`)
+## Standing Non-Claims
 
-Modified:
-- `resources/prompts/system.md`
-- `src/samizdat/agent/beam.clj`
-- `src/samizdat/agent/files.clj`
-- `src/samizdat/agent/resume.clj`
-- `src/samizdat/agent/tools.clj`
-- `src/samizdat/agent/tools/base.clj`
-- `src/samizdat/agent/tools/repl.clj`
-- `src/samizdat/store/migrations.clj`
-- `src/samizdat/workflow.clj`
-- `test/samizdat/test_runner.clj`
-
-New (untracked):
-- `src/samizdat/agent/sandbox.clj`
-- `src/samizdat/store/evals.clj`
-- `test/samizdat/evals_test.clj`
-- `test/samizdat/sandbox_test.clj`
-- `docs/JS1_FINDINGS.md`
-- `artifacts/js1-evidence.edn`
-
-## Non-Claims
-
-### What IS claimed
-- The JS1 phase-refusal gate rejects tools not in the closed vocabulary before dispatch.
-- When `:js1/binding` is present in ctx, `eval`/`doc`/`complete` route to the sandbox binding and never touch `samizdat.repl`.
-- When `:js1/binding` is absent, the tools behave exactly as before (bit-for-bit unchanged path).
-- Resume of a JS1-profiled run fails closed when SCI is unavailable.
-- The JS1 profile flag is set only from trusted config/workflow code, never from model input.
-- The nREPL, developer REPL, and all non-JS1 workflows are unaffected.
-
-### What is NOT claimed
-- **Evaluator spec/instance/binding IDs in durable eval calls**: The existing `runs/start-run!` API in `store/runs.clj` does not expose sandbox binding identity. The journal's `:js1-binding-created` event carries the binding/spec/instance IDs for resume, but these are NOT incorporated into the eval turn rows themselves (the turns table schema was not editable). This is documented as an **integration blocker**.
-- **SCI availability on plain JVM**: The sandbox requires `jolt.sandbox` and SCI, which are jolt-only. New-run fallback is logged; resume is fail-closed. This is a platform constraint, not a code defect.
-- **JS1 doc/complete fidelity**: SCI `ns-publics` and `resolve`/`meta` provide a subset of the live REPL's introspection. Core var metadata may be stripped by jolt. The model gets correct answers for project vars and clojure.core; metadata-dependent features (arglists from core) may be degraded.
-- **Beam multi-branch JS1 isolation**: All branches share the `:main` instance. A controller needing per-branch isolation must pass a distinct `:instance/key`. The current implementation does not do this automatically.
-- **Performance**: No measurement of JS1 eval latency vs. live REPL has been made.
-
-## Integration Blocker
-
-The `runs/start-run!` function and the turns table schema do not carry sandbox binding metadata (evaluator spec, instance ID, binding ID). The journal's `:js1-binding-created` event records these for resume reconstruction, but the individual eval turn rows in the `turns` table have no column for them. Adding this would require either:
-1. A schema migration (editing `stores/migrations/evals` — excluded by the file fence), or
-2. A separate join table mapping turn IDs to binding metadata.
-
-Neither is attempted. The journal event is the authority for resume.
+- No self-hosting canary has run; **SELF-HOSTING CANARY: PASS** is not claimed.
+- No `project/run`, generic shell, network, Git mutation, multi-agent binding,
+  JS2, or controller self-modification was added.
+- SCI is a Jolt runtime dependency; plain-JVM and non-Linux/platform lanes are
+  unexecuted.
+- The controlled recovery harness is not a live-model resume loop.
+- No performance or latency claim is made.
+- Conversational turns remain separate from authoritative evaluator history;
+  `:js1-binding-created` journal records provide resume reconstruction identity,
+  but individual turns do not carry evaluator metadata.

--- a/docs/JS1_FINDINGS.md
+++ b/docs/JS1_FINDINGS.md
@@ -1,0 +1,97 @@
+# JS1 Cutover — REVISE
+
+## Decision
+
+**REVISE.** The JS1 cutover is not approved to merge. Several required PASS
+criteria remain unmet, and nothing should be read into the passing gates as
+approval. This record leads with the decision, then states exactly which gates
+executed and which PASS criteria are unmet, and preserves the standing
+non-claims verbatim.
+
+## Baseline
+
+- Samizdat `main` @ `b93d601`. All JS1 work is **uncommitted** (working tree only).
+- Jolt upstream JS0: `04dd42db` on branch `js0-functional-sci-upstream`.
+  - Frozen tag: `js0-functional-sci-upstream-freeze`.
+  - Upstream baseline: `c4547b5e`.
+  - SCI: `32d62a51`.
+- Upstream action: **none** — no Samizdat PR opened, no push made.
+
+## Executed Gates (verified)
+
+| Gate | Result |
+|---|---|
+| Full Samizdat Jolt suite | `946` tests / `2998` assertions |
+| Direct sandbox (offline `-Scp` invocation) | `14` / `111` |
+| Eval store (`samizdat.store.evals`) | `13` / `58` |
+| Wiring require | guarded `samizdat.agent.sandbox` require verified; non-JS1 path incurs no dependency cost |
+| Model tool surface | closed set `#{eval doc complete done}` (verified) |
+| Host capability authority | `tools/base.clj` `phase-refusal` — single pre-dispatch enforcement point; profile flag set only from trusted config/workflow, never model input |
+| Replay | journal `:js1-binding-created` carries `profile`, `binding-id`, `instance-id`, `spec-coordinate`, `preset`; `store/evals` durable ordered receipts `{op args result|error}` |
+| Evaluator binding seam | `samizdat.agent.sandbox` `EvaluatorSpec` / `Instance` / `Binding` (three coordinates); `:js1/binding` in ctx checked first by `eval`/`doc`/`complete` → `sandbox/evaluate!` |
+| Upstream PR / push | **none** (no PR, no push) |
+
+## Unmet PASS Criteria (exact)
+
+- **No real model dogfood task** — no real model has exercised the JS1 tool
+  surface end-to-end.
+- **No actual process terminate / restart / resume evidence** — durable restart
+  is **not** demonstrated.
+- **No frozen bbagent A3c comparison** — the frozen `bbagent` A3c baseline was
+  not produced or compared.
+- **No live controller budget proof** — no demonstration of a live controller
+  budget under JS1.
+- **No cross-platform run** — no non-Jolt / plain-JVM (or any other) platform
+  lane was executed.
+
+## Durable-restart status
+
+**Not claimed completed.** Only the fail-closed resume *policy* is implemented;
+no actual terminate → restart → resume cycle has been executed end-to-end.
+
+## Files (uncommitted inventory, `main` @ `b93d601`)
+
+Modified:
+- `resources/prompts/system.md`
+- `src/samizdat/agent/beam.clj`
+- `src/samizdat/agent/files.clj`
+- `src/samizdat/agent/resume.clj`
+- `src/samizdat/agent/tools.clj`
+- `src/samizdat/agent/tools/base.clj`
+- `src/samizdat/agent/tools/repl.clj`
+- `src/samizdat/store/migrations.clj`
+- `src/samizdat/workflow.clj`
+- `test/samizdat/test_runner.clj`
+
+New (untracked):
+- `src/samizdat/agent/sandbox.clj`
+- `src/samizdat/store/evals.clj`
+- `test/samizdat/evals_test.clj`
+- `test/samizdat/sandbox_test.clj`
+- `docs/JS1_FINDINGS.md`
+- `artifacts/js1-evidence.edn`
+
+## Non-Claims
+
+### What IS claimed
+- The JS1 phase-refusal gate rejects tools not in the closed vocabulary before dispatch.
+- When `:js1/binding` is present in ctx, `eval`/`doc`/`complete` route to the sandbox binding and never touch `samizdat.repl`.
+- When `:js1/binding` is absent, the tools behave exactly as before (bit-for-bit unchanged path).
+- Resume of a JS1-profiled run fails closed when SCI is unavailable.
+- The JS1 profile flag is set only from trusted config/workflow code, never from model input.
+- The nREPL, developer REPL, and all non-JS1 workflows are unaffected.
+
+### What is NOT claimed
+- **Evaluator spec/instance/binding IDs in durable eval calls**: The existing `runs/start-run!` API in `store/runs.clj` does not expose sandbox binding identity. The journal's `:js1-binding-created` event carries the binding/spec/instance IDs for resume, but these are NOT incorporated into the eval turn rows themselves (the turns table schema was not editable). This is documented as an **integration blocker**.
+- **SCI availability on plain JVM**: The sandbox requires `jolt.sandbox` and SCI, which are jolt-only. New-run fallback is logged; resume is fail-closed. This is a platform constraint, not a code defect.
+- **JS1 doc/complete fidelity**: SCI `ns-publics` and `resolve`/`meta` provide a subset of the live REPL's introspection. Core var metadata may be stripped by jolt. The model gets correct answers for project vars and clojure.core; metadata-dependent features (arglists from core) may be degraded.
+- **Beam multi-branch JS1 isolation**: All branches share the `:main` instance. A controller needing per-branch isolation must pass a distinct `:instance/key`. The current implementation does not do this automatically.
+- **Performance**: No measurement of JS1 eval latency vs. live REPL has been made.
+
+## Integration Blocker
+
+The `runs/start-run!` function and the turns table schema do not carry sandbox binding metadata (evaluator spec, instance ID, binding ID). The journal's `:js1-binding-created` event records these for resume reconstruction, but the individual eval turn rows in the `turns` table have no column for them. Adding this would require either:
+1. A schema migration (editing `stores/migrations/evals` — excluded by the file fence), or
+2. A separate join table mapping turn IDs to binding metadata.
+
+Neither is attempted. The journal event is the authority for resume.

--- a/docs/JS1_FINDINGS.md
+++ b/docs/JS1_FINDINGS.md
@@ -8,21 +8,30 @@ gates are evidence gaps, not a decision to replace it.
 
 ## Baseline
 
-- Samizdat branch: `js1-bounded-samizdat`, rebased on `d083eeb`.
-- Jolt evaluator runtime: `619ef19685460af847654e22cf6beda904d052fb` on
-  `js0-functional-sci-upstream`; the original JS0 freeze remains tagged
-  `js0-functional-sci-upstream-freeze` at `04dd42db`.
+- Samizdat branch: `js1-bounded-samizdat`, recovery base
+  `321661649e174bb748adeb6970dad6c166003343`, rebased on current upstream
+  `dae78547a66c80f31fa7a78d0f9483186a2b0af9`; deterministic closure changes
+  are pending commit.
+- Current Jolt evaluator runtime:
+  `279bca18bbf50f37b8574a4e6998dee40313cd26` on
+  `js1-runtime-current-upstream`, rebased on upstream `edda7aec`.
+- Historical evidence remains distinct: JS0 freeze
+  `js0-functional-sci-upstream-freeze` at `04dd42db`, post-JS0 runtime
+  `619ef196`, and pre-current-upstream checkpoint
+  `js1-runtime-pre-upstream-sci-merge`.
 - SCI: `32d62a5136ad3dc148588752f5bcc4cc30b14752` (`0.13.53`).
 
 ## Executed Gates
 
 | Gate | Result |
 |---|---|
-| Full Samizdat Jolt suite | `1000` tests / `3316` assertions, zero failures/errors |
+| Full Samizdat Jolt suite | `1047` tests / `3658` assertions, zero failures/errors |
 | Direct bounded SCI sandbox | `28` tests / `268` assertions, zero failures/errors |
 | Durable evaluator store | `18` tests / `78` assertions, zero failures/errors |
 | Controlled OS-process recovery harness | `1` test / `30` assertions, zero failures/errors |
 | Static local SmolVM harness | `12` tests / `156` assertions, zero failures/errors |
+| Current Jolt gates | manifest / selfhost / scievaluator / testbin all pass |
+| Trusted verifier hardening | injection / env scrub / redaction / scoped cleanup pass |
 
 ## Now Evidenced
 
@@ -36,6 +45,9 @@ gates are evidence gaps, not a decision to replace it.
   receipt consumption and zero repeated semantic world operations.
 - A controlled real OS-process boundary proves helper reconstruction, no replay
   of an observation/edit, and fail-closed runtime/spec/pending-history cases.
+- Trusted verification uses a structured scoped request with explicit scrubbed
+  environment and bounded streams; output is redacted before model rendering,
+  and unavailable or malformed verification fails closed.
 - JS1 with multi-branch execution is refused; the current policy is one
   logical persistent `:main` evaluator.
 
@@ -44,12 +56,14 @@ gates are evidence gaps, not a decision to replace it.
 - A real-model JS1 red → repair → green dogfood task.
 - Frozen bbagent A3c comparison.
 - Live controller-owned budget proof.
-- SmolVM guest boot and clean-consumer execution. The checked-in local harness
-  is static/producer evidence only until a pinned guest is built and run.
+- SmolVM guest boot and clean-consumer execution (**unexecuted**: the guest
+  pack remains `:unbuilt`). The checked-in local harness is static/producer
+  evidence only until a pinned guest is built and run.
 
 ## Standing Non-Claims
 
 - No self-hosting canary has run; **SELF-HOSTING CANARY: PASS** is not claimed.
+- Jolt's own `selfhost` gate is not the JS1 self-hosting canary.
 - No `project/run`, generic shell, network, Git mutation, multi-agent binding,
   JS2, or controller self-modification was added.
 - SCI is a Jolt runtime dependency; plain-JVM and non-Linux/platform lanes are

--- a/docs/JS1_FINDINGS.md
+++ b/docs/JS1_FINDINGS.md
@@ -9,7 +9,7 @@ gates are evidence gaps, not a decision to replace it.
 ## Baseline
 
 - Samizdat branch: `js1-bounded-samizdat` at
-  `db1226f`, whose recovery base `321661649e174bb748adeb6970dad6c166003343`
+  `8995e113`, whose recovery base `321661649e174bb748adeb6970dad6c166003343`
   was rebased on current upstream `dae78547a66c80f31fa7a78d0f9483186a2b0af9`.
 - Current Jolt evaluator runtime:
   `279bca18bbf50f37b8574a4e6998dee40313cd26` on
@@ -49,15 +49,20 @@ gates are evidence gaps, not a decision to replace it.
   and unavailable or malformed verification fails closed.
 - JS1 with multi-branch execution is refused; the current policy is one
   logical persistent `:main` evaluator.
+- A live bounded-model run completed RED → deliberate SIGKILL → fresh-process
+  resume → persistent-helper proof → repair → GREEN. See
+  [`JS1_LIVE_DOGFOOD.md`](JS1_LIVE_DOGFOOD.md).
+- The frozen bbagent A3c comparison is recorded in
+  [`JS1_A3C_COMPARISON.md`](JS1_A3C_COMPARISON.md). JS1 retains the claimed
+  bounded-programming and no-repeat replay properties, not A3c guest isolation.
 
 ## Remaining PASS Gates
 
-- A real-model JS1 red → repair → green dogfood task.
-- Frozen bbagent A3c comparison.
-- Live controller-owned budget proof.
-- SmolVM guest boot and clean-consumer execution (**unexecuted**: the guest
-  pack remains `:unbuilt`). The checked-in local harness is static/producer
-  evidence only until a pinned guest is built and run.
+- **Controller-budget authority and audit are not safe enough for PASS.** The
+  resume API currently accepts a budget extension without an authenticated
+  trusted principal; the cap update and event are not one durable atomic audit
+  record; a branch timeout stops waiting but does not prove cancellation of the
+  underlying turn. These are implementation blockers, not merely missing tests.
 
 ## Standing Non-Claims
 
@@ -67,8 +72,9 @@ gates are evidence gaps, not a decision to replace it.
   JS2, or controller self-modification was added.
 - SCI is a Jolt runtime dependency; plain-JVM and non-Linux/platform lanes are
   unexecuted.
-- The controlled recovery harness is not a live-model resume loop.
 - No performance or latency claim is made.
+- A3c-style guest execution isolation, `project/run`, and clean-consumer
+  SmolVM execution remain unclaimed; the guest pack is `:unbuilt`.
 - Conversational turns remain separate from authoritative evaluator history;
   `:js1-binding-created` journal records provide resume reconstruction identity,
   but individual turns do not carry evaluator metadata.

--- a/docs/JS1_LIVE_DOGFOOD.md
+++ b/docs/JS1_LIVE_DOGFOOD.md
@@ -1,0 +1,36 @@
+# JS1 Live Dogfood — Passed Evidence
+
+This is live evidence, not a self-hosting canary or a JS1 PASS decision.
+
+## Coordinate
+
+- Samizdat: `8995e113` on `js1-bounded-samizdat`.
+- Jolt: `279bca18bbf50f37b8574a4e6998dee40313cd26` on
+  `js1-runtime-current-upstream`.
+- SCI: `32d62a5136ad3dc148588752f5bcc4cc30b14752` / `0.13.53`.
+- Provider/model: local OpenAI-compatible Lemonade
+  `http://localhost:13305/v1`, `Qwen3.6-27B-MTP-GGUF`.
+- Run: `709e2b2d-c0af-40e6-9d3e-0d9624217a2b`.
+
+## Result
+
+The bounded single-player model completed the scripted task through the JS1
+surface only. It reached durable RED verification at turn 10, was stopped only
+after the history was quiescent, and the producer process exited `137`. A fresh
+process resumed the same run, reconstructed the previously-defined SCI helper
+without redefinition, read the controller-produced red evidence, made the
+second anchored edit, and reached GREEN (`resume-exit 0`). The harness result
+was 5 tests / 40 assertions, zero failures/errors.
+
+The recorded semantic operations total two lists, two searches, four reads, two
+stats, and two anchored edits. The reconstruction counter remained unchanged:
+replay invoked zero project operations. The resumed phase added only the red
+evidence read, source stat, and green edit.
+
+Artifacts are retained under:
+
+`~/.local/share/samizdat/js1-dogfood/run-1787629704126-ad047d12-b837-4330-b1ba-7e162c0034f0/artifacts`
+
+The target was a detached disposable worktree; the trusted source checkout was
+witnessed unchanged. This does not claim guest isolation, generic execution,
+or a self-hosting canary.

--- a/docs/JS1_RUNTIME.md
+++ b/docs/JS1_RUNTIME.md
@@ -29,17 +29,61 @@ pin records.
 
 | Component | Coordinate |
 |---|---|
-| Samizdat | this repo — current source is `main` @ `818e9ff18428a875006e9ae6e29123fa35fc3f9f` plus the uncommitted JS1 working tree (`bin/js1 check` reports the actual checkout state at run time) |
-| Jolt runtime | `https://github.com/casselc/jolt` branch `js0-functional-sci-upstream` @ **`619ef19685460af847654e22cf6beda904d052fb`** ("sci: trusted inert language-surface API with versioned coordinate") |
+| Samizdat | this repo — current source is branch `js1-bounded-samizdat` @ `321661649e174bb748adeb6970dad6c166003343` plus the uncommitted JS1 working tree (`bin/js1 check` reports the actual checkout state at run time) |
+| Jolt runtime | `https://github.com/casselc/jolt` branch `js1-runtime-current-upstream` @ **`279bca18bbf50f37b8574a4e6998dee40313cd26`** ("test: wire current SCI evaluator gates"; the branch is rebased onto current upstream `edda7aec`, so the pre-rebase SHAs are superseded) |
 | SCI | `borkdude/sci` **0.13.53**, vendored as the Jolt checkout's `vendor/sci` submodule @ **`32d62a5136ad3dc148588752f5bcc4cc30b14752`** |
 | SCI deps | from the submodule's own `deps.edn` at that commit: `borkdude/edamame` 1.5.39, `org.babashka/sci.impl.types` 0.0.3, `borkdude/graal.locking` 0.0.2, and `org.clojure/tools.reader` 1.5.2 transitively via edamame's POM |
 | jolt-crypto | `jolt-lang/jolt-crypto` @ **`1ab72aa5f73be7ec41f01086953ffb43ecd3d84e`** — the digest substrate's MessageDigest shim; pinned once in samizdat's `deps.edn` and read from there by `bin/js1` |
 
-Why this Jolt commit: it is the one that adds `jolt.sandbox`'s
-`language-surface/0` and `language-coordinate/0` — the trusted, inert,
-versioned language surface the JS1 safe doc/complete path and the
-`samizdat.agent.sandbox` RuntimeCoordinate are built on. Earlier commits
-(e.g. the JS0 rederive `04dd42db`) lack that API.
+Why this Jolt commit: it is the tip of the branch that re-derives
+`jolt.sandbox` — the isolated, capability-bounded SCI evaluator — onto
+**current upstream**, now rebased onto `edda7aec`. The rebase landed the
+SCI follow-ups upstream (private `map`/`newline` compatibility vars,
+`Thread.getId`, `clojure.lang.Numbers` arithmetic statics, restored
+nested-interrupt polling, and a persistent-SCI evaluation test — PRs
+#721–#725), so the branch itself carries only: the evaluator
+re-derivation (`13e43418`, "feat: rederive JS1 evaluator on current
+upstream"), two scoped-process commits — `a5fb8a3b`, "feat: add scoped
+Linux process termination" (the JVM `ProcessBuilder`/`Process` surface
+over posix_spawn with waitpid/kill-driven exit/liveness/signalling) and
+`1f859e70`, "feat: bound scoped process output" (separately bounded
+stdout/stderr capture for the scoped run: `:out-bytes`/`:err-bytes`
+independent byte caps, a poll-bounded drain in the same loop that polls
+waitpid, and a fail-closed spawn gate so a capture pipe can never leak a
+wedged run) — and the tip `279bca18`, "test: wire current SCI evaluator
+gates", which wires the evaluator contract into opt-in make lanes
+(`js0sandbox`/`js0authority`/`scievaluator`) and adds discriminating
+`Numbers` checked-promote/unchecked-wrap/equiv rows to the sandbox suite.
+
+`jolt.sandbox` is **byte-identical** to the previous pin across this
+rebase — no sandbox or language surface changed. The scoped-process
+commits are pinned because JS1 verification consumes this bounded,
+scoped process primitive as the trusted controller process-scope
+substrate. The re-derivation preserves the trusted, inert, versioned
+language surface the JS1 safe doc/complete path and the
+`samizdat.agent.sandbox` RuntimeCoordinate are built on:
+
+- **Language coordinate** (unchanged across this lane's pins):
+  `jolt.sandbox/language-coordinate` emits the `js0-lang/v1:` scheme over
+  `jolt.sandbox/language-surface` — `language-surface-version` 1, lang
+  `js0-pure-sci`, the same 156-symbol reviewed vocabulary — so the pinned
+  coordinate is byte-identical:
+  `js0-lang/v1:[:map [[:jolt.sandbox.surface/count 156] … [:jolt.sandbox.surface/version 1]]]`.
+- **Capability/authority coordinate**: `jolt.sandbox/canonical-coordinate`
+  keeps the `js0:` scheme over `effective-authority`, with the closed
+  profile maxima `:agent/minimal`, `:agent/project-read`
+  (`:project/read :project/list :project/search :project/stat`), and
+  `:agent/project-develop` (those four plus `:project/edit`); context
+  creation still enforces requested ⊆ authorized ⊆ profile maximum with a
+  dispatch-time recheck, and `revoke!` remains the revocation
+  linearization point.
+- **Receipt protocol**: unchanged inert receipt domain (`nil`, booleans,
+  strings, exact integers, keywords, symbols, vectors, maps; `:op/id`,
+  `:op/args`, `:op/result`/`:op/error`) and fail-closed replay
+  (exhaustion, operation-mismatch, args-mismatch, unconsumed checks).
+
+Plain upstream commits (before this re-derivation) lack `jolt.sandbox`
+entirely.
 
 The SCI version is cross-checked against
 `vendor/sci/resources/SCI_VERSION` because the RuntimeCoordinate names it
@@ -71,8 +115,8 @@ Network is needed once per machine so jolt can fetch the four Maven jars
 into the shared `~/.m2` repository; everything is offline afterwards.
 
     git clone <samizdat-remote> samizdat && cd samizdat
-    git clone --branch js0-functional-sci-upstream https://github.com/casselc/jolt ../jolt
-    git -C ../jolt checkout 619ef19685460af847654e22cf6beda904d052fb
+    git clone --branch js1-runtime-current-upstream https://github.com/casselc/jolt ../jolt
+    git -C ../jolt checkout 279bca18bbf50f37b8574a4e6998dee40313cd26
     git -C ../jolt submodule update --init vendor/sci
     bin/js1 check
     bin/js1 smoke
@@ -150,14 +194,14 @@ time):
   has no coordinate to resolve; restore the dependency (it is an ordinary
   samizdat dep) — do not paper over it by hand-editing the wrapper.
 
-## Evidence (this workspace, 2026-08-23)
+## Evidence (this workspace, 2026-08-24)
 
     $ bin/js1 check
     js1 runtime stack: OK
       samizdat: /home/chuck/opencode/src/samizdat
-                git 818e9ff18428a875006e9ae6e29123fa35fc3f9f (14 tracked file(s) modified)
+                git 321661649e174bb748adeb6970dad6c166003343 (6 tracked file(s) modified)
       jolt:     /home/chuck/opencode/src/jolt
-                619ef19685460af847654e22cf6beda904d052fb (https://github.com/casselc/jolt branch js0-functional-sci-upstream)
+                279bca18bbf50f37b8574a4e6998dee40313cd26 (https://github.com/casselc/jolt branch js1-runtime-current-upstream)
       sci:      /home/chuck/opencode/src/jolt/vendor/sci
                 32d62a5136ad3dc148588752f5bcc4cc30b14752 (borkdude/sci 0.13.53)
       sci deps: borkdude/edamame 1.5.39, org.babashka/sci.impl.types 0.0.3,
@@ -181,12 +225,16 @@ time):
     Ran 28 tests. 268 assertions passed, 0 failures, 0 errors.
     SANDBOX-TEST OK
 
-The smoke's 28/268 is the same seam evidence the recorded direct
-invocation in `test/samizdat/sandbox_test.clj`'s docstring produces. The
-two root sets are equivalent — the wrapper's adds `vendor/sci/resources`
-(which the submodule's own `deps.edn` declares) and omits the
-source-less `sci.impl.types` extraction; only the composition (jolt's
-resolver, not a hand-written path list) is new.
+The smoke's 28/268 is byte-identical across every pin this lane has
+carried (pre- and post-rebase): `jolt.sandbox` is unchanged by the
+scoped-process commits and the rebase onto `edda7aec`, so the language
+surface and coordinate are preserved and no receipt, snapshot, or
+coordinate expectation moved with the pin. The smoke remains the same seam
+evidence the recorded direct invocation in `test/samizdat/sandbox_test.clj`'s
+docstring produces. The two root sets are equivalent — the wrapper's adds
+`vendor/sci/resources` (which the submodule's own `deps.edn` declares) and
+omits the source-less `sci.impl.types` extraction; only the composition
+(jolt's resolver, not a hand-written path list) is new.
 
 Failure modes exercised against synthetic checkouts: missing
 `JOLT_HOME`, absent sibling, wrong commit, submodule not checked out, and

--- a/docs/JS1_RUNTIME.md
+++ b/docs/JS1_RUNTIME.md
@@ -1,0 +1,209 @@
+# JS1 Runtime — pinned, reproducible invocation
+
+This document names the exact JS1 runtime stack and the one supported way
+to invoke it. `docs/JS1_FINDINGS.md` remains the JS1 **decision and
+evidence** record (REVISE); this file is only the runtime how-to. A green
+smoke here changes nothing there.
+
+## What JS1 needs that ordinary samizdat does not
+
+`samizdat.agent.sandbox` requires `jolt.sandbox`, which requires SCI
+(`sci.core`). The vendored SCI source and its Maven dependencies are on
+**no** samizdat source root — `deps.edn` deliberately does not declare
+them, so `jolt serve`, `jolt -M:test`, `jolt -A:dev`, the GUI, and every
+other ordinary invocation are byte-for-byte unchanged and never load SCI.
+Under `jolt -M:test` the sandbox namespace simply fails to resolve and the
+JS1 tests skip, exactly as before.
+
+The sandbox's digest substrate (`samizdat.agent.files`) computes content
+coordinates (stat digests, anchored edits) through jolt.crypto's
+MessageDigest shim, so the JS1 classpath additionally needs the source of
+`jolt-lang/jolt-crypto` — an ordinary samizdat dependency, already pinned
+in `deps.edn`, which `bin/js1` reuses rather than restates.
+
+The JS1 runtime therefore comes from a **Jolt source checkout at an exact
+commit**, plus that checkout's `vendor/sci` submodule at the commit the
+pin records.
+
+## Pins
+
+| Component | Coordinate |
+|---|---|
+| Samizdat | this repo — current source is `main` @ `818e9ff18428a875006e9ae6e29123fa35fc3f9f` plus the uncommitted JS1 working tree (`bin/js1 check` reports the actual checkout state at run time) |
+| Jolt runtime | `https://github.com/casselc/jolt` branch `js0-functional-sci-upstream` @ **`619ef19685460af847654e22cf6beda904d052fb`** ("sci: trusted inert language-surface API with versioned coordinate") |
+| SCI | `borkdude/sci` **0.13.53**, vendored as the Jolt checkout's `vendor/sci` submodule @ **`32d62a5136ad3dc148588752f5bcc4cc30b14752`** |
+| SCI deps | from the submodule's own `deps.edn` at that commit: `borkdude/edamame` 1.5.39, `org.babashka/sci.impl.types` 0.0.3, `borkdude/graal.locking` 0.0.2, and `org.clojure/tools.reader` 1.5.2 transitively via edamame's POM |
+| jolt-crypto | `jolt-lang/jolt-crypto` @ **`1ab72aa5f73be7ec41f01086953ffb43ecd3d84e`** — the digest substrate's MessageDigest shim; pinned once in samizdat's `deps.edn` and read from there by `bin/js1` |
+
+Why this Jolt commit: it is the one that adds `jolt.sandbox`'s
+`language-surface/0` and `language-coordinate/0` — the trusted, inert,
+versioned language surface the JS1 safe doc/complete path and the
+`samizdat.agent.sandbox` RuntimeCoordinate are built on. Earlier commits
+(e.g. the JS0 rederive `04dd42db`) lack that API.
+
+The SCI version is cross-checked against
+`vendor/sci/resources/SCI_VERSION` because the RuntimeCoordinate names it
+(`samizdat.agent.sandbox/sci-implementation` = `"sci-0.13.53"`): a
+vendored tree that moved without that constant moving is exactly the
+drift the check exists to catch. SCI's own dependency versions are stated
+nowhere in samizdat — they are resolved from the submodule's `deps.edn`
+at the pinned commit, so the pin is the single source of truth.
+
+## The supported invocation
+
+`bin/js1` is the only supported entry point, and the single
+repository-owned place where any SCI root is constructed:
+
+    bin/js1 check    # locate + pin-check the runtime stack, print coordinates
+    bin/js1 path     # print the resolver-composed JS1 source roots (':'-joined)
+    bin/js1 smoke    # run the JS1 seam evidence (test/samizdat/sandbox_test.clj)
+
+Locating Jolt: `$JOLT_HOME` if set, else the sibling checkout `../jolt`.
+The wrapper **fails closed** unless the checkout is exactly the pinned
+commit with a clean tracked tree and the `vendor/sci` submodule checked
+out at the pinned commit — see *Failure modes*.
+
+### Another checkout, from scratch
+
+Prerequisites: `git`, `sh`, and a threaded Chez Scheme 10.x (Jolt's own
+requirement; set `JOLT_CHEZ` to select one, as with any jolt run).
+Network is needed once per machine so jolt can fetch the four Maven jars
+into the shared `~/.m2` repository; everything is offline afterwards.
+
+    git clone <samizdat-remote> samizdat && cd samizdat
+    git clone --branch js0-functional-sci-upstream https://github.com/casselc/jolt ../jolt
+    git -C ../jolt checkout 619ef19685460af847654e22cf6beda904d052fb
+    git -C ../jolt submodule update --init vendor/sci
+    bin/js1 check
+    bin/js1 smoke
+
+No source or Maven path is ever composed by hand: `bin/js1` hands jolt a
+generated `-Sdeps` alias whose only dependencies are the pinned checkout's
+`vendor/sci` (`:local/root`) and the jolt-crypto coordinate from
+`deps.edn`, and **jolt's own resolver** composes the roots and
+fetches/extracts the jars.
+
+### How the roots are constructed (the one place)
+
+`bin/js1` generates this alias and selects it with `-A` (shown with
+`$JOLT` already resolved; the crypto SHA is read out of `deps.edn` at run
+time):
+
+    {:aliases {:js1-rt {:replace-paths ["src" "test"]
+                        :replace-deps {borkdude/sci {:local/root "$JOLT/vendor/sci"}
+                                       jolt-lang/jolt-crypto {:git/url "https://github.com/jolt-lang/jolt-crypto"
+                                                              :git/sha "<sha from deps.edn>"}}}}}
+
+- `:replace-paths` / `:replace-deps` keep every other samizdat `:deps`
+  coordinate (HTTP, store, nREPL, GUI natives) **out** of the evidence
+  run — the same deliberate minimality as the recorded direct `-Scp`
+  invocation in `test/samizdat/sandbox_test.clj`'s docstring (whose root
+  list is src, test, this same jolt-crypto checkout, `vendor/sci/src`,
+  and the four jar extractions), but with the roots composed and verified
+  by jolt instead of by hand.
+- `-Srepro` keeps a user-level `~/.clojure/deps.edn` out of the run.
+- jolt resolves SCI's `deps.edn` at the pinned submodule commit: roots
+  `vendor/sci/src` + `vendor/sci/resources`; jars fetched into
+  `~/.m2/repository` and extracted beside each artifact as
+  `<artifact>-<version>.jar.jolt/`. `org.babashka/sci.impl.types` ships a
+  `.class` and no Clojure source, so jolt correctly contributes no root
+  for it. jolt-crypto resolves through the shared gitlibs cache like any
+  samizdat run.
+- In this resolve mode jolt also loads jolt-crypto's `:jolt/native`
+  declarations (libcrypto, libssl) at startup, as production does. The
+  `-Scp` replay below loads no natives; `samizdat.agent.files` then
+  bootstraps libcrypto itself on first digest. Both shapes are green in
+  the evidence below.
+- `bin/js1 path` prints the composed roots. The answer is a complete,
+  recordable classpath — replay it offline with no dependency expansion:
+
+      cd samizdat
+      SAMIZDAT_SANDBOX_TEST_RUN=1 "$JOLT/bin/jolt" -Scp "$(bin/js1 path)" \
+        run "$PWD/test/samizdat/sandbox_test.clj"
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `JOLT_HOME` | Jolt checkout to use; default is the sibling `../jolt` |
+| `JOLT_CHEZ` | passed through to jolt's launcher to select Chez Scheme 10.x |
+| `SAMIZDAT_SANDBOX_TEST_RUN=1` | set by `bin/js1 smoke` itself; makes `sandbox_test.clj` self-run with a loud (non-skipping) require |
+
+## Failure modes (all fail closed, exit 1, remedy on stderr)
+
+- **No checkout**: `JOLT_HOME` unset and no `../jolt` — prints the clone /
+  checkout / submodule commands.
+- **`JOLT_HOME` not a directory**, or a directory without an executable
+  `bin/jolt` or without `.git` — same instructions.
+- **Wrong commit**: prints expected vs actual SHA and the provisioning
+  commands. A receipt's runtime coordinate is not meaningful under any
+  other tree.
+- **Dirty tracked tree** (jolt or `vendor/sci`): the pin no longer
+  describes the bytes jolt loads (dev source mode reads the working
+  tree), so the run is refused. Untracked build output is fine.
+- **`vendor/sci` not checked out / wrong submodule commit**: run the
+  printed `git submodule update --init vendor/sci`.
+- **`SCI_VERSION` mismatch**: the vendored tree and
+  `samizdat.agent.sandbox/sci-implementation` have drifted; bump both
+  deliberately, together.
+- **No `jolt-lang/jolt-crypto` pin in `deps.edn`**: the digest substrate
+  has no coordinate to resolve; restore the dependency (it is an ordinary
+  samizdat dep) — do not paper over it by hand-editing the wrapper.
+
+## Evidence (this workspace, 2026-08-23)
+
+    $ bin/js1 check
+    js1 runtime stack: OK
+      samizdat: /home/chuck/opencode/src/samizdat
+                git 818e9ff18428a875006e9ae6e29123fa35fc3f9f (14 tracked file(s) modified)
+      jolt:     /home/chuck/opencode/src/jolt
+                619ef19685460af847654e22cf6beda904d052fb (https://github.com/casselc/jolt branch js0-functional-sci-upstream)
+      sci:      /home/chuck/opencode/src/jolt/vendor/sci
+                32d62a5136ad3dc148588752f5bcc4cc30b14752 (borkdude/sci 0.13.53)
+      sci deps: borkdude/edamame 1.5.39, org.babashka/sci.impl.types 0.0.3,
+                borkdude/graal.locking 0.0.2 (+ org.clojure/tools.reader
+                1.5.2 transitively) — composed by jolt from the submodule's
+                own deps.edn at the pinned commit
+      crypto:   jolt-lang/jolt-crypto @ 1ab72aa5f73be7ec41f01086953ffb43ecd3d84e (digest substrate;
+                pinned by samizdat's deps.edn)
+
+    $ bin/js1 path
+    <samizdat>/src:<samizdat>/test:<jolt>/vendor/sci/resources:<jolt>/vendor/sci/src:~/.gitlibs/libs/jolt-lang/jolt-crypto/1ab72aa5f73be7ec41f01086953ffb43ecd3d84e/src:~/.m2/repository/borkdude/edamame/1.5.39/edamame-1.5.39.jar.jolt:~/.m2/repository/borkdude/graal.locking/0.0.2/graal.locking-0.0.2.jar.jolt:~/.m2/repository/org/clojure/tools.reader/1.5.2/tools.reader-1.5.2.jar.jolt
+
+    $ bin/js1 smoke        # identical from an unrelated cwd
+    Ran 28 tests. 268 assertions passed, 0 failures, 0 errors.
+    {:type :summary, :test 28, :pass 268, :fail 0, :error 0}
+    SANDBOX-TEST OK
+
+    # recorded-classpath replay (offline; no natives loaded):
+    $ SAMIZDAT_SANDBOX_TEST_RUN=1 <jolt>/bin/jolt -Scp "$(bin/js1 path)" \
+        run "$PWD/test/samizdat/sandbox_test.clj"
+    Ran 28 tests. 268 assertions passed, 0 failures, 0 errors.
+    SANDBOX-TEST OK
+
+The smoke's 28/268 is the same seam evidence the recorded direct
+invocation in `test/samizdat/sandbox_test.clj`'s docstring produces. The
+two root sets are equivalent — the wrapper's adds `vendor/sci/resources`
+(which the submodule's own `deps.edn` declares) and omits the
+source-less `sci.impl.types` extraction; only the composition (jolt's
+resolver, not a hand-written path list) is new.
+
+Failure modes exercised against synthetic checkouts: missing
+`JOLT_HOME`, absent sibling, wrong commit, submodule not checked out, and
+a dirty tracked tree each refused with the documented remedy. The
+fail-closed gates are also covered deterministically by
+`samizdat.js1-wrapper-test` in the ordinary suite (no SCI needed).
+
+## Non-claims
+
+- The smoke is **producer-side seam evidence**: the JS1
+  spec/instance/binding lifecycle, receipts, and durable-replay machinery
+  against the pinned runtime. It is not a real-model dogfood, not a
+  process terminate/restart/resume demonstration, and not a
+  cross-platform lane — the unmet PASS criteria in `docs/JS1_FINDINGS.md`
+  stand, and the REVISE decision is unchanged by anything here.
+- A green smoke asserts the sandbox seam on **this exact pin only**. It
+  implies nothing about kernel development, packaging, or any other Jolt
+  capability lane, and nothing about any other commit.
+- `bin/js1` changes no ordinary invocation: it is inert unless executed,
+  and `deps.edn` gains only a comment.

--- a/docs/JS1_RUNTIME.md
+++ b/docs/JS1_RUNTIME.md
@@ -29,7 +29,7 @@ pin records.
 
 | Component | Coordinate |
 |---|---|
-| Samizdat | this repo — current source is branch `js1-bounded-samizdat` @ `321661649e174bb748adeb6970dad6c166003343` plus the uncommitted JS1 working tree (`bin/js1 check` reports the actual checkout state at run time) |
+| Samizdat | this repo — current source is branch `js1-bounded-samizdat`; `bin/js1 check` reports the actual checkout state at run time |
 | Jolt runtime | `https://github.com/casselc/jolt` branch `js1-runtime-current-upstream` @ **`279bca18bbf50f37b8574a4e6998dee40313cd26`** ("test: wire current SCI evaluator gates"; the branch is rebased onto current upstream `edda7aec`, so the pre-rebase SHAs are superseded) |
 | SCI | `borkdude/sci` **0.13.53**, vendored as the Jolt checkout's `vendor/sci` submodule @ **`32d62a5136ad3dc148588752f5bcc4cc30b14752`** |
 | SCI deps | from the submodule's own `deps.edn` at that commit: `borkdude/edamame` 1.5.39, `org.babashka/sci.impl.types` 0.0.3, `borkdude/graal.locking` 0.0.2, and `org.clojure/tools.reader` 1.5.2 transitively via edamame's POM |
@@ -199,7 +199,7 @@ time):
     $ bin/js1 check
     js1 runtime stack: OK
       samizdat: /home/chuck/opencode/src/samizdat
-                git 321661649e174bb748adeb6970dad6c166003343 (6 tracked file(s) modified)
+                git <captured checkout revision> (the command reports the actual checkout state)
       jolt:     /home/chuck/opencode/src/jolt
                 279bca18bbf50f37b8574a4e6998dee40313cd26 (https://github.com/casselc/jolt branch js1-runtime-current-upstream)
       sci:      /home/chuck/opencode/src/jolt/vendor/sci

--- a/docs/JS1_SMOLVM_CI.md
+++ b/docs/JS1_SMOLVM_CI.md
@@ -1,0 +1,128 @@
+# JS1 × SmolVM CI lane (pilot)
+
+A bounded, non-model-facing CI harness that reruns the **existing** JS1
+producer-side seam evidence inside a pinned, network-disabled SmolVM guest
+on a self-hosted Linux x86_64 KVM runner. It changes no runtime behavior:
+`bin/js1`, the evaluator, capabilities, model tools, and every ordinary
+invocation are byte-for-byte untouched, and `.github/workflows/tests.yml`
+is unmodified.
+
+**Status: provisioned-statically, unexecuted.** No guest pack exists yet
+(`runtime-lock.edn` records `:guest-pack/status :unbuilt`), so every lane
+entry point **fails closed** with the provisioning remedy. Nothing here
+fabricates a run.
+
+## What the lane asserts — and what it does not
+
+A green run is the same evidence `docs/JS1_RUNTIME.md` records —
+`bin/js1 check` coordinates, `bin/js1 smoke` (28 tests / 268 assertions at
+the pin), and the `SAMIZDAT_JS1_BOUNDARY_TEST=1` durable-restart suite —
+plus one new fact: **that evidence was produced inside a digest-verified,
+network-disabled guest that saw the checkout read-only**. It remains
+producer-side seam evidence. It is not a real-model dogfood, not a
+cross-platform lane, and not evidence about kernel development, packaging,
+or any other Jolt capability. The REVISE decision in
+`docs/JS1_FINDINGS.md` is unchanged by anything this lane does.
+
+## Architecture
+
+```
+preflight.sh ──► producer-gate.sh ──► consumer-run.sh
+ (host gates)     (pin/inventory)      (one SmolVM machine:
+                                        create ► start ► status-contract
+                                        ► prepare ► check ► smoke
+                                        ► boundary ► teardown, always)
+```
+
+- **preflight.sh** — Linux + x86_64 + accessible `/dev/kvm`; required
+  tools; the pinned launcher present; the CI dir explicit, absolute, and
+  never under host `/tmp`; stale `js1ci-*` machines swept (deleted and
+  reported).
+- **producer-gate.sh** — the lock restates `bin/js1`'s pins and
+  `deps.edn`'s jolt-crypto pin *exactly* (drift = refusal); the smolvm
+  launcher reports exactly `smolvm 1.7.5` **and** the real `smolvm-bin`
+  bytes hash to the locked SHA-256 (a version string is never trusted
+  alone); the guest pack exists and hashes to the locked digest; the
+  repo-side inventory is complete.
+- **consumer-run.sh** — creates one machine from the pack with the
+  checkout mounted **read-only** and **no network**; verifies the status
+  contract (`running`, `network:false`, `ports:0`, exactly 1 mount);
+  copies the source to **VM-local** scratch and proves the guest sees
+  exactly this checkout (sorted per-file SHA-256 manifest compared
+  host↔guest); runs `check`, `smoke`, and the boundary suite through the
+  recorded `-Scp "$(bin/js1 path)"` replay with the fixture runner
+  `test/fixtures/js1/boundary_runner.clj`; then **stops and force-deletes
+  the machine under a trap** — teardown is not optional.
+- **build-guest-pack.sh** — the producer build lane (network + KVM,
+  manual). Fetches the pinned base rootfs (pin-on-first-build), stages the
+  digest-pinned Chez 10.4.1 payload, bakes the exact jolt/sci checkout
+  with `.git` intact, warms caches with the pinned jolt's own resolver,
+  packs with `smolvm pack create --from-vm`, and prints the digest a human
+  pins into the lock. It never edits the lock itself.
+
+## Trust anchors
+
+| Anchors | What is verified | Where pinned |
+|---|---|---|
+| jolt / sci / sci version | commit equality, clean tracked tree, `SCI_VERSION` — re-verified *in the guest* by `bin/js1 check` | `bin/js1`, restated in `runtime-lock.edn` |
+| jolt-crypto | `:git/sha` read from `deps.edn` at run time | `deps.edn`, restated in the lock |
+| smolvm executor | `smolvm --version` == 1.7.5 **and** SHA-256 of the real `smolvm-bin` | `runtime-lock.edn` |
+| guest pack | SHA-256 of the pack file before any boot | `runtime-lock.edn` (`nil` while `:unbuilt`) |
+| guest inputs | per-jar SHA-256s, Chez payload digest, base tarball digest | `guest-recipe.edn` + `pack-manifest.edn` (build side) |
+| source identity | sorted per-file SHA-256 manifest, host vs guest copy | computed per run, compared |
+
+A descriptor fetched from beside an archive is never an independent trust
+anchor: the build records what it actually fetched into
+`pack-manifest.edn`, and the consumer anchor is the pack's own digest.
+
+## Bounds
+
+| Bound | Value (lock) |
+|---|---|
+| machine | 2 vCPU / 4096 MiB, name prefix `js1ci-` |
+| per-step deadlines | setup 420s, check 180s, smoke 900s, boundary 1500s, teardown 240s |
+| total deadline | 2400s (workflow `timeout-minutes: 45` is the outer backstop) |
+| logs | per-step capture truncated to 8 MiB head+tail with an elision banner |
+| exec timeout | guest `--timeout <n>s`; host `timeout` wrapper +45s; exit 124 + `command timed out after <N>ms` is a host wait, teardown stop+delete is the kill backstop |
+
+## Host /tmp discipline
+
+The harness creates **no** host `/tmp` paths. Every explicit work product
+lives under `$JS1_SMOLVM_CI_DIR/<run-id>` (the workflow sets it to
+`${{ runner.temp }}/js1-smolvm`); harness children inherit a `TMPDIR`
+under the run dir. The unavoidable exceptions are OS/tooling state, not
+harness work dirs: smolvm's own machine store under its state dir, git's
+internal plumbing during `rev-parse`/`status`, and `/dev/kvm` itself. The
+guest's `/tmp` (used by the boundary suite's phase dirs) is VM-local
+scratch, destroyed with the machine.
+
+## Failure modes (all fail closed, remedy on stderr)
+
+- **No pack / `:unbuilt`** — build it: `ci/js1-smolvm/build-guest-pack.sh`,
+  then pin the printed SHA-256 and set `:guest-pack/status :built`. The
+  workflow stays red until a runner does this; that is the intended
+  signal, not a broken pipeline.
+- **KVM missing/inaccessible** — `usermod -aG kvm <runner-user>` (or the
+  udev rule), re-dispatch.
+- **Launcher version or digest mismatch** — re-provision smolvm 1.7.5;
+  investigate any digest change as a supply-chain event.
+- **Pin drift between lock / `bin/js1` / `deps.edn`** — fix the lock; the
+  wrapper and `deps.edn` are the authorities, never edited from CI.
+- **Guest manifest mismatch** — the guest does not see this checkout;
+  evidence refused.
+- **Status contract violation** (network on, ports, extra mounts) — the
+  guest is refused before any test runs.
+- **Stale `js1ci-*` machines** — swept at preflight; teardown re-verified
+  after every run.
+
+## Dispatch
+
+Actions → `js1-smolvm` → Run workflow. Manual only; cannot gate merges.
+
+## Static validation
+
+`test/samizdat/js1_harness_test.clj` (registered in the ordinary suite)
+validates the lock/recipe/fixtures against `bin/js1`, `deps.edn`, and the
+suite sources, and pins the harness disciplines above — offline, with no
+SCI, smolvm, KVM, or guest. Fixture **definitions** live in
+`test/fixtures/js1/`; mutable results are CI artifacts only.

--- a/resources/prompts/system.md
+++ b/resources/prompts/system.md
@@ -233,3 +233,7 @@ fetch_turn({turn})
 ## Honesty
 
 A number in your answer has to come from something the run actually established or measured — that is the difference between a report and a fabricated one. A partial result is a perfectly good answer, but it has to say that is what it is: state which of the problem's questions you did not settle, and what you established instead.
+
+## Sandboxed context (JS1)
+
+When this run is operating in a sandboxed JS1 context, your available tools are reduced to `eval`, `doc`, `complete`, and `done`. File, shell, manifest, mutate, and all other tools are not available. Your `eval` runs in a sandboxed SCI environment, not in the live harness image — you can define functions, use Clojure core, and exercise code that is loaded into the sandbox, but you cannot reach the host process, the filesystem, or the network. Definitions persist across your evals within this run. Use `doc` to inspect available symbols and `complete` to discover names.

--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -39,9 +39,10 @@
             [clojure.tools.logging :as log]
             [samizdat.agent.critic :as critic]
             [samizdat.agent.gates :as gates]
-            [samizdat.agent.loop :as branch-loop]
-            [samizdat.agent.state :as state]
-            [samizdat.store.artifacts :as artifacts]
+             [samizdat.agent.loop :as branch-loop]
+             [samizdat.agent.state :as state]
+             [samizdat.agent.tools.base :as js1-base]
+             [samizdat.store.artifacts :as artifacts]
             [samizdat.store.failures :as failures]
             [samizdat.store.interventions :as interventions]
             [samizdat.store.journal :as journal]
@@ -762,6 +763,20 @@
         ;; seeds nobody reads would be dead rows.
         config (cond-> config
                  seed-run (assoc-in [:run :share-artifacts?] true))
+        ;; JS1 propagation: a caller (beam/run! wired from the control
+        ;; surface) or the run config may ask for a JS1 sandboxed run.
+        js1-binding (:js1/binding opts)
+        js1-profile (:js1/profile opts)
+        ;; JS1 is single-player: one persistent :main instance and one
+        ;; durable history per work-id.  A width-N beam would evaluate N
+        ;; branches into that one instance and interleave N durable
+        ;; histories under one binding id — not a boundary that can be
+        ;; enforced mid-run.  Refused HERE: before the run row is opened,
+        ;; before on-start fires, before any branch or provider call.
+        _ (js1-base/js1-assert-single-branch!
+           (boolean (or js1-binding js1-profile
+                        (get-in config [:run :js1/profile])))
+           width)
         run-id (runs/start-run! conn {:problem problem
                                       :provider (:provider llm-config)
                                       :model (:model llm-config)
@@ -785,11 +800,6 @@
         ;; paths discard one: the tool-level catch, the turn deadline, and a
         ;; turn that throws. See tools/register-session! (vf-cfp).
         engine-sessions (atom [])
-        ;; JS1 binding: propagate from opts when the caller (beam/run!)
-        ;; or the control surface wired one.  The beam runs multiple branches
-        ;; sharing one persistent :main instance — same as workflow/run!.
-        js1-binding (:js1/binding opts)
-        js1-profile (:js1/profile opts)
         ctx {:conn conn :run-id run-id :config config :problem problem
              :llm-adapter llm-adapter :llm-config llm-config
              :max-turns max-turns :beam? (> width 1) :beam-width width
@@ -798,8 +808,11 @@
              :abort abort
              ;; JS1 profile flags — set only by trusted config/control, read
              ;; by phase-refusal to enforce the minimal tool vocabulary.
+             ;; The binding installs as a refreshable holder so a rollback
+             ;; can be absorbed between turns (tools.base/js1-binding).
              :js1/profile js1-profile
-             :js1/binding js1-binding}]
+             :js1/binding (when-let [b js1-binding] (atom b))
+             :js1/provider (:js1/provider opts)}]
     ;; Before the branches, not after. api.control/start-run! blocks until this
     ;; fires, so this line is how long POST /v1/runs takes — and open-branch!
     ;; spawns a Prolog session per branch, so putting it after made the endpoint

--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -785,12 +785,21 @@
         ;; paths discard one: the tool-level catch, the turn deadline, and a
         ;; turn that throws. See tools/register-session! (vf-cfp).
         engine-sessions (atom [])
+        ;; JS1 binding: propagate from opts when the caller (beam/run!)
+        ;; or the control surface wired one.  The beam runs multiple branches
+        ;; sharing one persistent :main instance — same as workflow/run!.
+        js1-binding (:js1/binding opts)
+        js1-profile (:js1/profile opts)
         ctx {:conn conn :run-id run-id :config config :problem problem
              :llm-adapter llm-adapter :llm-config llm-config
              :max-turns max-turns :beam? (> width 1) :beam-width width
              :sessions sessions
              :engine-sessions engine-sessions
-             :abort abort}]
+             :abort abort
+             ;; JS1 profile flags — set only by trusted config/control, read
+             ;; by phase-refusal to enforce the minimal tool vocabulary.
+             :js1/profile js1-profile
+             :js1/binding js1-binding}]
     ;; Before the branches, not after. api.control/start-run! blocks until this
     ;; fires, so this line is how long POST /v1/runs takes — and open-branch!
     ;; spawns a Prolog session per branch, so putting it after made the endpoint

--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -763,6 +763,10 @@
         ;; seeds nobody reads would be dead rows.
         config (cond-> config
                  seed-run (assoc-in [:run :share-artifacts?] true))
+        ;; The trusted project root used by file/git/verify tools.  Keep the
+        ;; same controller-owned precedence as workflow/run! and resume!;
+        ;; model data is never a source for this value.
+        root (or (get-in config [:run :root]) (System/getProperty "user.dir"))
         ;; JS1 propagation: a caller (beam/run! wired from the control
         ;; surface) or the run config may ask for a JS1 sandboxed run.
         js1-binding (:js1/binding opts)
@@ -802,6 +806,7 @@
         engine-sessions (atom [])
         ctx {:conn conn :run-id run-id :config config :problem problem
              :llm-adapter llm-adapter :llm-config llm-config
+             :root root
              :max-turns max-turns :beam? (> width 1) :beam-width width
              :sessions sessions
              :engine-sessions engine-sessions

--- a/src/samizdat/agent/files.clj
+++ b/src/samizdat/agent/files.clj
@@ -248,88 +248,335 @@
            :repaired? (= :repaired status)})
          (miss branch (str "Path " path " is outside the project root and cannot be written."))))))
 
-;; --- sandbox helpers: digest, bounded list/search ---------------------------------
+;; --- sandbox substrate: strict UTF-8, bounded reads, digests, listing, search ---
+;;
+;; The primitives the JS1 sandbox's five projected semantic operations are
+;; normalized against: the frozen bb4t A2/A3b project contract.  Everything
+;; here fails closed — bounded reads stop AT the bound instead of consuming
+;; whole files first, strict UTF-8 decoding rejects rather than replaces,
+;; digests propagate errors instead of returning nil, and no walk ever
+;; follows a symbolic link.
+
+(defn utf8-bytes
+  "The UTF-8 encoding of `s` as a byte array."
+  [^String s]
+  (.getBytes s "UTF-8"))
+
+(defn utf8-byte-count
+  "The UTF-8 byte length of `s`."
+  [^String s]
+  (alength (utf8-bytes s)))
+
+(defn valid-utf8?
+  "Strict structural UTF-8 validation of `bs`: rejects truncated sequences,
+  bad continuations, overlong forms, surrogates and code points beyond
+  U+10FFFF — the same inputs a Java CharsetDecoder with REPORT would
+  reject."
+  [^bytes bs]
+  (let [n (alength bs)
+        continuation? (fn [b] (<= 0x80 b 0xbf))]
+    (loop [i 0]
+      (if (>= i n)
+        true
+        (let [b (bit-and (aget bs i) 0xff)]
+          (cond
+            (< b 0x80) (recur (inc i))
+
+            (<= 0xc2 b 0xdf)
+            (and (< (inc i) n)
+                 (continuation? (bit-and (aget bs (inc i)) 0xff))
+                 (recur (+ i 2)))
+
+            ;; Three-byte forms: e0 and ed constrain the second byte
+            ;; (overlong forms, surrogates); the tail is plain continuation.
+            (= b 0xe0)
+            (and (< (+ i 2) n)
+                 (<= 0xa0 (bit-and (aget bs (inc i)) 0xff) 0xbf)
+                 (continuation? (bit-and (aget bs (+ i 2)) 0xff))
+                 (recur (+ i 3)))
+
+            (or (<= 0xe1 b 0xec) (<= 0xee b 0xef))
+            (and (< (+ i 2) n)
+                 (continuation? (bit-and (aget bs (inc i)) 0xff))
+                 (continuation? (bit-and (aget bs (+ i 2)) 0xff))
+                 (recur (+ i 3)))
+
+            (= b 0xed)
+            (and (< (+ i 2) n)
+                 (<= 0x80 (bit-and (aget bs (inc i)) 0xff) 0x9f)
+                 (continuation? (bit-and (aget bs (+ i 2)) 0xff))
+                 (recur (+ i 3)))
+
+            ;; Four-byte forms: f0 and f4 constrain the second byte
+            ;; (overlong forms, beyond U+10FFFF).
+            (= b 0xf0)
+            (and (< (+ i 3) n)
+                 (<= 0x90 (bit-and (aget bs (inc i)) 0xff) 0xbf)
+                 (continuation? (bit-and (aget bs (+ i 2)) 0xff))
+                 (continuation? (bit-and (aget bs (+ i 3)) 0xff))
+                 (recur (+ i 4)))
+
+            (<= 0xf1 b 0xf3)
+            (and (< (+ i 3) n)
+                 (continuation? (bit-and (aget bs (inc i)) 0xff))
+                 (continuation? (bit-and (aget bs (+ i 2)) 0xff))
+                 (continuation? (bit-and (aget bs (+ i 3)) 0xff))
+                 (recur (+ i 4)))
+
+            (= b 0xf4)
+            (and (< (+ i 3) n)
+                 (<= 0x80 (bit-and (aget bs (inc i)) 0xff) 0x8f)
+                 (continuation? (bit-and (aget bs (+ i 2)) 0xff))
+                 (continuation? (bit-and (aget bs (+ i 3)) 0xff))
+                 (recur (+ i 4)))
+
+            ;; 0xc0, 0xc1 (overlong two-byte), 0xf5..0xff: never valid.
+            :else false))))))
+
+(defn decode-utf8
+  "Strict UTF-8 decode of `bs`.  Malformed input fails
+   {:samizdat.files/error :invalid-utf8} — never silently replaced — so a
+   binary file is an error (read) or a skip (search), not mojibake."
+  [^bytes bs]
+  (when-not (valid-utf8? bs)
+    (throw (ex-info "Content is not valid UTF-8"
+                    {:samizdat.files/error :invalid-utf8})))
+  (String. bs "UTF-8"))
+
+(defn decode-utf8-or-nil
+  "Strict decode, or nil for anything that is not valid UTF-8 — how a binary
+   file is recognized during search without guessing from its name."
+  [^bytes bs]
+  (try (decode-utf8 bs) (catch Exception _ nil)))
+
+(defn read-bounded-bytes
+  "Read at most `max-bytes` bytes from `path`.  Consumption stops at the
+   bound: content larger than the limit fails
+   {:samizdat.files/error :too-large :limit max-bytes} instead of being read
+   whole and truncated afterwards.  Any read failure propagates."
+  [path max-bytes]
+  (let [input (java.io.FileInputStream. (str path))]
+    (try
+      (let [output (java.io.ByteArrayOutputStream.)
+            buffer (byte-array 8192)]
+        (loop [total 0]
+          (let [remaining (- (inc max-bytes) total)
+                read (.read input buffer 0 (min (alength buffer) remaining))]
+            (cond
+              (neg? read) (.toByteArray output)
+
+              (> (+ total read) max-bytes)
+              (throw (ex-info "File content exceeds the byte limit"
+                              {:samizdat.files/error :too-large
+                               :limit max-bytes}))
+
+              :else
+              (do (.write output buffer 0 read)
+                  (recur (+ total read)))))))
+      (finally
+        (try (.close input) (catch Throwable _ nil))))))
+
+;; --- digest ------------------------------------------------------------------
+
+(def ^:private libcrypto-candidates
+  "The shared libraries jolt-crypto's foreign functions resolve against
+   (mirroring its :jolt/native declaration), tried in order."
+  ["libcrypto.so.3" "libcrypto.so.1.1" "libcrypto.so"
+   "/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib"
+   "/usr/lib/libcrypto.dylib" "libcrypto.dylib"])
+
+(defn- hex-encode
+  "Lowercase hex of `bs`, two digits per byte."
+  [^bytes bs]
+  (apply str (map #(format "%02x" %) bs)))
+
+(defn- compute-digest
+  "One digest attempt: getInstance (whose miss auto-loads jolt.crypto's
+   host-class shim when that namespace is on the roots) then the one-shot
+   digest over `bs`."
+  [^bytes bs]
+  (hex-encode (.digest (java.security.MessageDigest/getInstance "SHA-256") bs)))
+
+(defn bytes-digest
+  "SHA-256 hex digest (64 lowercase hex chars) of `bs`.  Fail-closed, with a
+   one-time bootstrap for processes that did not get jolt-crypto's natives
+   through dependency resolution (an -Scp run loads none): the first failure
+   opens libcrypto, loads jolt.crypto — installing the MessageDigest shim
+   and binding its foreign functions to the opened handle — and retries
+   once.  Any remaining failure propagates: a digest is a content
+   coordinate, and an uncomputable coordinate must not become a fake one."
+  [^bytes bs]
+  (try
+    (compute-digest bs)
+    (catch Throwable failure
+      (try
+        (doseq [lib libcrypto-candidates]
+          (try (jolt.ffi/load-native lib) (catch Throwable _ nil)))
+        (require 'jolt.crypto)
+        (compute-digest bs)
+        (catch Throwable _
+          (throw failure))))))
 
 (defn file-digest
-  "SHA-256 hex digest of file at `path`.  Returns a 64-character lowercase
-   hex string, or nil if the file cannot be read.  The hex string is the receipt-
-   domain representation of a content identity — a deterministic fingerprint
-   suitable for anchored-edit base-digest comparison."
+  "SHA-256 hex digest of a file's bytes, reading at most `max-bytes` through
+   the bounded reader.  Fail-closed: over the bound, unreadable, or without
+   digest machinery it THROWS — never nil — so stat/edit cannot hand out a
+   coordinate that was never computed."
+  [path max-bytes]
+  (bytes-digest (read-bounded-bytes path max-bytes)))
+
+;; --- one-level listing -------------------------------------------------------
+
+(defn nofollow-size
+  "The lstat byte size of `path` (a symbolic link reports the link, not its
+   target).  Throws when the attributes cannot be read."
   [path]
-  (try
-    (when (and path (fs/exists? path))
-      (let [^java.security.MessageDigest d
-            (doto (java.security.MessageDigest/getInstance "SHA-256")
-              (.update (fs/read-all-bytes path)))]
-        (format "%064x" (java.math.BigInteger/1 (.digest d)))))
-    (catch Exception _ nil)))
+  (fs/get-attribute path "basic:size" {:nofollow-links true}))
 
-(defn safe-list-dir
-  "List entries under `root` at relative `rel-path`, bounded to `max-entries`.
-   Returns a sorted vector of relative path strings (from root).  Only
-   descend into directories; symlinks are not followed so a symlink that
-   would escape root never causes the walk to leave it.  Returns an empty
-   vector for non-directory or missing paths."
-  ([root rel-path] (safe-list-dir root rel-path 1000))
-  ([root rel-path max-entries]
-   (let [root* (str (fs/canonicalize root))]
-     (if-let [abs (resolve-under-root root* (or rel-path "."))]
-       (if (fs/directory? abs {:nofollow-links true})
-         (let [entries (atom [])
-               limit (atom max-entries)]
-           (fs/walk-file-tree
-             abs
-             {:follow-links false
-              :pre-visit-dir (fn [_ _]
-                               (if (pos? @limit) :continue :terminate))
-              :visit-file (fn [f _]
-                           (if (pos? @limit)
-                             (do (swap! entries conj
-                                    (str (fs/relativize root* (str f))))
-                                 (swap! limit dec)
-                                 :continue)
-                             :terminate))})
-           (sort @entries))
-         [])
-        []))))
+(defn entry-kind
+  "The NOFOLLOW kind of `path`: :symlink, :directory, :file or :other.  A
+   link is reported as a link and never followed, inside or outside any
+   root.  Existence is the caller's question — this mirrors bb4t's
+   entry-kind, which is only asked about entries known to exist."
+  [path]
+  (cond
+    (fs/sym-link? path) :symlink
+    (fs/directory? path {:nofollow-links true}) :directory
+    (fs/regular-file? path {:nofollow-links true}) :file
+    :else :other))
 
-(defn safe-search-files
-  "Search for `pattern` (a regex string) in files under `root` at relative
-   `rel-path`, bounded by `max-results` and `max-chars`.  Returns a vector of
-   `[rel-path line-number line-text]` tuples.  Symlinks are not followed.
-   Returns an empty vector for non-directory or missing paths."
-  ([root rel-path pattern] (safe-search-files root rel-path pattern 500 500000))
-  ([root rel-path pattern max-results max-chars]
-   (let [root* (str (fs/canonicalize root))
-         re (re-pattern pattern)]
-     (if-let [abs (resolve-under-root root* (or rel-path "."))]
-       (if (fs/directory? abs {:nofollow-links true})
-         (let [results (atom [])
-               chars-scanned (atom 0)]
-           (fs/walk-file-tree
-             abs
-             {:follow-links false
-              :pre-visit-dir (fn [_ _]
-                              (if (and (< (count @results) max-results)
-                                       (< @chars-scanned max-chars))
-                                :continue
-                                :terminate))
-              :visit-file
-              (fn [f _]
-                (if (and (< (count @results) max-results)
-                         (< @chars-scanned max-chars))
-                  (try
-                    (let [content (slurp (str f))
-                          _ (swap! chars-scanned + (count content))
-                          rel (str (fs/relativize root* (str f)))]
-                      (doseq [[i line] (map-indexed vector
-                                                   (str/split content #"\n" -1))
-                              :while (< (count @results) max-results)
-                              :when (re-find re line)]
-                        (swap! results conj [rel (inc i) line]))
-                      :continue)
-                    (catch Exception _ :continue))
-                  :terminate))})
-            (vec @results))
-         [])
-        []))))
+(defn list-one-level
+  "The IMMEDIATE entries of the directory at `abs-dir` — exactly one level,
+   never recursing — as inert structured maps sorted by name:
+   {:name :kind} with :bytes added for regular files, :kind one of :file,
+   :directory, :symlink, :other.  Attributes are read NOFOLLOW so a symbolic
+   link is a link, not whatever it names.  More than `max-entries` entries
+   fails {:samizdat.files/error :too-many-entries} rather than truncating:
+   a bounded listing is a bound, not a sample."
+  [abs-dir max-entries]
+  (let [entries (mapv (fn [p]
+                        (let [kind (entry-kind p)]
+                          (cond-> {:name (str (fs/file-name p)) :kind kind}
+                            (= :file kind) (assoc :bytes (nofollow-size p)))))
+                      (fs/list-dir abs-dir))]
+    (when (> (count entries) max-entries)
+      (throw (ex-info "Project directory exceeds the entry limit"
+                      {:samizdat.files/error :too-many-entries
+                       :limit max-entries})))
+    (vec (sort-by :name entries))))
+
+;; --- atomic anchored write ---------------------------------------------------
+
+(defn atomic-write-file!
+  "Write `content-bytes` at `abs-path` through a sibling temporary and an
+   atomic rename, so a reader never observes a partially written file and a
+   failed write leaves any original intact.  `replace-existing?` selects
+   rename-onto-target (an anchored update) against fail-if-present (a
+   creation whose leaf must be the only thing absent).  The temporary is
+   removed on any failure.  Creates no directories — the parent must exist:
+   the frozen A2 edit contract never materializes a hierarchy."
+  [abs-path ^bytes content-bytes replace-existing?]
+  (let [parent (fs/parent abs-path)
+        temp (str parent "/.samizdat-edit-" (random-uuid))]
+    (try
+      (fs/create-file temp)
+      (let [out (java.io.FileOutputStream. temp)]
+        (try
+          (.write out content-bytes)
+          (finally (try (.close out) (catch Throwable _ nil)))))
+      (fs/move temp abs-path {:replace-existing replace-existing?
+                              :atomic-move true})
+      (catch Throwable failure
+        (try (fs/delete-if-exists temp) (catch Throwable _ nil))
+        (throw failure)))))
+
+;; --- bounded search ----------------------------------------------------------
+
+(def ^:const search-match-budget
+  "Character budget one line may cost the regex engine before the whole
+   search fails — the superlinear-backtracking bound bb4t enforces with a
+   counting CharSequence.  Implemented here as a line-length gate: a line
+   longer than the budget necessarily costs at least its length in matcher
+   reads on a full scan, so refusing it up front holds the same bound."
+  200000)
+
+(defn search-tree
+  "Bounded regex search under the directory at `abs-dir`, with match paths
+   prefixed by `prefix`.  Returns a vector of {:path :line :text} maps
+   ordered by path (depth-first walk, entries sorted at every level).
+   Bounds, exactly the frozen A2 semantics:
+
+     :max-results    collection STOPS when reached;
+     :max-file-bytes a file larger than this is SKIPPED — its size is
+                     checked BEFORE any byte is consumed, so a huge file is
+                     never slurped and discarded;
+     :max-files      more regular files than this FAILS the search;
+     :include-hidden? dot-entries are skipped unless true;
+     :max-chars      total decoded characters the scan may consume (a JS1
+                     narrowing beyond the frozen contract; only ever stops
+                     the walk earlier).
+
+   Symbolic links are never followed; files that are not valid UTF-8 are
+   skipped; matched line text is trimmed and capped at :max-line-chars.
+   `re` must already be compiled."
+  [abs-dir prefix re {:keys [max-results max-file-bytes max-files
+                             include-hidden? max-chars max-line-chars]}]
+  (let [state (atom {:results [] :files 0 :chars 0})
+        budget-file!
+        (fn [file]
+          "Consume `file`'s size against the total budget BEFORE reading;
+           nil means the budget is exhausted for this file (skip)."
+          (let [size (nofollow-size file)]
+            (when (<= (+ (:chars @state) size) max-chars)
+              (swap! state update :chars + size)
+              size)))
+        search-file!
+        (fn [file rel]
+          (when-let [size (budget-file! file)]
+            (when (<= size max-file-bytes)
+              (when-let [content (decode-utf8-or-nil
+                                   (read-bounded-bytes file max-file-bytes))]
+                (loop [lines (str/split content #"\n" -1)
+                       number 1]
+                  (when (and (seq lines)
+                             (< (count (:results @state)) max-results))
+                    (let [line (first lines)]
+                      (when (> (count line) search-match-budget)
+                        (throw (ex-info
+                                "Project search pattern exceeded its matching budget"
+                                {:samizdat.files/error :match-budget
+                                 :budget search-match-budget})))
+                      (when (re-find re line)
+                        (swap! state update :results conj
+                               {:path rel
+                                :line number
+                                :text (let [trimmed (str/trim line)]
+                                        (if (> (count trimmed) max-line-chars)
+                                          (str (subs trimmed 0 max-line-chars) "...")
+                                          trimmed))}))
+                      (recur (rest lines) (inc number)))))))))
+        search-directory!
+        (fn search-directory! [dir prefix']
+          (doseq [entry (sort-by (fn [p] (str (fs/file-name p)))
+                                 (fs/list-dir dir))
+                  :while (< (count (:results @state)) max-results)]
+            (let [name (str (fs/file-name entry))
+                  rel (if (str/blank? prefix')
+                        name (str prefix' "/" name))]
+              (when (or include-hidden? (not (str/starts-with? name ".")))
+                (case (entry-kind entry)
+                  ;; Never followed, exactly as in listing, so a search
+                  ;; cannot be steered out of the authorized root.
+                  :symlink nil
+                  :directory (search-directory! entry rel)
+                  :file (do
+                          (when (>= (:files @state) max-files)
+                            (throw (ex-info
+                                    "Project search exceeded its file limit"
+                                    {:samizdat.files/error :too-many-files
+                                     :limit max-files})))
+                          (swap! state update :files inc)
+                          (search-file! entry rel))
+                  nil)))))]
+    (search-directory! abs-dir prefix)
+    (vec (:results @state))))

--- a/src/samizdat/agent/files.clj
+++ b/src/samizdat/agent/files.clj
@@ -40,13 +40,18 @@
 
 (defn- resolve-under-root
   "Canonicalize `path` under `root`; return the resolved absolute path string,
-  or nil when it escapes the root. The canonical root is the boundary — a
-  `..` or an absolute path that lands outside it fails closed."
+   or nil when it escapes the root, is blank, or is invalid. Uses
+   canonicalization to detect symlink escapes: any symlink chain that
+   lands outside root is caught because the canonical target falls
+   outside the boundary. Fails closed on any I/O error."
   [root path]
-  (let [root* (str (fs/canonicalize root))
-        target (str (fs/canonicalize (fs/path root path)))]
-    (when (or (= target root*) (str/starts-with? target (str root* "/")))
-      target)))
+  (when (and (string? path) (not (str/blank? path)))
+    (try
+      (let [root* (str (fs/canonicalize root))
+            target (str (fs/canonicalize (fs/path root path)))]
+        (when (or (= target root*) (str/starts-with? target (str root* "/")))
+          target))
+      (catch Exception _ nil))))
 
 (defn- miss [branch msg]
   {:result msg :category :mechanics :progress? false :branch branch})
@@ -241,4 +246,90 @@
                                " balance: " note " It will not load until you fix it.")))
            :category :success :progress? true :branch branch
            :repaired? (= :repaired status)})
-        (miss branch (str "Path " path " is outside the project root and cannot be written."))))))
+         (miss branch (str "Path " path " is outside the project root and cannot be written."))))))
+
+;; --- sandbox helpers: digest, bounded list/search ---------------------------------
+
+(defn file-digest
+  "SHA-256 hex digest of file at `path`.  Returns a 64-character lowercase
+   hex string, or nil if the file cannot be read.  The hex string is the receipt-
+   domain representation of a content identity — a deterministic fingerprint
+   suitable for anchored-edit base-digest comparison."
+  [path]
+  (try
+    (when (and path (fs/exists? path))
+      (let [^java.security.MessageDigest d
+            (doto (java.security.MessageDigest/getInstance "SHA-256")
+              (.update (fs/read-all-bytes path)))]
+        (format "%064x" (java.math.BigInteger/1 (.digest d)))))
+    (catch Exception _ nil)))
+
+(defn safe-list-dir
+  "List entries under `root` at relative `rel-path`, bounded to `max-entries`.
+   Returns a sorted vector of relative path strings (from root).  Only
+   descend into directories; symlinks are not followed so a symlink that
+   would escape root never causes the walk to leave it.  Returns an empty
+   vector for non-directory or missing paths."
+  ([root rel-path] (safe-list-dir root rel-path 1000))
+  ([root rel-path max-entries]
+   (let [root* (str (fs/canonicalize root))]
+     (if-let [abs (resolve-under-root root* (or rel-path "."))]
+       (if (fs/directory? abs {:nofollow-links true})
+         (let [entries (atom [])
+               limit (atom max-entries)]
+           (fs/walk-file-tree
+             abs
+             {:follow-links false
+              :pre-visit-dir (fn [_ _]
+                               (if (pos? @limit) :continue :terminate))
+              :visit-file (fn [f _]
+                           (if (pos? @limit)
+                             (do (swap! entries conj
+                                    (str (fs/relativize root* (str f))))
+                                 (swap! limit dec)
+                                 :continue)
+                             :terminate))})
+           (sort @entries))
+         [])
+        []))))
+
+(defn safe-search-files
+  "Search for `pattern` (a regex string) in files under `root` at relative
+   `rel-path`, bounded by `max-results` and `max-chars`.  Returns a vector of
+   `[rel-path line-number line-text]` tuples.  Symlinks are not followed.
+   Returns an empty vector for non-directory or missing paths."
+  ([root rel-path pattern] (safe-search-files root rel-path pattern 500 500000))
+  ([root rel-path pattern max-results max-chars]
+   (let [root* (str (fs/canonicalize root))
+         re (re-pattern pattern)]
+     (if-let [abs (resolve-under-root root* (or rel-path "."))]
+       (if (fs/directory? abs {:nofollow-links true})
+         (let [results (atom [])
+               chars-scanned (atom 0)]
+           (fs/walk-file-tree
+             abs
+             {:follow-links false
+              :pre-visit-dir (fn [_ _]
+                              (if (and (< (count @results) max-results)
+                                       (< @chars-scanned max-chars))
+                                :continue
+                                :terminate))
+              :visit-file
+              (fn [f _]
+                (if (and (< (count @results) max-results)
+                         (< @chars-scanned max-chars))
+                  (try
+                    (let [content (slurp (str f))
+                          _ (swap! chars-scanned + (count content))
+                          rel (str (fs/relativize root* (str f)))]
+                      (doseq [[i line] (map-indexed vector
+                                                   (str/split content #"\n" -1))
+                              :while (< (count @results) max-results)
+                              :when (re-find re line)]
+                        (swap! results conj [rel (inc i) line]))
+                      :continue)
+                    (catch Exception _ :continue))
+                  :terminate))})
+            (vec @results))
+         [])
+        []))))

--- a/src/samizdat/agent/gitdiff.clj
+++ b/src/samizdat/agent/gitdiff.clj
@@ -8,16 +8,53 @@
   tree at that moment (git stash create), which does not touch the tree — so
   the diff at finalization is exactly what the RUN changed, not whatever was
   already uncommitted. Everything here fails soft: no git, no repo, or any
-  error yields an empty diff, and the critic simply reviews completeness only."
+  error yields an empty diff / nil baseline / cannot-tell, and the critic
+  simply reviews completeness only.
+
+  git runs as STRUCTURED scoped requests (samizdat.engine.proc/scope-run,
+  jolt.host's scoped process primitive): a direct argv with the repo root
+  as the request cwd — no shell, no composed directory prefix — under the
+  explicit scrubbed allowlist environment (nothing inherited from the
+  controller), a hard timeout whose expiry takes the whole git process
+  tree down (TERM wave, grace, KILL wave, /proc-confirmed empty), and
+  byte-capped capture, so even a pathological repository cannot make a
+  diff call unbounded.
+
+  Boundary contract: this namespace's fail-soft answers are 'git cannot
+  tell' answers, and cannot-tell is a TRUST decision that belongs to the
+  consumer. The ship gate therefore probes the execution boundary itself
+  (proc/scope-supported?) before trusting a cannot-tell: on a runtime
+  without the scoped primitive every git call here fails, changed-files
+  reads as cannot-tell, and done would fall through to trust — so the
+  gate blocks as UNAVAILABLE instead. Failing soft here can never fail
+  OPEN there."
   (:require [clojure.string :as str]
             [samizdat.engine.proc :as proc]))
 
 (def max-diff-chars 12000)
 
-(defn- git [root & args]
-  (let [r (apply proc/run {:timeout-ms 15000} "git" "-C" (str root) args)]
-    (when (and (not (:timeout r)) (zero? (or (:exit r) 1)))
-      (:out r))))
+(def ^:private git-timeout-ms 15000)
+(def ^:private git-term-grace-ms 2000)
+(def ^:private git-out-bytes 262144)
+(def ^:private git-err-bytes 65536)
+
+(defn- git
+  "One bounded scoped git invocation in `root` as a direct argv with the
+  scrubbed allowlist environment. Returns the captured stdout on exit 0,
+  nil on anything else — non-zero, timeout, spawn failure — preserving the
+  fail-soft contract the callers' nil-vs-empty logic depends on."
+  [root & args]
+  (try
+    (let [r (proc/scope-run {:cmd (into ["git"] (mapv str args))
+                             :dir (str root)
+                             :env (proc/scrubbed-allowlist-env)
+                             :timeout-ms git-timeout-ms
+                             :term-grace-ms git-term-grace-ms
+                             :out-bytes git-out-bytes
+                             :err-bytes git-err-bytes})]
+      (when (and (not (:timed-out r)) (zero? (or (:exit r) 1)))
+        (:out r)))
+    (catch Throwable _ nil)))
 
 (defn baseline
   "A ref the run's changes are diffed against: a commit object capturing the
@@ -38,7 +75,13 @@
   as 'changed nothing' and be judged hollow. nil when git or the repo is
   unavailable — 'cannot tell', distinct from [] which means 'genuinely nothing
   changed'. Ground truth for whether a run that claims done actually produced
-  anything."
+  anything.
+
+  These paths are attacker-named data (the model writes the files): they feed
+  verification only through samizdat.agent.verify's narrow grammar, which
+  refuses anything unrepresentable — and git's own path quoting
+  (core.quotePath) keeps exotic names visibly exotic rather than smuggling
+  them through as plain text."
   [root baseline]
   (when (and root baseline)
     (let [lines (fn [out] (some->> out str/split-lines (remove str/blank?)))

--- a/src/samizdat/agent/resume.clj
+++ b/src/samizdat/agent/resume.clj
@@ -547,6 +547,14 @@
           js1 (reconstruct-run-js1-binding! conn run-id root)
           ctx {:conn conn :run-id run-id :config config :problem (:problem run)
                :llm-adapter llm-adapter :llm-config llm-config
+               ;; The trusted controller root must survive the handoff back
+               ;; into the beam scheduler.  JS1 project operations use the
+               ;; reconstructed binding's root, but done verification reads
+               ;; :root directly from this ctx; omitting it made a resumed
+               ;; GREEN repair call scope-run with an empty cwd.  This comes
+               ;; only from run config (or the controller cwd), never journal
+               ;; text or model data.
+               :root root
                :max-turns max-turns :beam? (> width 1) :beam-width width
                :sessions sessions
                :abort abort

--- a/src/samizdat/agent/resume.clj
+++ b/src/samizdat/agent/resume.clj
@@ -102,22 +102,30 @@
      would not compare equal to the next clean one — replaying it would break
      the detection it was meant to restore.
 
-   JS1 resume contract:
-   - When the journal contains a :js1-binding-created event, the resume MUST
-     reconstruct a JS1 binding with the same spec coordinate before continuing.
-   - If SCI (jolt.sandbox) is unavailable at resume time, the resume FAILS
-     CLOSED — it throws rather than silently falling back to live eval in a
-     context that was supposed to be sandboxed.  The model's prior turns ran
-     inside SCI; switching to live eval mid-run would be a trust boundary
-     violation.
-   - The JS1 binding's SCI state (definitions made by prior evals) is NOT
-     replayable — SCI sessions are in-process state, like Lean sessions.
-     Definitions are lost.  This is the accepted JS1 analogue of the Lean
-     gap: the model can re-evaluate its definitions and they will take
-     effect in the fresh SCI context.
-   - The spec coordinate from the journal is verified against the newly
-     constructed binding's coordinate.  A mismatch (different root,
-     capabilities, or bounds) fails closed."
+    JS1 resume contract:
+    - When the journal contains a :js1-binding-created event, the resume MUST
+      reconstruct a JS1 binding with the same spec coordinate before continuing.
+    - The event carries the EXACT reconstruction information (spec
+      capabilities/bounds/timeout, spec coordinate, binding/instance ids,
+      preset, and the versioned runtime coordinate); every field is verified
+      against the re-minted binding, and any missing field or mismatched
+      value fails closed rather than guessing.
+    - If SCI (jolt.sandbox) is unavailable at resume time, the resume FAILS
+      CLOSED — it throws rather than silently falling back to live eval in a
+      context that was supposed to be sandboxed.  The model's prior turns ran
+      inside SCI; switching to live eval mid-run would be a trust boundary
+      violation.
+    - Whole-history rebuild: the re-minted binding's instance is rebuilt
+      from the binding's ENTIRE durable committed history
+      (sandbox/rebuild-binding!) — every committed evaluation replayed, in
+      the binding's durable total order, into ONE fresh SCI context, with
+      zero real project operations executed (jolt.sandbox :replay mode
+      throughout).  Definitions from prior turns SURVIVE the crash: a
+      terminated process resumes with its helper fns and def'd state intact,
+      reconstructed from receipts rather than re-run against the project.
+      A pending record, a gap in the total order, or any spec/instance/
+      binding/authority/runtime mismatch in the history fails closed —
+      history that cannot be verified is not replayed."
   (:require [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -125,6 +133,7 @@
             [samizdat.agent.gates :as gates]
             [samizdat.agent.loop :as branch-loop]
             [samizdat.agent.state :as state]
+            [samizdat.agent.tools.base :as js1-base]
             [samizdat.store.journal :as journal]
             [samizdat.store.runs :as runs]))
 
@@ -253,76 +262,223 @@
                     (keyword "project" s)))
     :else v))
 
-(defn- reconstruct-js1-binding!
-  "Fail-closed JS1 binding reconstruction for resume.
+(defn- journal-capability
+  "A journaled capability name back to a keyword.  Capabilities are
+   journaled as full name strings (\"project/read\"); tolerate the
+   name-only form jolt's data.json port can produce for keywords
+   (\"read\"), same as journal-preset."
+  [v]
+  (cond
+    (keyword? v) v
+    (string? v) (let [s (if (str/starts-with? v ":") (subs v 1) v)]
+                  (if (str/includes? s "/")
+                    (keyword s)
+                    (keyword "project" s)))
+    :else v))
 
-   Looks for the :js1-binding-created journal event to recover the
-   original spec coordinate and preset.  Then constructs a NEW binding
-   (the SCI state is lost, like Lean sessions) and verifies the
-   coordinate matches.
+(defn- js1-fail!
+  [code msg data]
+  (throw (ex-info msg (assoc data :js1/error code))))
 
-   Returns the binding, or throws if:
-   - The journal has a JS1 event but SCI is unavailable
-   - The coordinate does not match the original
+(defn- work-id-from-binding-id
+  "The work-id encoded in a durable binding id (\"bind:<key>:<work-id>\")."
+  [binding-id]
+  (let [s (str binding-id)]
+    (subs s (inc (str/last-index-of s ":")))))
 
-   Returns nil when no JS1 event exists (non-JS1 run)."
-  [conn run-id config root]
+(defn- normalize-js1-info
+  "Journaled JS1 reconstruction info into canonical shapes, or a
+   :reconstruction-info-missing failure.  Validated BEFORE anything is
+   allocated or required: corrupt journal data is refused on its own,
+   whatever the sandbox's availability."
+  [info]
+  (when-not (map? info)
+    (js1-fail! :reconstruction-info-missing
+               "JS1 resume: journal event data is not a map"
+               {:info (pr-str info)}))
+  (let [missing (into []
+                      (comp
+                        (filter #(let [v (get info %)]
+                                   (or (nil? v) (str/blank? (str v)))))
+                        (map name))
+                      [:spec-coordinate :runtime-coordinate :binding-id
+                       :instance-id :preset :capabilities :bounds :timeout-ms])]
+    (when (seq missing)
+      (js1-fail! :reconstruction-info-missing
+                 (str "JS1 resume: journal event lacks exact reconstruction"
+                      " information: " (str/join ", " missing))
+                 {:missing (vec missing)})))
+  (let [caps (cond
+               (vector? (:capabilities info)) (:capabilities info)
+               (set? (:capabilities info)) (vec (:capabilities info))
+               :else (js1-fail! :reconstruction-info-missing
+                                "JS1 resume: journaled capabilities are not a collection"
+                                {:capabilities (pr-str (:capabilities info))}))
+        bounds (if (map? (:bounds info))
+                 (into {} (map (fn [[k v]] [(keyword (name k)) v]))
+                       (:bounds info))
+                 (js1-fail! :reconstruction-info-missing
+                            "JS1 resume: journaled bounds are not a map"
+                            {:bounds (pr-str (:bounds info))}))
+        timeout (:timeout-ms info)]
+    (when-not (and (integer? timeout) (pos? timeout))
+      (js1-fail! :reconstruction-info-missing
+                 "JS1 resume: journaled timeout-ms is not a positive integer"
+                 {:timeout-ms (pr-str timeout)}))
+    (doseq [[k v] bounds]
+      (when-not (and (integer? v) (pos? v))
+        (js1-fail! :reconstruction-info-missing
+                   (str "JS1 resume: journaled bound " (name k)
+                        " is not a positive integer")
+                   {:bound k :value (pr-str v)})))
+    {:profile (:profile info)
+     :binding-id (str (:binding-id info))
+     :instance-id (str (:instance-id info))
+     :preset (journal-preset (:preset info))
+     :spec-coordinate (str (:spec-coordinate info))
+     :capabilities (vec (sort-by str (mapv journal-capability caps)))
+     :bounds bounds
+     :timeout-ms timeout
+     :runtime-coordinate (str (:runtime-coordinate info))}))
+
+(defn reconstruct-js1-binding!
+  "Fail-closed JS1 binding reconstruction for resume, from the journal's
+   EXACT binding information and the binding's WHOLE durable committed
+   history.
+
+   `conn` is the trusted connection the durable-eval store reads (the
+   run database in production; a controller/harness may bind the
+   sandbox's *eval-store* adapter instead).  `info` is the parsed
+   :js1-binding-created event data.  `root` is the trusted project root
+   the re-minted binding is confined to.
+
+   The ladder, each rung failing closed with {:js1/error ...}:
+
+   1. The journaled info is validated as data (normalize-js1-info) —
+      before SCI is even required, because corrupt journal data must be
+      refused on its own.
+   2. samizdat.agent.sandbox must load.  A run that evaluated inside SCI
+      cannot resume on live eval: that would be a trust boundary
+      violation, not a degradation.
+   3. This process's RuntimeCoordinate must equal the journaled one.
+      Receipts are only meaningful under the runtime that produced them;
+      an upgraded runtime fails closed instead of replaying across the
+      change.
+   4. A new binding is minted from the trusted preset + the EXACT
+      journaled capabilities/bounds/timeout — not from defaults, which a
+      harness upgrade could have moved.
+   5. The new binding's identity and spec are verified field by field
+      against the journal: binding id, instance id, spec coordinate (the
+      self-certifying content address over preset/root/capabilities/
+      bounds/timeout), and the explicit capabilities/bounds/timeout.
+   6. rebuild-binding! replays EVERY committed evaluation of the binding,
+      in the binding's durable total order, into ONE fresh SCI context —
+      zero real project operations, definitions restored from receipts.
+      A pending record (an unsettled effect's actuation state is
+      unknown), a gap in the total order, a spec/instance/binding/
+      authority/runtime mismatch in any record, or a replay whose result
+      does not reproduce the durable completion all fail closed.
+
+   Returns {:binding rebuilt-binding :provider provider :profile name};
+   the SCI state (definitions the model made with eval) is the committed
+   history, replayed — not lost."
+  [conn info root]
+  (let [info (normalize-js1-info info)]
+    (try
+      (require 'samizdat.agent.sandbox)
+      (catch Throwable e
+        (js1-fail! :sandbox-unavailable
+                   (str "JS1 resume failed: SCI/sandbox unavailable. "
+                        "The run was JS1-profiled but the sandbox cannot be "
+                        "constructed. Refusing to resume with live eval.")
+                   {:original (ex-message e)})))
+    (let [provider-fn (resolve 'samizdat.agent.sandbox/provider)
+          bind-fn     (resolve 'samizdat.agent.sandbox/bind!)
+          rt-fn       (resolve 'samizdat.agent.sandbox/runtime-coordinate)
+          rebuild-fn  (resolve 'samizdat.agent.sandbox/rebuild-binding!)]
+      (when (or (nil? provider-fn) (nil? bind-fn) (nil? rt-fn)
+                (nil? rebuild-fn))
+        (js1-fail! :sandbox-unavailable
+                   "JS1 resume failed: the sandbox API is incomplete in this process"
+                   {}))
+      ;; 3. The runtime coordinate gates everything below: receipts are
+      ;; only meaningful under the runtime that produced them.
+      (let [current-runtime (rt-fn)]
+        (when (not= current-runtime (:runtime-coordinate info))
+          (js1-fail! :runtime-mismatch
+                     (str "JS1 resume: runtime coordinate mismatch. The run"
+                          " evaluated under a different runtime stack; its"
+                          " receipts cannot be replayed here.")
+                     {:journaled (:runtime-coordinate info)
+                      :current current-runtime})))
+      ;; 4. Mint from the trusted preset + the exact journaled authority.
+      ;;    A bind! or spec error here (unknown preset, over-request) is a
+      ;;    sandbox-domain failure and keeps its own diagnostics.
+      (let [prov (provider-fn {:root root})
+            work-id (work-id-from-binding-id (:binding-id info))
+            binding (bind-fn prov work-id
+                             (-> {:preset (:preset info)
+                                  :root root
+                                  :instance/key :main}
+                                 (into (:bounds info))
+                                 (assoc :capabilities (set (:capabilities info))
+                                        :timeout-ms (:timeout-ms info))))
+            spec (:spec binding)
+            expect (fn [code what actual expected]
+                     (when (not= actual expected)
+                       (js1-fail! code
+                                  (str "JS1 resume: reconstructed binding "
+                                       what " does not match the journal")
+                                  {:expected expected :actual actual})))
+            _ (expect :binding-id-mismatch "binding id"
+                      (:binding/id binding) (:binding-id info))
+            _ (expect :instance-id-mismatch "instance id"
+                      (:instance/id binding) (:instance-id info))
+            _ (expect :coordinate-mismatch "spec coordinate"
+                      (:spec/coordinate spec) (:spec-coordinate info))
+            _ (expect :capability-mismatch "capabilities"
+                      (vec (:capabilities spec)) (:capabilities info))
+            _ (expect :bounds-mismatch "bounds"
+                      (:bounds spec) (:bounds info))
+            _ (expect :timeout-mismatch "timeout"
+                      (:timeout-ms spec) (:timeout-ms info))
+            ;; 6. Whole-history rebuild: ONE fresh SCI context carrying
+            ;;    every committed definition, or a closed failure.
+            rebuilt (try
+                      (rebuild-fn conn binding)
+                      (catch Throwable e
+                        (let [d (ex-data e)]
+                          (if (:js1/error d)
+                            (throw e)
+                            (throw (ex-info
+                                    (str "JS1 resume: the binding's durable"
+                                         " history failed whole-history"
+                                         " validation: " (ex-message e))
+                                    (-> (or d {})
+                                        (assoc :js1/error :history-invalid)
+                                        (assoc :sandbox-error
+                                               (:samizdat.sandbox/error d)))
+                                    e))))))]
+        (log/info "JS1 binding reconstructed for work" work-id
+                  "spec" (:spec-coordinate info)
+                  "- whole committed history replayed into one SCI context")
+        {:binding rebuilt :provider prov :profile (:profile info)}))))
+
+(defn- reconstruct-run-js1-binding!
+  "The journal-driven wrapper around reconstruct-js1-binding!: finds the
+   run's :js1-binding-created event, parses its data, and delegates.
+   Returns the reconstruction map, or nil for a non-JS1 run (in which
+   case SCI is never required — an unprofiled resume must not depend on
+   it)."
+  [conn run-id root]
   (let [all-events (journal/events-since conn run-id 0)
         js1-events (filter
-                     #(and (= "js1-binding-created" (:kind %))
-                           (some? (:data %)))
-                     all-events)]
+                    #(and (= "js1-binding-created" (:kind %))
+                          (some? (:data %)))
+                    all-events)]
     (when-let [evt (first js1-events)]
-      ;; The journal says this run was JS1-profiled.  Fail closed.
       ;; :data is JSON text from the events table; parse it.
-      (let [evt-data (parse-json (:data evt))
-            original-coordinate (get-in evt-data [:spec-coordinate])
-            original-profile (get-in evt-data [:profile])
-            original-preset (journal-preset (get-in evt-data [:preset]))]
-        (try
-          (require 'samizdat.agent.sandbox)
-          (let [provider-fn (resolve 'samizdat.agent.sandbox/provider)
-                bind-fn     (resolve 'samizdat.agent.sandbox/bind!)
-                desc-fn     (resolve 'samizdat.agent.sandbox/describe)
-                prov    (provider-fn {:root root})
-                preset  (or original-preset :project/develop)
-                binding (bind-fn prov (str run-id)
-                                 {:preset preset :root root
-                                  :instance/key :main})
-                desc    (desc-fn binding)
-                new-coord (:samizdat.sandbox/spec-coordinate desc)]
-            ;; A JS1 event that carries no coordinate cannot be verified
-            ;; against the reconstruction — fail closed rather than skip.
-            (when (nil? original-coordinate)
-              (throw (ex-info
-                       "JS1 resume: journal event carries no spec coordinate"
-                       {:run-id run-id
-                        :js1/error :coordinate-missing})))
-            (when (not= original-coordinate new-coord)
-              (throw (ex-info
-                        (str "JS1 resume: spec coordinate mismatch. Original: "
-                             original-coordinate ", reconstructed: " new-coord)
-                        {:run-id run-id
-                         :original-coordinate original-coordinate
-                         :reconstructed-coordinate new-coord
-                         :js1/error :coordinate-mismatch})))
-            (log/info "JS1 binding reconstructed for run" run-id
-                      "spec" new-coord "profile" original-profile)
-            (log/warn "JS1 resume: SCI definitions from prior turns are lost;"
-                      " the model must re-evaluate them")
-            binding)
-          (catch Throwable e
-            (if (:js1/error (ex-data e))
-              (throw e)
-              (throw (ex-info
-                      (str "JS1 resume failed: SCI/sandbox unavailable. "
-                           "The run was JS1-profiled but the sandbox cannot be "
-                           "constructed. Refusing to resume with live eval.")
-                      {:run-id run-id
-                       :original-profile original-profile
-                       :original-coordinate original-coordinate
-                       :js1/error :sandbox-unavailable}
-                                             e)))))))))
+      (reconstruct-js1-binding! conn (parse-json (:data evt)) root))))
 
 (defn resume!
   "Rebuild a run's branches from the journal and continue the beam's round
@@ -342,20 +498,32 @@
    pending-directives drain picks them up at the first resumed boundary — this
    function does not reimplement that path.
 
-   JS1 fail-closed: if the journal contains a :js1-binding-created event,
-   the resume reconstructs a JS1 binding and verifies its spec coordinate.
-   If SCI is unavailable, the resume throws rather than falling back to
-   live eval — the model's prior turns ran inside SCI, and switching to
-   live eval would be a trust boundary violation.  SCI definitions are
-   lost (same gap as Lean sessions).
+    JS1 fail-closed: if the journal contains a :js1-binding-created event,
+    the resume reconstructs a JS1 binding, verifies every journaled
+    reconstruction field (spec capabilities/bounds/timeout, coordinates,
+    identity), and replays the binding's WHOLE durable committed history
+    into one fresh SCI context — so the model's definitions survive the
+    crash.  If SCI is unavailable, the runtime/spec/identity mismatch, or
+    the durable history is malformed or unsettled, the resume THROWS
+    rather than falling back to live eval — the model's prior turns ran
+    inside SCI, and switching to live eval would be a trust boundary
+    violation.  A JS1 journal event on a multi-branch run is likewise
+    refused before any work: JS1 is single-player by construction.
 
-   Returns the beam/run-rounds result. Throws when the run is not resumable."
+    Returns the beam/run-rounds result. Throws when the run is not resumable."
   [{:keys [conn config llm-adapter llm-config run-id abort max-turns]}]
   (let [run (runs/get-run conn run-id)]
     (when-not (resumable? conn run-id)
       (throw (ex-info (str "run " run-id " is not resumable (status "
                            (:status run) ")")
                        {:run-id run-id :status (:status run)})))
+    ;; JS1 is single-player: a journaled JS1 binding on a width-N run
+    ;; (however it got there) is refused BEFORE the run is marked running
+    ;; again, before branches are rebuilt, before any model work.
+    (when (and (some #(= "js1-binding-created" (:kind %))
+                     (journal/events-since conn run-id 0))
+               (> (or (:beam_width run) 1) 1))
+      (js1-base/js1-assert-single-branch! true (:beam_width run)))
     ;; The row said 'interrupted' (or 'failed'); it is about to be running
     ;; again, and stalled? only watches runs whose status says so.
     (runs/mark-running! conn run-id)
@@ -371,9 +539,12 @@
           artifacts (group-by :branch_id (journal/artifacts conn run-id))
           firings (group-by :branch_id (journal/gate-firings conn run-id))
           sessions (atom [])
-          ;; JS1 reconstruction: fail-closed if the run was JS1-profiled
+          ;; JS1 reconstruction: fail-closed on unavailable SCI, runtime/
+          ;; spec/identity mismatch, or malformed/unsettled history; the
+          ;; whole committed durable history replays into ONE fresh SCI
+          ;; context, so the model's definitions survive the crash.
           root (or (get-in config [:run :root]) (System/getProperty "user.dir"))
-          js1 (reconstruct-js1-binding! conn run-id config root)
+          js1 (reconstruct-run-js1-binding! conn run-id root)
           ctx {:conn conn :run-id run-id :config config :problem (:problem run)
                :llm-adapter llm-adapter :llm-config llm-config
                :max-turns max-turns :beam? (> width 1) :beam-width width
@@ -381,9 +552,12 @@
                :abort abort
                ;; JS1 profile flags — reconstructed from journal, never
                ;; from model input.  :repl-session is nil when JS1 is
-               ;; active; the sandbox binding is the eval target.
-               :js1/profile (when js1 "single-player")
-               :js1/binding js1}
+               ;; active; the sandbox binding is the eval target.  The
+               ;; binding installs as a refreshable holder so a rollback
+               ;; between turns can be absorbed (tools.base/js1-binding).
+               :js1/profile (:profile js1)
+               :js1/binding (when-let [b (:binding js1)] (atom b))
+               :js1/provider (:provider js1)}
           branches (mapv (fn [row]
                            (rebuild-branch run row turns artifacts firings
                                            max-turns))

--- a/src/samizdat/agent/resume.clj
+++ b/src/samizdat/agent/resume.clj
@@ -93,15 +93,34 @@
     the failures that caused the reframe. Bounded by :reframe-grace, and the
     cull was always the documented backstop.
   - :critic scores and :fork-invited markers are branch memory; a resumed
-    branch is re-scored at its next boundary, and may be re-invited to fork
-    sooner than the cooldown would otherwise allow.
-  - the per-turn :error that repeating-failure? compares is not replayed, so a
-    branch that was looping on one identical failure gets one un-escalated
-    answer after a resume before the harness can see the loop again. The turns
-    table does hold the result text, but it holds the ESCALATED copy, which
-    would not compare equal to the next clean one — replaying it would break
-    the detection it was meant to restore."
+     branch is re-scored at its next boundary, and may be re-invited to fork
+     sooner than the cooldown would otherwise allow.
+   - the per-turn :error that repeating-failure? compares is not replayed, so a
+     branch that was looping on one identical failure gets one un-escalated
+     answer after a resume before the harness can see the loop again. The turns
+     table does hold the result text, but it holds the ESCALATED copy, which
+     would not compare equal to the next clean one — replaying it would break
+     the detection it was meant to restore.
+
+   JS1 resume contract:
+   - When the journal contains a :js1-binding-created event, the resume MUST
+     reconstruct a JS1 binding with the same spec coordinate before continuing.
+   - If SCI (jolt.sandbox) is unavailable at resume time, the resume FAILS
+     CLOSED — it throws rather than silently falling back to live eval in a
+     context that was supposed to be sandboxed.  The model's prior turns ran
+     inside SCI; switching to live eval mid-run would be a trust boundary
+     violation.
+   - The JS1 binding's SCI state (definitions made by prior evals) is NOT
+     replayable — SCI sessions are in-process state, like Lean sessions.
+     Definitions are lost.  This is the accepted JS1 analogue of the Lean
+     gap: the model can re-evaluate its definitions and they will take
+     effect in the fresh SCI context.
+   - The spec coordinate from the journal is verified against the newly
+     constructed binding's coordinate.  A mismatch (different root,
+     capabilities, or bounds) fails closed."
   (:require [clojure.data.json :as json]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [samizdat.agent.beam :as beam]
             [samizdat.agent.gates :as gates]
             [samizdat.agent.loop :as branch-loop]
@@ -216,31 +235,127 @@
   (when-let [r (runs/get-run conn run-id)]
     (not (contains? #{"completed" "aborted"} (:status r)))))
 
+(defn- journal-preset
+  "The journal stores event data as JSON, so the preset keyword reads back
+   as a STRING: \":project/develop\" under data.json's colon form, or just
+   \"develop\" under jolt's port, which writes keyword values via name and
+   drops the namespace.  Convert both shapes back to the keyword bind!
+   expects — the closed preset catalog lives in the fixed project namespace
+   — or nil so the caller's default applies.  bind! still fails closed on
+   anything that is not a key of that catalog."
+  [v]
+  (cond
+    (nil? v) nil
+    (keyword? v) v
+    (string? v) (let [s (if (str/starts-with? v ":") (subs v 1) v)]
+                  (if (str/includes? s "/")
+                    (keyword s)
+                    (keyword "project" s)))
+    :else v))
+
+(defn- reconstruct-js1-binding!
+  "Fail-closed JS1 binding reconstruction for resume.
+
+   Looks for the :js1-binding-created journal event to recover the
+   original spec coordinate and preset.  Then constructs a NEW binding
+   (the SCI state is lost, like Lean sessions) and verifies the
+   coordinate matches.
+
+   Returns the binding, or throws if:
+   - The journal has a JS1 event but SCI is unavailable
+   - The coordinate does not match the original
+
+   Returns nil when no JS1 event exists (non-JS1 run)."
+  [conn run-id config root]
+  (let [all-events (journal/events-since conn run-id 0)
+        js1-events (filter
+                     #(and (= "js1-binding-created" (:kind %))
+                           (some? (:data %)))
+                     all-events)]
+    (when-let [evt (first js1-events)]
+      ;; The journal says this run was JS1-profiled.  Fail closed.
+      ;; :data is JSON text from the events table; parse it.
+      (let [evt-data (parse-json (:data evt))
+            original-coordinate (get-in evt-data [:spec-coordinate])
+            original-profile (get-in evt-data [:profile])
+            original-preset (journal-preset (get-in evt-data [:preset]))]
+        (try
+          (require 'samizdat.agent.sandbox)
+          (let [provider-fn (resolve 'samizdat.agent.sandbox/provider)
+                bind-fn     (resolve 'samizdat.agent.sandbox/bind!)
+                desc-fn     (resolve 'samizdat.agent.sandbox/describe)
+                prov    (provider-fn {:root root})
+                preset  (or original-preset :project/develop)
+                binding (bind-fn prov (str run-id)
+                                 {:preset preset :root root
+                                  :instance/key :main})
+                desc    (desc-fn binding)
+                new-coord (:samizdat.sandbox/spec-coordinate desc)]
+            ;; A JS1 event that carries no coordinate cannot be verified
+            ;; against the reconstruction — fail closed rather than skip.
+            (when (nil? original-coordinate)
+              (throw (ex-info
+                       "JS1 resume: journal event carries no spec coordinate"
+                       {:run-id run-id
+                        :js1/error :coordinate-missing})))
+            (when (not= original-coordinate new-coord)
+              (throw (ex-info
+                        (str "JS1 resume: spec coordinate mismatch. Original: "
+                             original-coordinate ", reconstructed: " new-coord)
+                        {:run-id run-id
+                         :original-coordinate original-coordinate
+                         :reconstructed-coordinate new-coord
+                         :js1/error :coordinate-mismatch})))
+            (log/info "JS1 binding reconstructed for run" run-id
+                      "spec" new-coord "profile" original-profile)
+            (log/warn "JS1 resume: SCI definitions from prior turns are lost;"
+                      " the model must re-evaluate them")
+            binding)
+          (catch Throwable e
+            (if (:js1/error (ex-data e))
+              (throw e)
+              (throw (ex-info
+                      (str "JS1 resume failed: SCI/sandbox unavailable. "
+                           "The run was JS1-profiled but the sandbox cannot be "
+                           "constructed. Refusing to resume with live eval.")
+                      {:run-id run-id
+                       :original-profile original-profile
+                       :original-coordinate original-coordinate
+                       :js1/error :sandbox-unavailable}
+                                             e)))))))))
+
 (defn resume!
   "Rebuild a run's branches from the journal and continue the beam's round
-  loop at the round after the last recorded turn, under the run's ORIGINAL
-  max-turns.
+   loop at the round after the last recorded turn, under the run's ORIGINAL
+   max-turns.
 
-  `:max-turns` is the one exception to the anchor rule, and it is explicit:
-  when passed AND larger than the recorded budget, the runs row is raised to
-  it and branches closed as `exhausted` reopen — they closed because the
-  budget ran out, not for cause, so more budget un-closes them. Culled,
-  abandoned, and done branches stay closed. The extension is journaled
-  (budget-extended, branch-reopened) and the rows are updated BEFORE the
-  branches are read back, so a crash mid-extension replays correctly. A
-  crash still cannot re-grant budget; only a caller asking for more can.
+   `:max-turns` is the one exception to the anchor rule, and it is explicit:
+   when passed AND larger than the recorded budget, the runs row is raised to
+   it and branches closed as `exhausted` reopen — they closed because the
+   budget ran out, not for cause, so more budget un-closes them. Culled,
+   abandoned, and done branches stay closed. The extension is journaled
+   (budget-extended, branch-reopened) and the rows are updated BEFORE the
+   branches are read back, so a crash mid-extension replays correctly. A
+   crash still cannot re-grant budget; only a caller asking for more can.
 
-  Pending interventions are already in their table; the existing
-  pending-directives drain picks them up at the first resumed boundary — this
-  function does not reimplement that path.
+   Pending interventions are already in their table; the existing
+   pending-directives drain picks them up at the first resumed boundary — this
+   function does not reimplement that path.
 
-  Returns the beam/run-rounds result. Throws when the run is not resumable."
+   JS1 fail-closed: if the journal contains a :js1-binding-created event,
+   the resume reconstructs a JS1 binding and verifies its spec coordinate.
+   If SCI is unavailable, the resume throws rather than falling back to
+   live eval — the model's prior turns ran inside SCI, and switching to
+   live eval would be a trust boundary violation.  SCI definitions are
+   lost (same gap as Lean sessions).
+
+   Returns the beam/run-rounds result. Throws when the run is not resumable."
   [{:keys [conn config llm-adapter llm-config run-id abort max-turns]}]
   (let [run (runs/get-run conn run-id)]
     (when-not (resumable? conn run-id)
       (throw (ex-info (str "run " run-id " is not resumable (status "
                            (:status run) ")")
-                      {:run-id run-id :status (:status run)})))
+                       {:run-id run-id :status (:status run)})))
     ;; The row said 'interrupted' (or 'failed'); it is about to be running
     ;; again, and stalled? only watches runs whose status says so.
     (runs/mark-running! conn run-id)
@@ -256,11 +371,19 @@
           artifacts (group-by :branch_id (journal/artifacts conn run-id))
           firings (group-by :branch_id (journal/gate-firings conn run-id))
           sessions (atom [])
+          ;; JS1 reconstruction: fail-closed if the run was JS1-profiled
+          root (or (get-in config [:run :root]) (System/getProperty "user.dir"))
+          js1 (reconstruct-js1-binding! conn run-id config root)
           ctx {:conn conn :run-id run-id :config config :problem (:problem run)
                :llm-adapter llm-adapter :llm-config llm-config
                :max-turns max-turns :beam? (> width 1) :beam-width width
                :sessions sessions
-               :abort abort}
+               :abort abort
+               ;; JS1 profile flags — reconstructed from journal, never
+               ;; from model input.  :repl-session is nil when JS1 is
+               ;; active; the sandbox binding is the eval target.
+               :js1/profile (when js1 "single-player")
+               :js1/binding js1}
           branches (mapv (fn [row]
                            (rebuild-branch run row turns artifacts firings
                                            max-turns))

--- a/src/samizdat/agent/sandbox.clj
+++ b/src/samizdat/agent/sandbox.clj
@@ -50,27 +50,71 @@
      :project/read    — :agent/project-read,  capabilities read/list/search/stat
      :project/develop — :agent/project-develop, read/list/search/stat + edit
 
-   Five semantic ops projected as project/read, project/list,
-   project/search, project/stat, project/edit — all rooted at the trusted
-   host root with relative nonescaping paths, symlink escape prevention,
-   bounded reads, deterministic digest stat, and anchored edit
-   (base-digest or :absent, stale conflict detection, no blind overwrite).
-   All returned data is inert/canonical via jolt.sandbox.
+    Five semantic ops projected as project/read, project/list,
+    project/search, project/stat, project/edit — normalized against the
+    frozen bb4t A2/A3b project contract, all rooted at the trusted host
+    root: relative nonescaping paths validated lexically, symbolic links
+    refused everywhere (leaf or component, in-root or escaping), bounded
+    strict-UTF-8 reads that stop at the bound before consuming, one-level
+    inert sorted structured listings, {:path :line :text} search results
+    under file/result/byte/regex bounds with per-file consumption checked
+    before reading, fail-closed stat digests (a coordinate is computed or
+    the operation fails — never nil/fake), and an anchored edit that writes
+    through a sibling temporary and an atomic rename, creates only an
+    absent leaf (never parent hierarchy), and conflicts rather than
+    overwriting blindly.  All returned data is inert/canonical via
+    jolt.sandbox.  Safe host-derived doc/complete unions the effective
+    project operations with the reviewed pure language surface
+    (jolt.sandbox/language-surface at Jolt 619ef196) — trusted static data,
+    never live introspection.
 
-   Timeout uses Jolt cooperative interrupt with an unraiseable host
-   ceiling: jolt.host/run-interruptible checks the token from the host
-   side; SCI code cannot catch or suppress the interruption.
+    Timeout uses Jolt cooperative interrupt with an unraiseable host
+    ceiling: jolt.host/run-interruptible checks the token from the host
+    side; SCI code cannot catch or suppress the interruption.
 
-   Legacy direct API (preserved): new / evaluate! / rebuild! / describe.
-   Note: the original draft named the constructor `registry/new`; under
-   Jolt a multi-segment defn name interns under its final segment, so it
-   was always callable only as plain `new` — that name is kept.
+    Durable recorded evaluation (evaluate-recorded! / rebuild-binding!):
 
-   See samizdat.sandbox-test docstring for the direct invocation.
+      RuntimeCoordinate — every durable record names the exact runtime stack
+        its receipts are meaningful under: Jolt version, vendored SCI
+        coordinate, evaluator-protocol version, reviewed language-surface
+        coordinate, capability-catalog coordinate/version, and
+        receipt-protocol version, all under one versioned self-certifying
+        js1-rt/v1: coordinate.  Verification compares it exactly; an
+        upgraded runtime fails closed instead of replaying across the
+        change.
 
-   Blockers:
-     - jolt.sandbox requires SCI (sci.core) - not available on plain JVM.
-     - jolt.host/run-interruptible and make-interrupt are Jolt host fns."
+      Strict receipts, bounded rendered result — receipt payloads stay in
+        the strict canonical receipt domain, but an evaluation's FINAL value
+        may be any SCI value: inert values are stored exactly, everything
+        else is rendered under print bounds plus a character bound.
+
+        Commit-only state — a recorded evaluation's definitions become
+        evaluator state only by committing.  A failed or interrupted
+        evaluation's partial definitions are rolled back: the instance is
+        rebuilt from the binding's durable committed history and the rebuilt
+        instance is published before the original error propagates.  If that
+        rollback itself fails, the instance is poisoned and refuses further
+        evaluation until rebuilt.
+
+      Whole-history rebuild — rebuild-binding! replays EVERY committed
+        evaluation of a binding, in the binding's durable total order
+        (binding_seq), into ONE fresh SCI context.  Replay runs in
+        jolt.sandbox :replay mode throughout, so zero real project
+        operations execute; every record is validated against the binding's
+        spec/instance/binding identity, authority coordinate, and runtime
+        coordinate before any of it is trusted, and a pending record, a gap
+        in the total order, a shared instance, or any mismatch fails closed.
+
+    Legacy direct API (preserved): new / evaluate! / rebuild! / describe.
+    Note: the original draft named the constructor `registry/new`; under
+    Jolt a multi-segment defn name interns under its final segment, so it
+    was always callable only as plain `new` — that name is kept.
+
+    See samizdat.sandbox-test docstring for the direct invocation.
+
+    Blockers:
+      - jolt.sandbox requires SCI (sci.core) - not available on plain JVM.
+      - jolt.host/run-interruptible and make-interrupt are Jolt host fns."
   (:require [clojure.string :as str]
             [jolt.fs :as fs]
             [jolt.sandbox :as sandbox]
@@ -84,7 +128,25 @@
 (def ^:const default-max-list-entries 1000)
 (def ^:const default-max-search-results 500)
 (def ^:const default-search-max-chars 500000)
+(def ^:const default-search-max-files 20000)
+(def ^:const default-max-write-bytes 1048576)
 (def ^:const default-timeout-ms 30000)
+
+;; Bounds the frozen bb4t A2/A3b contract fixes for every path argument:
+;; a model-supplied path is one bounded (≤ `max-path-chars`) non-empty
+;; relative string, and a search pattern at most `max-search-pattern-chars`.
+(def ^:const max-path-chars 4096)
+(def ^:const max-search-pattern-chars 200)
+(def ^:const max-search-line-chars 300)
+
+(defn- read-byte-ceiling
+  "The byte bound a bounded read stops at, derived from the character bound
+   (a character occupies at most four UTF-8 bytes, so this is the largest
+   byte consumption a max-chars read can ever need).  Bounded BEFORE
+   decoding: no read ever consumes past this ceiling regardless of what the
+   file contains."
+  [max-chars]
+  (* 4 max-chars))
 
 ;; ═══════════════════════════════════════════════════════════════════════════
 ;; Trusted preset catalog (closed)
@@ -107,6 +169,92 @@
                     :project/edit}}})
 
 ;; ═══════════════════════════════════════════════════════════════════════════
+;; RuntimeCoordinate — versioned identity of the runtime a receipt names
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(def ^:const runtime-protocol-version
+  "Version of the RuntimeCoordinate scheme itself (the js1-rt/vN: prefix)."
+  1)
+
+(def ^:const evaluator-protocol-version
+  "Version of the JS1 evaluator protocol: the EvaluatorSpec/Instance/Binding
+   seam, the recorded intent/outcome/completion lifecycle, the five projected
+   operations' normalized frozen-contract semantics (bounded strict-UTF-8
+   read, one-level structured listing, {:path :line :text} bounded search,
+   fail-closed stat digests, atomic anchored edit that never creates
+   hierarchy), and the replay contract this namespace implements.  Bumped to
+   2 with that normalization: durable receipts recorded under the v1 result
+   shapes fail closed at replay instead of being reinterpreted."
+  2)
+
+(def ^:const receipt-protocol-version
+  "Version of the durable receipt protocol shared with samizdat.store.evals:
+   the canonical EDN receipt domain, intent-before-effect ordering, and the
+   append-only pending/completed settlement rules."
+  1)
+
+(def ^:const capability-catalog-version
+  "Version of the trusted closed preset catalog (`presets`).  The catalog
+   content is also named exactly by :runtime/capability-catalog's canonical
+   coordinate; this version names the catalog SCHEMA."
+  1)
+
+(def ^:const sci-implementation
+  "The SCI implementation coordinate named by the RuntimeCoordinate.  SCI
+   exposes no runtime version, so this names the vendored SCI release in the
+   local jolt source tree (vendor/sci, per its resources/SCI_VERSION) as a
+   reviewed constant: bump it deliberately when the vendored tree moves."
+  "sci-0.13.53")
+
+(defn- capability-catalog-description
+  "Inert, canonical description of the closed trusted preset catalog — the
+   capability catalog the RuntimeCoordinate names.  Sets are rendered as
+   sorted vectors so the description is wholly inside the receipt domain."
+  []
+  (into {}
+        (map (fn [[preset-key preset]]
+               [preset-key {:profile (str (:profile preset))
+                            :capabilities (vec (sort-by str (:capabilities preset)))}]))
+        presets))
+
+(defn runtime-snapshot
+  "Inert, data-only description of the exact runtime stack a durable JS1
+   record names: the Jolt version, the vendored SCI coordinate, the
+   evaluator-protocol version, the reviewed language-surface coordinate
+   (jolt.sandbox/language-coordinate, itself versioned), the capability
+   catalog's content coordinate and schema version, and the receipt-protocol
+   version.  Fully canonical (receipt domain throughout); suitable for
+   serialization and comparison."
+  []
+  (sandbox/inert
+    {:runtime/jolt (jolt.host/jolt-version)
+     :runtime/sci sci-implementation
+     :runtime/evaluator-protocol evaluator-protocol-version
+     :runtime/language (sandbox/language-coordinate)
+     :runtime/capability-catalog
+     (sandbox/canonical-coordinate (capability-catalog-description))
+     :runtime/capability-catalog-version capability-catalog-version
+     :runtime/receipt-protocol receipt-protocol-version}))
+
+(def ^:private runtime-coordinate*
+  (delay
+    (let [c (sandbox/canonical-coordinate (runtime-snapshot))]
+      (when-not (str/starts-with? c "js0:")
+        (throw (ex-info "Unexpected JS0 canonical coordinate form"
+                        {:samizdat.sandbox/error :coordinate})))
+      (str "js1-rt/v" runtime-protocol-version ":" (subs c 4)))))
+
+(defn runtime-coordinate
+  "The versioned RuntimeCoordinate of this process, as a self-certifying
+   js1-rt/v1: string: the JS0 canonical form of `runtime-snapshot`, retagged
+   and versioned.  Deterministic for one runtime stack; durable evaluation
+   records carry it and verification compares it exactly, so a runtime that
+   changed out from under a record fails closed at replay instead of
+   reinterpretating its receipts."
+  []
+  @runtime-coordinate*)
+
+;; ═══════════════════════════════════════════════════════════════════════════
 ;; Path resolution (symlink-safe, fail-closed)
 ;; ═══════════════════════════════════════════════════════════════════════════
 
@@ -115,201 +263,467 @@
   [root]
   (str (fs/canonicalize root)))
 
-(defn- resolve-under-root
-  "Resolve relative path under canonical root. Returns the absolute
-   path, or nil if the path escapes, is blank, or causes any I/O error.
-   Canonicalize follows symlinks so any chain that lands outside root
-   is caught.  For non-existing leaf paths the existing prefix is
-   resolved; a symlink in that prefix that points outside root is
-   still caught because canonicalize resolves it before appending the
-   remaining (non-existing) segments."
-  [root-canonical path]
-  (when (and (string? path) (not (str/blank? path)))
-    (try
-      (let [target (str (fs/canonicalize (fs/path root-canonical path)))]
-        (when (or (= target root-canonical)
-                  (str/starts-with? target (str root-canonical "/")))
-          target))
-      (catch Exception _ nil))))
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Path policy — the frozen bb4t A2/A3b rules, model-facing side
+;; ═══════════════════════════════════════════════════════════════════════════
 
-(defn- require-under-root!
-  "Resolve relative path under canonical root; throws on escape or
-   missing path with {:samizdat.sandbox/error} in ex-data."
-  [root-canonical rel-path label]
-  (if-let [abs (resolve-under-root root-canonical rel-path)]
-    abs
-    (throw (ex-info (str label ": path escapes root or is invalid: " rel-path)
-                    {:samizdat.sandbox/error :path-escape
-                     :path rel-path}))))
+(defn- fail!
+  [code message data]
+  (throw (ex-info message (assoc data :samizdat.sandbox/error code))))
+
+(defn- raise-files-failure
+  "Re-throw a samizdat.agent.files substrate failure with the sandbox error
+   key added under the same code, so every model-facing failure carries
+   {:samizdat.sandbox/error …} whichever layer produced it.  Non-files
+   failures pass through untouched."
+  [^Throwable failure]
+  (let [d (ex-data failure)]
+    (if (and (map? d) (contains? d :samizdat.files/error))
+      (throw (ex-info (ex-message failure)
+                      (assoc d :samizdat.sandbox/error (:samizdat.files/error d))
+                      failure))
+      (throw failure))))
+
+(defn- lexical-relative
+  "Validate one model-supplied relative path exactly as the frozen contract
+   does and return its lexically normalized components under the root ([] is
+   the root itself): a bounded non-empty relative string, normalized before
+   any filesystem access, and unable to leave the root lexically.  The root
+   itself is admitted only when allow-root? (listing and searching it is
+   their primary use; read/stat/edit reject it as 'not a regular file')."
+  [root-canonical rel-path operation allow-root?]
+  (when-not (and (string? rel-path)
+                 (not (str/blank? rel-path))
+                 (<= (count rel-path) max-path-chars))
+    (fail! :invalid-path
+           (str operation " expects one bounded non-empty relative path")
+           {:operation/id operation :path (str rel-path)}))
+  (when (fs/absolute? (fs/path rel-path))
+    (fail! :absolute-path
+           (str operation " rejects absolute paths")
+           {:operation/id operation :path rel-path}))
+  (let [lexical (str (fs/normalize (fs/path root-canonical rel-path)))]
+    (when-not (or (= lexical root-canonical)
+                  (str/starts-with? lexical (str root-canonical "/")))
+      (fail! :path-escape
+             (str operation " path escapes the authorized root")
+             {:operation/id operation :path rel-path}))
+    (when (and (= lexical root-canonical) (not allow-root?))
+      (fail! :not-file
+             (str operation " target is the project root, not a file")
+             {:operation/id operation}))
+    (if (= lexical root-canonical)
+      []
+      (vec (remove str/blank? (str/split (subs lexical (inc (count root-canonical)))
+                                         #"/"))))))
+
+(defn- require-directory-component!
+  "One intermediate walk component must exist, be a directory, and NOT be a
+   symbolic link.  Refusing links outright — even links that stay inside the
+   root — is the frozen contract's rule: no walk can be redirected through
+   one, so 'would this link escape?' never has to be answered."
+  [dir component operation]
+  (let [child (str dir "/" component)]
+    (cond
+      (not (fs/exists? child {:nofollow-links true}))
+      (fail! :not-found (str operation " path does not exist")
+             {:operation/id operation :component component})
+
+      (fs/sym-link? child)
+      (fail! :symlink (str operation " will not follow a symbolic link")
+             {:operation/id operation :component component})
+
+      (not (fs/directory? child {:nofollow-links true}))
+      (fail! :not-found (str operation " path component is not a directory")
+             {:operation/id operation :component component}))))
+
+(defn- descend
+  "Walk `components` under the root, refusing every symbolic link and every
+   missing/non-directory component (bb4t's descend).  Returns the absolute
+   path of the directory the walk lands in — the target itself when
+   components is empty."
+  [root-canonical components operation]
+  (loop [dir root-canonical
+         [component & more] components]
+    (if component
+      (do (require-directory-component! dir component operation)
+          (recur (str dir "/" component) more))
+      dir)))
+
+(defn- target-of
+  "Resolve a leaf path to [parent-abs leaf-name kind]: the walk descends to
+   the parent with the frozen rules and classifies the leaf NOFOLLOW."
+  [root-canonical components operation]
+  (let [parent (descend root-canonical (butlast components) operation)
+        leaf (last components)
+        abs (str parent "/" leaf)
+        kind (cond
+               (not (fs/exists? abs {:nofollow-links true})) :absent
+               (fs/sym-link? abs) :symlink
+               (fs/directory? abs {:nofollow-links true}) :directory
+               (fs/regular-file? abs {:nofollow-links true}) :file
+               :else :other)]
+    [parent leaf kind]))
+
+(defn- relative-name
+  "The canonical relative name results carry: the lexically normalized
+   components rejoined, exactly the path the model's write will be known by."
+  [components]
+  (str/join "/" components))
 
 ;; ═══════════════════════════════════════════════════════════════════════════
-;; Digest
+;; Digest — a coordinate is computed or the operation fails
 ;; ═══════════════════════════════════════════════════════════════════════════
 
 (defn- file-digest-str
-  "SHA-256 hex digest string prefixed with 'sha256:', or nil."
-  [abs-path]
-  (when-let [hex (files/file-digest abs-path)]
-    (str "sha256:" hex)))
+  "The file's sha256:… content coordinate, read through the bounded reader.
+   Fail-closed like the frozen contract: a digest that cannot be computed
+   (unreadable, over the byte bound, no digest machinery) FAILS the caller
+   with {:samizdat.sandbox/error :digest-failed} — it never becomes nil or a
+   fake coordinate an anchored write could be tempted to trust."
+  [abs-path max-bytes]
+  (try
+    (str "sha256:" (files/file-digest abs-path max-bytes))
+    (catch Throwable failure
+      (fail! :digest-failed
+             "The content digest could not be computed; refusing to invent one"
+             {:cause (str failure)}))))
 
 ;; ═══════════════════════════════════════════════════════════════════════════
-;; Operation descriptors
+;; Operation descriptors — the frozen bb4t A2/A3b contract, projected
 ;; ═══════════════════════════════════════════════════════════════════════════
 
 (defn- make-read-op
-  "project/read — bounded file read. Returns {:path :content :truncated}"
+  "project/read — one bounded UTF-8 file read.  Returns the decoded string.
+
+   Exactly the frozen contract: a regular file only (a symlink is refused,
+   not followed, whether it points in or out), bytes consumed only up to the
+   derived byte ceiling, strict UTF-8 decoding (invalid input fails, never
+   replaces), and the character bound fails rather than truncates — a bound
+   the caller can rely on naming everything it got."
   [root-canonical max-chars]
-  {:id :project/read :name 'read :effect :observation
-   :fn (fn [rel-path]
-         (let [abs (require-under-root! root-canonical rel-path "project/read")]
-           (when-not (fs/regular-file? abs {:nofollow-links true})
-             (throw (ex-info "project/read: not a regular file"
-                             {:samizdat.sandbox/error :not-file :path rel-path})))
-           (let [content (slurp abs)
-                 truncated? (> (count content) max-chars)
-                 shown (if truncated? (subs content 0 max-chars) content)]
-             {:path rel-path :content shown :truncated truncated?})))})
+  (let [max-bytes (read-byte-ceiling max-chars)]
+    {:id :project/read :name 'read :effect :observation
+     :fn (fn [rel-path]
+           (let [components (lexical-relative root-canonical rel-path
+                                              :project/read false)]
+             (when (empty? components)
+               (fail! :not-file "project/read target is not a regular file"
+                      {:path rel-path}))
+             (let [[parent leaf kind] (target-of root-canonical components
+                                                 :project/read)]
+               (when-not (= :file kind)
+                 (fail! :not-file "project/read target is not a regular file"
+                        {:path rel-path :kind kind}))
+                (let [abs (str parent "/" leaf)]
+                  (try
+                    (let [bytes (files/read-bounded-bytes abs max-bytes)
+                          content (files/decode-utf8 bytes)]
+                      (when (> (count content) max-chars)
+                        (fail! :too-large
+                               "File content exceeds the character limit"
+                               {:path rel-path :limit max-chars}))
+                      content)
+                    (catch Throwable failure
+                      (raise-files-failure failure)))))))}))
 
 (defn- make-list-op
-  "project/list — bounded directory listing.
-   Optional rel-path argument defaults to the root."
+  "project/list — one directory level, as inert structured entries.
+
+   Exactly the frozen contract: exactly one relative path ('.' for the root),
+   the IMMEDIATE entries only (never recursive), each a {:name :kind} map
+   with :bytes on files, :kind one of :file/:directory/:symlink/:other,
+   sorted by name, attributes read NOFOLLOW so a link is a link.  More
+   entries than the bound fails rather than truncating.  Returns the entries
+   vector."
   [root-canonical max-entries]
   {:id :project/list :name 'list :effect :observation
-   :fn (fn [& args]
-         (let [rel-path (or (first args) ".")
-               abs (resolve-under-root root-canonical rel-path)]
-           (if (and abs (fs/directory? abs {:nofollow-links true}))
-             {:path rel-path
-              :entries (files/safe-list-dir root-canonical rel-path max-entries)}
-             {:path rel-path :entries []})))})
+   :fn (fn [rel-path]
+         (let [components (lexical-relative root-canonical rel-path
+                                            :project/list true)
+               dir (descend root-canonical components :project/list)
+               kind (cond
+                      (not (fs/exists? dir {:nofollow-links true})) :absent
+                      (fs/sym-link? dir) :symlink
+                      (fs/directory? dir {:nofollow-links true}) :directory
+                      :else :other)]
+           (cond
+             (= :symlink kind)
+             (fail! :symlink "project/list will not follow a symbolic link"
+                    {:path rel-path})
+
+             (= :absent kind)
+             (fail! :not-found "project/list target does not exist"
+                    {:path rel-path})
+
+             (not= :directory kind)
+             (fail! :not-found "project/list target is not a directory"
+                    {:path rel-path})
+
+              :else (try
+                      (files/list-one-level dir max-entries)
+                      (catch Throwable failure
+                        (raise-files-failure failure))))))})
 
 (defn- make-search-op
-  "project/search — bounded regex search. Returns {:pattern :matches}."
-  [root-canonical max-results max-chars]
-  {:id :project/search :name 'search :effect :observation
-   :fn (fn [pattern & args]
-         (let [rel-path (or (first args) ".")]
-           {:pattern pattern
-            :path rel-path
-            :matches (files/safe-search-files
-                       root-canonical rel-path pattern max-results max-chars)}))})
+  "project/search — bounded regex search.  Returns a vector of
+   {:path :line :text} maps ordered by path.
+
+   Exactly the frozen contract: a bounded pattern (≤ 200 chars) that must
+   compile, an optional options map {:path \"sub\" :include-hidden? true};
+   dot-entries skipped unless included; symlinks never followed; files that
+   are not valid UTF-8 skipped; a file larger than the per-file byte bound
+   skipped with its bytes never consumed (the size is checked first); more
+   regular files than :search-max-files FAILS the search; collection stops
+   at :max-search-results.  Matched text is trimmed and capped."
+  [root-canonical max-results max-chars max-files max-read-chars]
+  (let [max-file-bytes (read-byte-ceiling max-read-chars)]
+    {:id :project/search :name 'search :effect :observation
+     :fn
+     (fn [& args]
+       (let [[pattern options] args]
+         (when-not (and (<= 1 (count args) 2)
+                        (string? pattern)
+                        (not (str/blank? pattern))
+                        (<= (count pattern) max-search-pattern-chars)
+                        (or (nil? options) (map? options)))
+           (fail! :invalid-arguments
+                  "project/search expects a bounded pattern and an optional options map"
+                  {:operation/id :project/search}))
+         (let [rel-path (or (:path options) ".")]
+           (when-not (and (string? rel-path) (not (str/blank? rel-path))
+                          (<= (count rel-path) max-path-chars))
+             (fail! :invalid-path
+                    "project/search :path must be a bounded relative path"
+                    {:path rel-path}))
+           (let [components (lexical-relative root-canonical rel-path
+                                              :project/search true)
+                 dir (descend root-canonical components :project/search)
+                 kind (cond
+                        (not (fs/exists? dir {:nofollow-links true})) :absent
+                        (fs/sym-link? dir) :symlink
+                        (fs/directory? dir {:nofollow-links true}) :directory
+                        :else :other)
+                 re (try (re-pattern pattern)
+                         (catch Throwable _
+                           (fail! :invalid-regex
+                                  "project/search pattern is not a valid regex"
+                                  {:pattern pattern})))]
+             (cond
+               (= :symlink kind)
+               (fail! :symlink "project/search will not follow a symbolic link"
+                      {:path rel-path})
+
+               (= :absent kind)
+               (fail! :not-found "project/search :path does not exist"
+                      {:path rel-path})
+
+               (not= :directory kind)
+               (fail! :not-found "project/search :path is not a directory"
+                      {:path rel-path})
+
+                :else
+                (try
+                  (files/search-tree dir (relative-name components) re
+                                     {:max-results max-results
+                                      :max-file-bytes max-file-bytes
+                                      :max-files max-files
+                                      :include-hidden? (true? (:include-hidden? options))
+                                      :max-chars max-chars
+                                      :max-line-chars max-search-line-chars})
+                  (catch Throwable failure
+                    (raise-files-failure failure))))))))}))
 
 (defn- make-stat-op
-  "project/stat — deterministic stat with coordinate/digest.
-   Returns {:path :exists :type :size :digest}."
-  [root-canonical]
-  {:id :project/stat :name 'stat :effect :observation
-   :fn (fn [rel-path]
-         (if-let [abs (resolve-under-root root-canonical rel-path)]
-           (let [exists? (fs/exists? abs {:nofollow-links true})]
-             (if exists?
-               (let [sym? (fs/sym-link? abs)
-                     dir? (fs/directory? abs {:nofollow-links true})
-                     reg? (and (not sym?) (not dir?) (fs/regular-file? abs))
-                     type (cond sym? :symlink dir? :dir reg? :file)
-                     size (when reg? (fs/size abs))
-                     digest (when reg? (file-digest-str abs))]
-                 {:path rel-path :exists true :type type
-                  :size size :digest digest})
-               {:path rel-path :exists false}))
-           {:path rel-path :exists false}))})
+  "project/stat — deterministic coordinate of one path.
+
+   Exactly the frozen contract: {:path :kind :bytes :digest} for a regular
+   file, {:path :kind} for a directory/symlink/other, {:path :kind :absent}
+   when it does not exist.  The digest is computed through the bounded
+   reader and FAILS on error (unreadable, over the bound, no machinery) — a
+   regular file's coordinate never carries nil, because that is a fake
+   coordinate, not an absent one."
+  [root-canonical max-read-chars]
+  (let [max-bytes (read-byte-ceiling max-read-chars)]
+    {:id :project/stat :name 'stat :effect :observation
+     :fn (fn [rel-path]
+           (let [components (lexical-relative root-canonical rel-path
+                                              :project/stat false)]
+             (when (empty? components)
+               (fail! :not-file "project/stat target is the project root, not a file"
+                      {:path rel-path}))
+             (let [[parent leaf kind] (target-of root-canonical components
+                                                 :project/stat)
+                   rel (relative-name components)]
+               (case kind
+                 :absent {:path rel :kind :absent}
+                 :file {:path rel :kind :file
+                        :bytes (try (files/nofollow-size (str parent "/" leaf))
+                                    (catch Throwable failure
+                                      (fail! :digest-failed
+                                             "The file size could not be read; refusing to invent a coordinate"
+                                             {:path rel :cause (str failure)})))
+                        :digest (file-digest-str (str parent "/" leaf) max-bytes)}
+                 {:path rel :kind kind}))))}))
 
 (defn- make-edit-op
-  "project/edit — anchored edit requiring base digest or :absent.
+  "project/edit — anchored replacement of one regular file's contents.
 
-   Args: [rel-path base-digest new-content]
+   JS1 projection of the frozen contract's edit (positional args, the JS1
+   receipt convention; bb4t spells the same fields as one options map):
 
-   - base-digest is a sha256:… string (for an existing file) or :absent / nil
-     (for creation).  A string base-digest on a non-existing file, or
-     :absent on an existing file, is a conflict.
-   - Stale conflict: file exists but its current digest ≠ base-digest.
-   - No blind overwrite: base-digest must be supplied when the file exists.
-   - Returns {:path :digest :created?}"
-  [root-canonical]
-  {:id :project/edit :name 'edit :effect :actuation
-   :fn (fn [rel-path base-digest new-content]
-         (let [abs (require-under-root! root-canonical rel-path "project/edit")
-               new-content (str new-content)
-               exists? (fs/exists? abs {:nofollow-links true})
-               creating? (or (nil? base-digest) (= :absent base-digest))]
-           (cond
-             ;; Creation path
-             creating?
-             (when exists?
-               (throw (ex-info "project/edit: file already exists"
-                               {:samizdat.sandbox/error :already-exists
-                                :path rel-path
-                                :actual-digest (file-digest-str abs)})))
+     (project/edit rel-path base new-content)
 
-             ;; Update path — base-digest must be a string
-              (string? base-digest)
-              (do
-                (when (not exists?)
-                  (throw (ex-info "project/edit: file does not exist"
-                                  {:samizdat.sandbox/error :not-found
-                                   :path rel-path})))
-                (let [current-digest (file-digest-str abs)]
-                  (when (not= base-digest current-digest)
-                    (throw (ex-info "project/edit: stale conflict"
-                                    {:samizdat.sandbox/error :stale-conflict
-                                     :path rel-path
-                                     :expected base-digest
-                                     :actual current-digest})))))
+   base is :absent (or nil) to CREATE — the leaf must be the only thing
+   absent, so a missing parent FAILS and no directory is ever created — or
+   the file's current sha256:… digest from project/stat: an update states
+   which version it believed, and a file that exists with a different
+   digest, that does not exist, or whose base was :absent while it exists,
+   is a CONFLICT, never a blind overwrite.  The write goes through a
+   sibling temporary and an atomic rename, so a reader never sees a partial
+   file and a failed write leaves the original intact.  Content over the
+   write byte bound fails.  Returns {:path :bytes :digest} of the new
+   content."
+  [root-canonical max-write-bytes max-read-chars]
+  (let [max-bytes (read-byte-ceiling max-read-chars)]
+    {:id :project/edit :name 'edit :effect :actuation
+     :fn (fn [rel-path base-digest new-content]
+           (let [components (lexical-relative root-canonical rel-path
+                                              :project/edit false)]
+             (when (empty? components)
+               (fail! :not-file "project/edit target is the project root, not a file"
+                      {:path rel-path}))
+             (when-not (string? new-content)
+               (fail! :invalid-arguments
+                      "project/edit :content must be a string"
+                      {:path rel-path}))
+             (let [creating? (or (nil? base-digest) (= :absent base-digest))]
+               (when-not (or creating? (string? base-digest))
+                 (fail! :invalid-base-digest
+                        (str "project/edit :base must be :absent or the file's "
+                             "sha256:… digest; an edit without a base coordinate "
+                             "is a blind overwrite")
+                        {:path rel-path :base-digest (str base-digest)}))
+               (let [encoded (files/utf8-bytes new-content)]
+                 (when (> (alength encoded) max-write-bytes)
+                   (fail! :write-limit
+                          "project/edit content exceeds the write byte limit"
+                          {:limit max-write-bytes
+                           :bytes (alength encoded)}))
+                 (let [[parent leaf kind] (target-of root-canonical components
+                                                     :project/edit)
+                       abs (str parent "/" leaf)
+                       rel (relative-name components)]
+                   (cond
+                     (contains? #{:symlink :directory :other} kind)
+                     (fail! :not-file "project/edit target is not a regular file"
+                            {:path rel :kind kind})
 
-             ;; Invalid base-digest
-             :else
-             (throw (ex-info "project/edit: invalid base-digest"
-                             {:samizdat.sandbox/error :invalid-base-digest
-                              :path rel-path
-                              :base-digest base-digest})))
+                     ;; Creation: the leaf must be the ONLY thing absent.  A
+                     ;; missing parent fails here through the descent above;
+                     ;; no hierarchy is ever materialized.
+                     (and creating? (not= :absent kind))
+                     (fail! :already-exists
+                            "project/edit conflict: file exists but base was :absent"
+                            {:path rel
+                             :conflict/observed (when (= :file kind)
+                                                 (file-digest-str abs max-bytes))
+                             :bbagent/conflict true})
 
-         ;; Perform the write
-         (when-let [parent (fs/parent abs)]
-           (fs/create-dirs parent))
-         (spit abs new-content)
+                     (and (not creating?) (= :absent kind))
+                     (fail! :not-found
+                            "project/edit conflict: file does not exist"
+                            {:path rel
+                             :conflict/expected base-digest
+                             :bbagent/conflict true})
 
-         ;; Return new digest
-         (let [new-digest (file-digest-str abs)]
-           {:path rel-path
-            :digest new-digest
-            :created? (not exists?)})))})
+                     :else
+                     (do
+                       (when (and (not creating?) (= :file kind))
+                         (let [observed (file-digest-str abs max-bytes)]
+                           (when-not (= base-digest observed)
+                             (fail! :stale-conflict
+                                    "project/edit conflict: file changed since it was read"
+                                    {:path rel
+                                     :conflict/expected base-digest
+                                     :conflict/observed observed
+                                     :bbagent/conflict true}))))
+                       (files/atomic-write-file! abs encoded (not creating?))
+                       {:path rel
+                        :bytes (alength encoded)
+                        :digest (str "sha256:" (files/bytes-digest encoded))})))))))}))
 
 ;; ═══════════════════════════════════════════════════════════════════════════
 ;; Operation construction
 ;; ═══════════════════════════════════════════════════════════════════════════
 
 (defn- build-operations
-  "Build the five semantic operation descriptors."
+  "Build the five semantic operation descriptors from the resolved bounds."
   [root-canonical {:keys [max-read-chars max-list-entries
-                           max-search-results search-max-chars]}]
-  [(make-read-op  root-canonical (or max-read-chars default-max-read-chars))
-   (make-list-op  root-canonical (or max-list-entries default-max-list-entries))
+                           max-search-results search-max-chars
+                           search-max-files max-write-bytes]}]
+  [(make-read-op root-canonical (or max-read-chars default-max-read-chars))
+   (make-list-op root-canonical (or max-list-entries default-max-list-entries))
    (make-search-op root-canonical
-                     (or max-search-results default-max-search-results)
-                     (or search-max-chars default-search-max-chars))
-   (make-stat-op  root-canonical)
-   (make-edit-op  root-canonical)])
+                   (or max-search-results default-max-search-results)
+                   (or search-max-chars default-search-max-chars)
+                   (or search-max-files default-search-max-files)
+                   (or max-read-chars default-max-read-chars))
+   (make-stat-op root-canonical (or max-read-chars default-max-read-chars))
+   (make-edit-op root-canonical
+                 (or max-write-bytes default-max-write-bytes)
+                 (or max-read-chars default-max-read-chars))])
 
 (def ^:private operation-docs
   "Host-owned inert documentation for the five projected operations — the
-   same knowledge the constructors above encode, kept beside them so safe
-   discovery (operation-doc) can describe authority without evaluating any
-   form inside the sandbox."
+    same knowledge the constructors above encode, kept beside them so safe
+    discovery (operation-doc) can describe authority without evaluating any
+    form inside the sandbox.  Mirrors the frozen bb4t A2/A3b contract."
   {:project/read
    {:arglists '([rel-path])
-    :doc "Bounded read of one file under the sandbox root. Returns {:path :content :truncated}."}
+    :doc (str "Read one UTF-8 file relative to the authorized project root. "
+              "Reads at most the context's byte and character bounds and "
+              "fails when they are exceeded; invalid UTF-8 fails.  A "
+              "symbolic link is refused, not followed.  Returns the decoded "
+              "string.")}
    :project/list
-   {:arglists '([rel-path?])
-    :doc "Bounded listing of a directory under the sandbox root (default the root itself). Returns {:path :entries}."}
+   {:arglists '([rel-path])
+    :doc (str "List entries directly under one directory relative to the "
+              "authorized project root (\".\" for the root itself).  Returns "
+              "a vector of {:name :kind} sorted by name, where :kind is "
+              ":file, :directory, :symlink or :other, and files also carry "
+              ":bytes.  Exactly one level; does not follow symbolic links; "
+              "more entries than the bound fails.")}
    :project/search
-   {:arglists '([pattern rel-path?])
-    :doc "Bounded regex search under the sandbox root. Returns {:pattern :path :matches}."}
+   {:arglists '([pattern] [pattern options])
+    :doc (str "Search file contents under the authorized project root for a "
+              "regular expression (at most 200 characters).  Returns a "
+              "vector of {:path :line :text} ordered by path.  Options: "
+              "{:path \"subdir\"} to search one subtree, {:include-hidden? "
+              "true} to include dot-entries, which are skipped by default. "
+              "Does not follow symbolic links, skips files that are not "
+              "valid UTF-8, skips files larger than the per-file byte bound "
+              "without reading them, and fails past its file limit.")}
    :project/stat
    {:arglists '([rel-path])
-    :doc "Deterministic stat of one path, with content digest. Returns {:path :exists :type :size :digest}."}
+    :doc (str "Report {:path :kind :bytes :digest} for a file under the "
+              "authorized project root, {:path :kind} for a directory, "
+              "symbolic link or other entry, or {:path :kind :absent} when "
+              "it does not exist.  The :digest is the coordinate "
+              "project/edit requires as its base; if it cannot be computed "
+              "the operation fails rather than returning a fake one.")}
    :project/edit
-   {:arglists '([rel-path base-digest new-content])
-    :doc "Anchored write: base-digest is the file's current sha256:… digest, or :absent to create. A stale digest conflicts; existing files are never blindly overwritten. Returns {:path :digest :created?}."}})
+   {:arglists '([rel-path base new-content])
+    :doc (str "Replace one file's contents under the authorized project "
+              "root.  base is the file's current sha256:… digest from "
+              "project/stat, or :absent to create a file that must not "
+              "already exist.  Fails as a conflict — never overwrites — "
+              "when the file changed since that digest, exists against "
+              ":absent, or is missing against a digest.  Creates no "
+              "directories: the leaf must be the only thing absent.  Writes "
+              "through a temporary and renames atomically, so a reader "
+              "never sees a partial file.  Returns {:path :bytes :digest} "
+              "of the new content.")}})
 
 ;; ═══════════════════════════════════════════════════════════════════════════
 ;; EvaluatorSpec — inert, self-certifying coordinate
@@ -337,13 +751,16 @@
   v)
 
 (defn- resolve-bounds
-  "Validate the four bound options (defaults applied).  Fail-closed: every
+  "Validate the six bound options (defaults applied).  Fail-closed: every
    bound must be a positive integer."
-  [{:keys [max-read-chars max-list-entries max-search-results search-max-chars]}]
+  [{:keys [max-read-chars max-list-entries max-search-results search-max-chars
+           search-max-files max-write-bytes]}]
   (let [bounds {:max-read-chars (or max-read-chars default-max-read-chars)
                 :max-list-entries (or max-list-entries default-max-list-entries)
                 :max-search-results (or max-search-results default-max-search-results)
-                :search-max-chars (or search-max-chars default-search-max-chars)}]
+                :search-max-chars (or search-max-chars default-search-max-chars)
+                :search-max-files (or search-max-files default-search-max-files)
+                :max-write-bytes (or max-write-bytes default-max-write-bytes)}]
     (doseq [[k v] bounds]
       (require-positive-int! (str "bound " (name k)) v))
     bounds))
@@ -364,14 +781,15 @@
    Required opts:
      :root — trusted host root directory (string)
 
-   Optional controller attenuation / bounds:
-     :capabilities — subset of the preset's capabilities (default: the
-                     preset's exact set).  Anything beyond the preset is a
-                     fail-closed :over-request.
-     :max-read-chars / :max-list-entries / :max-search-results /
-     :search-max-chars — bounds (positive integers; defaults apply)
-     :timeout-ms — cooperative interrupt ceiling (non-negative integer;
-                   0 disables; default 30000)
+    Optional controller attenuation / bounds:
+      :capabilities — subset of the preset's capabilities (default: the
+                      preset's exact set).  Anything beyond the preset is a
+                      fail-closed :over-request.
+      :max-read-chars / :max-list-entries / :max-search-results /
+      :search-max-chars / :search-max-files / :max-write-bytes — bounds
+                      (positive integers; defaults apply)
+      :timeout-ms — cooperative interrupt ceiling (non-negative integer;
+                    0 disables; default 30000)
 
    The returned map is fully inert (jolt.sandbox receipt domain): no
    functions, atoms, or host values.  :capabilities is a sorted vector;
@@ -464,7 +882,13 @@
      ;; not to a caller thread or a DB record.  Contention fails closed rather
      ;; than letting an unrecorded evaluation pass through somebody else's
      ;; hook.
-     ::evaluation-owner (atom nil)}))
+     ::evaluation-owner (atom nil)
+     ;; Commit-only discipline: when a failed/interrupted recorded evaluation
+     ;; cannot be rolled back to the durable committed state, the live context
+     ;; is no longer a state the history can reconstruct.  The instance is
+     ;; poisoned and refuses further evaluation; only a rebuild (which forks a
+     ;; fresh, unpoisoned context) cures it.
+     ::poisoned (atom nil)}))
 
 (defn instantiate!
   "Allocate a live Instance from an inert EvaluatorSpec (controller API).
@@ -481,16 +905,17 @@
   ([spec] (instantiate! spec nil))
   ([spec {:keys [instance/key] :or {key :standalone}}]
    (let [c (context-from-spec spec)]
-     {:samizdat.sandbox/kind :instance
-      :instance/key key
-       :instance/id (str "inst:" (name key))
-       :spec spec
-       :root-canonical (:root-canonical c)
-       :timeout-ms (:timeout-ms spec)
-       :operations (:operations c)
-       ::state (::state c)
-       ::effect-hook (::effect-hook c)
-       ::evaluation-owner (::evaluation-owner c)})))
+      {:samizdat.sandbox/kind :instance
+       :instance/key key
+        :instance/id (str "inst:" (name key))
+        :spec spec
+        :root-canonical (:root-canonical c)
+        :timeout-ms (:timeout-ms spec)
+        :operations (:operations c)
+        ::state (::state c)
+        ::effect-hook (::effect-hook c)
+        ::evaluation-owner (::evaluation-owner c)
+        ::poisoned (::poisoned c)})))
 
 ;; ═══════════════════════════════════════════════════════════════════════════
 ;; Provider — JS1 acquire/bind policy
@@ -613,14 +1038,16 @@
      :profile — :agent/minimal, :agent/project-read, or
                 :agent/project-develop
 
-   Optional opts:
-     :authorized-capabilities — explicit subset of the profile's maximum
-                                (default: the profile maximum itself)
-     :max-read-chars    — bounded read limit (default 60000)
-     :max-list-entries  — bounded list limit (default 1000)
-     :max-search-results — bounded search result limit (default 500)
-     :search-max-chars  — bounded search scan limit (default 500000)
-     :timeout-ms        — cooperative interrupt ceiling (default 30000)
+    Optional opts:
+      :authorized-capabilities — explicit subset of the profile's maximum
+                                 (default: the profile maximum itself)
+      :max-read-chars    — bounded read limit (default 60000)
+      :max-list-entries  — bounded list limit (default 1000)
+      :max-search-results — bounded search result limit (default 500)
+      :search-max-chars  — bounded search scan limit (default 500000)
+      :search-max-files  — search file-count limit (default 20000)
+      :max-write-bytes   — edit write byte limit (default 1048576)
+      :timeout-ms        — cooperative interrupt ceiling (default 30000)
 
    Returns an opaque context map for use with evaluate!, rebuild!,
    describe, and capabilities."
@@ -661,7 +1088,8 @@
          :spec sp
          ::state (::state c)
          ::effect-hook (::effect-hook c)
-         ::evaluation-owner (::evaluation-owner c)}))))
+         ::evaluation-owner (::evaluation-owner c)
+         ::poisoned (::poisoned c)}))))
 
 (def ^:private authority-selection-keys
   "evaluate! is the model-facing entry: authority was fixed when the
@@ -676,7 +1104,8 @@
    bridge dynamically resolves samizdat.store.evals, keeping this namespace
    directly loadable on the small Jolt+SCI classpath.  A controller/test may
    bind a map containing :begin!, :record-intent!, :record-outcome!,
-   :complete!, :load-eval, and :verify-binding! to supply the same contract."
+   :complete!, :load-eval, :verify-binding!, and :history to supply the same
+   contract."
   nil)
 
 (def ^:private eval-store-symbols
@@ -685,7 +1114,8 @@
    :record-outcome! 'samizdat.store.evals/record-outcome!
    :complete! 'samizdat.store.evals/complete!
    :load-eval 'samizdat.store.evals/load-eval
-   :verify-binding! 'samizdat.store.evals/verify-binding!})
+   :verify-binding! 'samizdat.store.evals/verify-binding!
+   :history 'samizdat.store.evals/history})
 
 (defn- eval-store
   "Resolve the complete durable-store surface at call time.  Resolution is
@@ -722,10 +1152,41 @@
   (let [target (if (::instance x) (::instance x) x)]
     (when-not (and (::state target)
                    (::effect-hook target)
-                   (::evaluation-owner target))
+                   (::evaluation-owner target)
+                   (::poisoned target))
       (throw (ex-info (str label " needs a sandbox context, instance, or binding")
                       {:samizdat.sandbox/error :not-a-context})))
     target))
+
+(defn- check-not-poisoned!
+  "Evaluation is refused on a poisoned instance: its live context is known not
+   to be the committed state, and only a rebuild (which forks a fresh context)
+   may follow a failed rollback.  Rebuild paths deliberately do NOT call this
+   — they are the cure."
+  [target label]
+  (when @(::poisoned target)
+    (throw (ex-info (str label " refused: the instance is poisoned because a"
+                         " failed evaluation could not be rolled back to its"
+                         " committed state; rebuild it from durable history"
+                         " before evaluating")
+                    {:samizdat.sandbox/error :instance-poisoned
+                     :instance/id (:instance/id target)}))))
+
+(defn- check-current-binding!
+  "Fail closed when `binding` has been superseded in its provider registry by
+   a rebuild/rollback.  A recorded evaluation must run on the instance the
+   registry currently publishes: the durable record names stable
+   spec/instance/binding ids, so source evaluated on a superseded context
+   would append receipts a whole-history rebuild cannot have produced."
+  [binding]
+  (when-let [reg (::registry binding)]
+    (let [registered (get-in @reg [:bindings (:work-id binding)])]
+      (when (and registered
+                 (not= (::state (::instance registered))
+                       (::state (::instance binding))))
+        (throw (ex-info "Binding has been superseded by a rebuild; re-acquire it from the provider"
+                        {:samizdat.sandbox/error :stale-binding
+                         :binding/id (:binding/id binding)}))))))
 
 (defn- reject-authority-selection!
   [label opts]
@@ -801,6 +1262,7 @@
    (let [target (evaluation-target x "evaluate!")
          claim (claim-evaluation! target)]
      (try
+       (check-not-poisoned! target "evaluate!")
        (evaluate-state! target source opts)
        (finally
          (release-evaluation! target claim))))))
@@ -817,15 +1279,71 @@
   binding)
 
 (defn- binding-identity
+  "The durable identity of a binding: the three stable ids plus the versioned
+   RuntimeCoordinate of this process.  begin! stores all four (with the exact
+   authority coordinate as the fifth durable field); verify-binding! and
+   whole-history validation compare all five."
   [binding]
   {:spec-id (:spec/coordinate (:spec binding))
    :instance-id (:instance/id binding)
-   :binding-id (:binding/id binding)})
+   :binding-id (:binding/id binding)
+   :runtime (runtime-coordinate)})
 
 (defn- current-coordinate
   [target]
   (sandbox/canonical-coordinate
    (sandbox/effective-authority @(::state target))))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Bounded rendered final result
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(def ^:const max-render-chars
+  "Character bound on a rendered final result.  Only reached by non-inert
+   values; inert final values are stored exactly and never truncated."
+  8000)
+
+(def ^:const render-print-length 100)
+(def ^:const render-print-level 20)
+
+(defn- result-record
+  "The durable terminal result for an evaluation's final value.
+
+   Receipt payloads stay strict (jolt.sandbox/inert) — a receipt that cannot
+   round-trip as data is not a receipt.  The FINAL value of an evaluation is
+   different: it is the answer, not an effect, and arbitrary SCI values are
+   legitimate answers.  An inert final value is stored exactly under :value;
+   any other value (functions, floats, seqs, host objects) is accepted by
+   rendering it — printed under *print-length*/*print-level* bounds (an
+   infinite or very deep value cannot hang or explode the rendering) and then
+   character-bounded, with :render-truncated? recording whether the bound
+   cut.  Rendering is deterministic for replay verification: the same value
+   under the same RuntimeCoordinate renders to the same stored form, and a
+   value that does not (e.g. one whose printed form carries identity) fails
+   closed at replay instead of pretending a match."
+  [value]
+  (let [inert-attempt (try {:ok (sandbox/inert value)}
+                           (catch Throwable _ nil))]
+    (if (contains? inert-attempt :ok)
+      {:value (:ok inert-attempt)}
+      (let [rendered (try
+                       (binding [*print-length* render-print-length
+                                 *print-level* render-print-level]
+                         (pr-str value))
+                       (catch Throwable render-error
+                         (str "#<unrenderable " (type render-error) ">")))
+            truncated? (> (count rendered) max-render-chars)]
+        {:rendered (if truncated? (subs rendered 0 max-render-chars) rendered)
+         :render-truncated? truncated?}))))
+
+(defn- result-matches?
+  "Whether a replayed final `value` matches a durable record's terminal
+   :result — exactly for inert values, rendering-compared otherwise.  A
+   record with no structured result at all (nil) matches nothing."
+  [record value]
+  (and (some? (:result record))
+       (= (sandbox/inert (:result record))
+          (sandbox/inert (result-record value)))))
 
 (defn- run-recorded-effect!
   "Persist intent, run exactly once, then persist exactly one outcome.  A
@@ -852,18 +1370,60 @@
   ((:complete! store) conn eval-id
    {:status :failed :result {:error (str error)}}))
 
+;; Defined in the whole-history rebuild section below; rollback after a
+;; failed/interrupted recorded evaluation is the same operation.
+(declare rebuild-binding-internal!)
+
+(defn- rollback-to-committed!
+  "Roll the instance back to the binding's durable committed state after a
+   failed/interrupted recorded evaluation: rebuild from the whole committed
+   history and publish the fresh instance.  The caller holds the evaluation
+   claim, so the rebuild core runs without re-claiming.
+
+   Commit-only discipline: definitions become evaluator state only by
+   committing, so the state after a failure must be exactly the committed
+   history, never whatever partial definitions the failed source happened to
+   land.  If the rebuild cannot be completed, the live context is no longer
+   a state the durable history can reconstruct: the instance is poisoned
+   (further evaluation is refused until a rebuild cures it) and a
+   :rollback-failed error naming the original evaluation error is thrown."
+  [store conn binding target eval-id evaluation-error]
+  (try
+    (rebuild-binding-internal! store conn binding target)
+    (catch Throwable rollback-error
+      (reset! (::poisoned target) true)
+      (throw (ex-info
+              "Evaluation failed and rollback to the committed state failed; the instance is poisoned"
+              {:samizdat.sandbox/error :rollback-failed
+               :eval-id eval-id
+               :evaluation-error (str evaluation-error)}
+              rollback-error)))))
+
 (defn evaluate-recorded!
   "Evaluate source in a controller-minted Binding while appending a durable
    JS1 record to trusted `conn`.
 
    The evaluation row (spec/instance/binding ids, exact current authority
-   coordinate, and source) lands before source runs.  Every semantic operation
-   appends intent before touching the project and outcome afterward.  The
-   terminal row is appended only after evaluation returns and all outcomes have
-   settled.  Returns {:eval-id id :value value}.
+   coordinate, versioned runtime coordinate, and source) lands before source
+   runs.  Every semantic operation appends intent before touching the project
+   and outcome afterward.  The terminal row is appended only after evaluation
+   returns and all outcomes have settled.  Returns {:eval-id id :value value}.
+
+   Commit-only evaluator state: a committed evaluation's definitions persist;
+   a failed or interrupted evaluation leaves the instance rolled back —
+   rebuilt from the binding's durable committed history and republished —
+   before the original error propagates, so partial definitions of failed
+   source never become evaluator state.
+
+   The final value may be any SCI value: inert values are stored exactly,
+   anything else is stored as a bounded rendering (see result-record).
+   Receipt payloads remain strict.
 
    If an outcome append fails after an operation, completion also fails closed
-   and the durable record remains pending with its unsettled intent."
+   and the durable record remains pending with its unsettled intent.  If the
+   :failed terminal row itself cannot be appended, the record likewise stays
+   pending and the instance is poisoned: a pending record blocks whole-history
+   rebuild, so the dirty context has no cure and must refuse evaluation."
   ([conn binding source] (evaluate-recorded! conn binding source nil))
   ([conn binding source opts]
    (require-binding! binding "evaluate-recorded!")
@@ -872,6 +1432,8 @@
          target (evaluation-target binding "evaluate-recorded!")
          claim (claim-evaluation! target)]
      (try
+       (check-not-poisoned! target "evaluate-recorded!")
+       (check-current-binding! binding)
        (let [identity (binding-identity binding)
              eval-id ((:begin! store) conn
                       (assoc identity
@@ -884,9 +1446,7 @@
          (try
            (let [outcome (try
                            (let [value (evaluate-state! target source opts)]
-                             {:ok true
-                              :value value
-                              :inert-value (sandbox/inert value)})
+                             {:ok true :value value})
                            (catch Throwable evaluation-error
                              {:ok false :error evaluation-error}))]
              (if (:ok outcome)
@@ -896,17 +1456,20 @@
                  ;; leave the original record pending.
                  ((:complete! store) conn eval-id
                   {:status :completed
-                   :result {:value (:inert-value outcome)}})
+                   :result (result-record (:value outcome))})
                  {:eval-id eval-id :value (:value outcome)})
                (let [evaluation-error (:error outcome)]
                  (try
                    (complete-failed-evaluation! store conn eval-id evaluation-error)
                    (catch Throwable completion-error
+                     (reset! (::poisoned target) true)
                      (throw (ex-info
-                             "Evaluation failed and its durable record could not be completed; the record remains pending"
+                             "Evaluation failed and its durable record could not be completed; the record remains pending and the instance is poisoned"
                              {:samizdat.sandbox/error :durable-evaluation-incomplete
                               :eval-id eval-id}
                              completion-error))))
+                 (rollback-to-committed! store conn binding target
+                                         eval-id evaluation-error)
                  (throw evaluation-error))))
            (finally
              (reset! hook nil))))
@@ -957,7 +1520,8 @@
 (defn- fresh-target
   "Allocate an independent context from the same spec, attenuated to the
    source target's current authority.  It intentionally does not publish into
-   a provider registry until replay has succeeded exactly."
+   a provider registry until replay has succeeded exactly.  The fresh context
+   is never poisoned: a rebuild is the cure for a poisoned instance."
   [target]
   (let [c (context-from-spec (:spec target))
         old-state @(::state target)
@@ -968,7 +1532,8 @@
                      :operations (:operations c)
                      ::state (::state c)
                      ::effect-hook (::effect-hook c)
-                     ::evaluation-owner (::evaluation-owner c))]
+                     ::evaluation-owner (::evaluation-owner c)
+                     ::poisoned (::poisoned c))]
     (doseq [capability (remove authorized (set (:capabilities (:spec target))))]
       (sandbox/revoke! fresh-state capability))
     fresh))
@@ -1049,12 +1614,8 @@
               state @(::state fresh-instance)]
           (sandbox/load-receipts! state receipts)
           (sandbox/set-mode! state :replay)
-          (let [value (evaluate-state! fresh-instance (:source record) nil)
-                inert-value (sandbox/inert value)
-                result (:result record)]
-            (when-not (and (map? result)
-                           (contains? result :value)
-                           (= (sandbox/inert (:value result)) inert-value))
+          (let [value (evaluate-state! fresh-instance (:source record) nil)]
+            (when-not (result-matches? record value)
               (throw (ex-info "Replayed source result does not match its durable completion"
                               {:samizdat.sandbox/error :replay-result-mismatch
                                :eval-id eval-id})))
@@ -1064,6 +1625,141 @@
             (sandbox/load-receipts! state [])
             (sandbox/set-mode! state :normal)
             (publish-recorded-rebuild! binding fresh-instance))))
+      (finally
+        (release-evaluation! target claim)))))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Whole-history rebuild — one fresh SCI context from the committed record
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- check-single-recorded-binding!
+  "Whole-history rebuild reconstructs the INSTANCE from ONE binding's durable
+   history, which is sound only when that binding is the instance's sole
+   recorded binding — the JS1 provider policy (one work-id per instance key;
+   a controller needing isolation passes a distinct :instance/key).  A
+   provider registry showing a second binding on the same instance key fails
+   closed: replaying one binding's history would silently drop the sibling's
+   committed definitions."
+  [binding]
+  (when-let [reg (::registry binding)]
+    (let [siblings (->> (:bindings @reg)
+                        vals
+                        (filter #(= (:instance/key binding) (:instance/key %)))
+                        (map :binding/id)
+                        distinct
+                        vec)]
+      (when (< 1 (count siblings))
+        (throw (ex-info "Instance is shared by multiple bindings; one binding's durable history cannot rebuild it"
+                        {:samizdat.sandbox/error :shared-instance
+                         :instance/key (:instance/key binding)
+                         :binding-ids siblings}))))))
+
+(defn- validate-history!
+  "Fail-closed validation of a binding's durable evaluation history before any
+   of it is trusted as replay material:
+
+     - the total order is contiguous from 0 (a gap is a torn record);
+     - no record is pending (an unfinished evaluation's actuations may or may
+       not have happened — the honest answer is refusal, and an unsettled
+       effect intent inside one is the same refusal one level down);
+     - every record — replayed or not — names exactly this spec, instance,
+       binding, current authority coordinate, and current runtime coordinate."
+  [identity coordinate rows]
+  (when-not (= (mapv :binding_seq rows) (vec (range (count rows))))
+    (throw (ex-info "Durable evaluation history is not a contiguous total order from 0"
+                    {:samizdat.sandbox/error :malformed-history
+                     :binding-seqs (mapv :binding_seq rows)})))
+  (let [expected {:spec_id (str (:spec-id identity))
+                  :instance_id (str (:instance-id identity))
+                  :binding_id (str (:binding-id identity))
+                  :coordinate (str coordinate)
+                  :runtime (str (:runtime identity))}]
+    (doseq [record rows]
+      (when (= :pending (:status record))
+        (throw (ex-info "Durable evaluation history contains a pending record; its actuations may or may not have happened"
+                        {:samizdat.sandbox/error :pending-history
+                         :eval-id (:id record)
+                         :binding_seq (:binding_seq record)})))
+      (when-not (= expected (select-keys record (keys expected)))
+        (throw (ex-info "Durable evaluation record does not match this binding's spec, instance, binding, coordinate, or runtime"
+                        {:samizdat.sandbox/error :history-mismatch
+                         :eval-id (:id record)
+                         :expected expected
+                         :actual (select-keys record (keys expected))}))))))
+
+(defn- replay-one-record!
+  "Replay one validated completed record into the fresh instance: its exact
+   durable receipts in, its source evaluated in :replay mode — so every
+   operation is served from the receipts and ZERO real project operations
+   execute — then its replayed final value checked against the durable
+   terminal result.  jolt.sandbox itself fails replay on operation or
+   argument mismatch and on unconsumed receipts."
+  [fresh-instance record]
+  (let [state @(::state fresh-instance)
+        receipts (replay-receipts fresh-instance record)]
+    (sandbox/load-receipts! state receipts)
+    (sandbox/set-mode! state :replay)
+    (let [value (evaluate-state! fresh-instance (:source record) nil)]
+      (when-not (result-matches? record value)
+        (throw (ex-info "Replayed source result does not match its durable completion"
+                        {:samizdat.sandbox/error :replay-result-mismatch
+                         :eval-id (:id record)}))))))
+
+(defn- rebuild-binding-internal!
+  "Whole-history rebuild core, shared by rebuild-binding! and the
+   commit-only rollback path: validate the binding's durable history against
+   its current identity, then replay EVERY committed evaluation, in the
+   binding's total order, into ONE fresh SCI context, and publish the fresh
+   instance only after every replay has matched exactly.  Failed evaluations
+   are validated but not replayed — their definitions never committed.
+   Returns the rebuilt Binding.  The caller must hold the evaluation claim
+   on `target`."
+  [store conn binding target]
+  (check-single-recorded-binding! binding)
+  (let [identity (binding-identity binding)
+        coordinate (current-coordinate target)
+        rows ((:history store) conn (:binding/id binding))]
+    ;; Validation is complete before the fresh context is allocated: nothing
+    ;; the history says is trusted until every record has checked out.
+    (validate-history! identity coordinate rows)
+    (let [fresh-instance (fresh-target target)
+          state @(::state fresh-instance)]
+      (doseq [record rows]
+        (when (= :completed (:status record))
+          (replay-one-record! fresh-instance record)))
+      ;; Historical evidence remains in the DB, not in the now-live context.
+      ;; Clearing it also prevents a later mode change from accidentally
+      ;; treating history as a new replay program.
+      (sandbox/load-receipts! state [])
+      (sandbox/set-mode! state :normal)
+      (publish-recorded-rebuild! binding fresh-instance))))
+
+(defn rebuild-binding!
+  "Rebuild `binding`'s instance from its WHOLE durable committed history:
+   every committed evaluation for the binding, in the binding's durable
+   total order, replayed into ONE fresh SCI context.  Returns the rebuilt
+   Binding.
+
+   Zero real project operations execute: replay runs in jolt.sandbox :replay
+   mode throughout, so every observation and actuation is served from the
+   exact durable receipts of its original evaluation.  Before any record is
+   trusted, the whole history is validated — contiguous total order, no
+   pending records, and per-record spec/instance/binding identity plus exact
+   authority and runtime coordinates — and any gap, pending record, shared
+   instance, or mismatch fails closed.  Each replayed evaluation must also
+   reproduce its durable terminal result exactly.
+
+   A binding with no recorded history rebuilds to a fresh empty context.
+   This supersedes rebuild-recorded! (which replays a single evaluation)
+   whenever definitions span evaluations: it is the resume/reconcile
+   operation, and it is what rollback after a failed evaluation runs."
+  [conn binding]
+  (require-binding! binding "rebuild-binding!")
+  (let [store (eval-store)
+        target (evaluation-target binding "rebuild-binding!")
+        claim (claim-evaluation! target)]
+    (try
+      (rebuild-binding-internal! store conn binding target)
       (finally
         (release-evaluation! target claim)))))
 
@@ -1127,17 +1823,19 @@
      :jolt.sandbox/authorized — authorized capability IDs
      :jolt.sandbox/operations — authorized operation descriptors
 
-   JS1 seam coordinates:
-     :samizdat.sandbox/kind — :context / :instance / :binding
-     :samizdat.sandbox/root-canonical — the trusted root
-     :samizdat.sandbox/timeout-ms — the configured ceiling
-     :samizdat.sandbox/bounds — the four bounds
-     :samizdat.sandbox/preset — the trusted preset (catalog specs only)
-     :samizdat.sandbox/spec-coordinate — the inert js1: content coordinate
-     :samizdat.sandbox/instance-key / :samizdat.sandbox/instance-id
-       (instances and bindings)
-     :samizdat.sandbox/binding-id / :samizdat.sandbox/work-id
-       (bindings only)"
+    JS1 seam coordinates:
+      :samizdat.sandbox/kind — :context / :instance / :binding
+      :samizdat.sandbox/root-canonical — the trusted root
+      :samizdat.sandbox/timeout-ms — the configured ceiling
+       :samizdat.sandbox/bounds — the six bounds
+      :samizdat.sandbox/preset — the trusted preset (catalog specs only)
+      :samizdat.sandbox/spec-coordinate — the inert js1: content coordinate
+      :samizdat.sandbox/runtime-coordinate — the versioned js1-rt/v1:
+        RuntimeCoordinate of this process
+      :samizdat.sandbox/instance-key / :samizdat.sandbox/instance-id
+        (instances and bindings)
+      :samizdat.sandbox/binding-id / :samizdat.sandbox/work-id
+        (bindings only)"
   [x]
   (let [binding (when (::instance x) x)
         target (if binding (::instance x) x)
@@ -1153,7 +1851,8 @@
                   :samizdat.sandbox/root-canonical (:root-canonical target)
                   :samizdat.sandbox/timeout-ms (:timeout-ms target)
                   :samizdat.sandbox/bounds (:bounds spec)
-                  :samizdat.sandbox/spec-coordinate (:spec/coordinate spec))
+                  :samizdat.sandbox/spec-coordinate (:spec/coordinate spec)
+                  :samizdat.sandbox/runtime-coordinate (runtime-coordinate))
           (:preset spec)
           (assoc :samizdat.sandbox/preset (:preset spec))
           (:instance/id target)
@@ -1206,39 +1905,156 @@
       (when (re-matches #"[A-Za-z0-9*+!_'?<>=./-]+" s)
         (keyword s)))))
 
-(defn operation-doc
-  "Host-derived safe capability discovery for `doc`: an inert doc-style map
-   for the projected operation named by `sym` (e.g. \"project/read\"), or
-   nil when no authorized operation matches.
+(def ^:private reviewed-surface*
+  "The reviewed pure language surface as trusted static data —
+   jolt.sandbox/language-surface (Jolt 619ef196): derived solely from the
+   reviewed static allow-list, inert and canonical, with no live SCI
+   Context, no introspection, and no host handles.  Cached: the surface is
+   a constant of the runtime the RuntimeCoordinate already names."
+  (delay (:jolt.sandbox.surface/symbols (sandbox/language-surface))))
 
-   Derived ONLY from the target's effective authority (describe) plus the
-   host-owned operation-docs table.  No resolve/find-ns/ns-publics/meta
-   form is ever evaluated inside the sandbox: the sandbox vocabulary
+(defn- reviewed-symbols
+  "The reviewed pure symbol-name strings, sorted."
+  []
+  @reviewed-surface*)
+
+(defn- reviewed-symbol?
+  "Whether `s` names a symbol of the reviewed pure language surface."
+  [s]
+  (boolean (some #{s} (reviewed-symbols))))
+
+(def ^:private pure-symbol-docs
+  "Host-owned inert documentation for the reviewed pure symbols models ask
+   about most, keyed by surface symbol name.  The language surface carries
+   names, not docs, by design — this is the host's documentation database
+   the surface description names.  Absent entries get the generic
+   reviewed-surface doc; nothing here grants or attests authority."
+  {"map" {:arglists '([f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])
+          :doc "Returns the lazy sequence of applying f to each item in the coll(s)."}
+   "mapv" {:arglists '([f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])
+           :doc "Applies f to each item in the coll(s), eagerly into a vector."}
+   "filter" {:arglists '([pred coll])
+             :doc "Returns the lazy sequence of items of coll for which (pred item) is true."}
+   "filterv" {:arglists '([pred coll])
+              :doc "Returns a vector of items of coll for which (pred item) is true."}
+   "reduce" {:arglists '([f coll] [f init coll])
+             :doc "Accumulates f over coll, optionally starting from init."}
+   "mapcat" {:arglists '([f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])
+             :doc "Applies f to each item of the coll(s) and concatenates the results."}
+   "first" {:arglists '([coll]) :doc "The first item of coll, or nil if empty."}
+   "rest" {:arglists '([coll]) :doc "The items of coll after the first; empty seq if none."}
+   "last" {:arglists '([coll]) :doc "The last item of coll, in linear time."}
+   "count" {:arglists '([coll]) :doc "The number of items in coll."}
+   "take" {:arglists '([n coll]) :doc "The lazy sequence of the first n items of coll."}
+   "drop" {:arglists '([n coll]) :doc "The lazy sequence of all but the first n items of coll."}
+   "nth" {:arglists '([coll index] [coll index not-found])
+          :doc "The item at index of coll, or not-found when out of range."}
+   "str" {:arglists '([& xs]) :doc "Concatenates the string forms of xs, with no separators."}
+   "subs" {:arglists '([s start] [s start end])
+           :doc "The substring of s from start (inclusive) to end (defaults to the end)."}
+   "split-at" {:arglists '([n coll])
+               :doc "A pair [(take n coll) (drop n coll)]."}
+   "sort" {:arglists '([coll] [comp coll])
+           :doc "A sorted sequence of coll's items, optionally by comparator."}
+   "sort-by" {:arglists '([keyfn coll] [keyfn comp coll])
+              :doc "A sorted sequence of coll's items by (keyfn item)."}
+   "assoc" {:arglists '([map key val] [map key val & kvs])
+            :doc "Associates key with val in map, later pairs winning."}
+   "dissoc" {:arglists '([map key] [map key & ks])
+             :doc "Dissociates the keys from map."}
+   "get" {:arglists '([map key] [map key not-found])
+          :doc "The value for key in map, or not-found."}
+   "merge" {:arglists '([& maps])
+            :doc "Merges the maps left to right, later entries winning."}
+   "select-keys" {:arglists '([map keyseq])
+                  :doc "A map of only the entries of map whose keys are in keyseq."}
+   "defn" {:arglists '([name doc-string? attr-map? [params*] prepost-map? body])
+           :doc "Defines a function. Pure here: the sandbox vocabulary reaches nothing."}
+   "let" {:arglists '([bindings & body])
+          :doc "Binding => binding-form init-expr; evaluates body with the bindings."}
+   "if-let" {:arglists '([binding then] [binding then else])
+             :doc "Binds the test's value when truthy, evaluating then, else else."}
+   "cond" {:arglists '([& clauses])
+           :doc "Takes test/expr pairs; evaluates the expr of the first truthy test."}
+   "range" {:arglists '([] [end] [start end] [start end step])
+            :doc "A lazy sequence of numbers from start (0) to end by step (1)."}
+   "vec" {:arglists '([coll]) :doc "Creates a vector containing the items of coll."}
+   "vector" {:arglists '([& xs]) :doc "Creates a vector of the arguments."}
+   "set" {:arglists '([coll]) :doc "Creates a set containing the distinct items of coll."}
+   "frequencies" {:arglists '([coll])
+                  :doc "A map from the distinct items of coll to their counts."}
+   "group-by" {:arglists '([f coll])
+               :doc "A map from (f item) to the vectors of items producing it."}
+   "distinct" {:arglists '([coll])
+               :doc "The lazy sequence of coll's items with duplicates removed."}
+   "apply" {:arglists '([f args] [f x args] [f x y args] [f x y z args] [f a b c d & more])
+            :doc "Applies f to the arguments, splicing the final coll's items in."}
+   "partial" {:arglists '([f] [f arg1] [f arg1 arg2] [f arg1 arg2 arg3] [f arg1 arg2 arg3 & more])
+              :doc "A partially applied f with the given arguments fixed."}
+   "comp" {:arglists '([& fs]) :doc "Composes the functions right to left."}
+   "pr-str" {:arglists '([& xs]) :doc "Prints the arguments to a string."}
+   "format" {:arglists '([fmt & args])
+             :doc "Formats args per the java.util.Formatter-style fmt string."}
+   "name" {:arglists '([x]) :doc "The name string of a string, symbol or keyword."}
+   "keyword" {:arglists '([x] [ns x]) :doc "A keyword from the name (and namespace)."}
+   "symbol" {:arglists '([name] [ns name]) :doc "A symbol from the name (and namespace)."}})
+
+(defn- reviewed-symbol-doc
+  "The inert doc map for one reviewed pure symbol: the host-owned curated
+   entry when there is one, otherwise the generic reviewed-surface doc."
+  [s]
+  (if-let [curated (get pure-symbol-docs s)]
+    {:name s
+     :arglists (vec (:arglists curated))
+     :doc (str (:doc curated) "  Effect: pure.")}
+    {:name s
+     :doc (str "Reviewed pure language-surface symbol (js0-pure-sci): computes "
+               "over inert values and reaches nothing — no IO, no state, no "
+               "host access.  Part of the frozen reviewed vocabulary named by "
+               "the runtime coordinate.  Effect: pure.")}))
+
+(defn operation-doc
+  "Host-derived safe discovery for `doc`: an inert doc-style map for the
+   projected operation named by `sym` (e.g. \"project/read\"), or for a
+   symbol of the reviewed pure language surface (e.g. \"map\"), or nil.
+
+   The answer is the UNION the model can actually call: effective project
+   operations (from the target's describe map plus the host-owned
+   operation-docs table) and pure reviewed symbols (from
+   jolt.sandbox/language-surface — trusted static data with a versioned
+   coordinate, never a live SCI Context).  No resolve/find-ns/ns-publics/
+   meta form is ever evaluated inside the sandbox: the sandbox vocabulary
    forbids them, and splicing untrusted symbol text into evaluated source
    would be an injection seam, so discovery never evaluates at all — the
    symbol text is matched as inert data.  Ungranted capabilities are not
-   discoverable."
+   discoverable, and no doc attests anything the target cannot do."
   [x sym]
   (when-let [cap (discovery-symbol sym)]
     (let [d (describe-for-discovery x)
           ;; :op/id is the string form ":project/read"; re-keyword it.
           op (some (fn [o] (when (= cap (keyword (subs (:op/id o) 1))) o))
                    (:jolt.sandbox/operations d))]
-      (when op
-        (let [docs (or (get operation-docs cap) {})]
-          {:name (str "project/" (:op/name op))
-           :arglists (vec (or (:arglists docs) '([& args])))
-           :doc (str (:doc docs)
-                     "  Effect: " (name (:op/effect op)) ".")})))))
+      (or (when op
+            (let [docs (or (get operation-docs cap) {})]
+              {:name (str "project/" (:op/name op))
+               :arglists (vec (or (:arglists docs) '([& args])))
+               :doc (str (:doc docs)
+                         "  Effect: " (name (:op/effect op)) ".")}))
+          (let [s (name cap)]
+            (when (reviewed-symbol? s)
+              (reviewed-symbol-doc s)))))))
 
 (defn complete-capability
-  "Host-derived safe capability discovery for `complete`: the sorted
-   projected operation names (\"project/…\") authorized for `x` whose full
-   name starts with `prefix`.  Pure filtering over effective authority —
-   nothing is evaluated inside the sandbox, so untrusted prefix text can
-   only narrow the answer, never widen it or run."
+  "Host-derived safe discovery for `complete`: the sorted names `x`'s
+   evaluation can actually resolve, filtered by `prefix` — the UNION of the
+   authorized projected operation names (\"project/…\") and the reviewed
+   pure language surface's symbol names.  Both corpora are inert data
+   (effective authority and jolt.sandbox/language-surface); nothing is
+   evaluated inside the sandbox, so untrusted prefix text can only narrow
+   the answer, never widen it or run."
   [x prefix]
   (let [p (str prefix)]
     (vec (sort (filter #(str/starts-with? % p)
-                       (map (fn [cap] (str "project/" (name cap)))
-                            (capabilities x)))))))
+                       (concat (map (fn [cap] (str "project/" (name cap)))
+                                    (capabilities x))
+                               (reviewed-symbols)))))))

--- a/src/samizdat/agent/sandbox.clj
+++ b/src/samizdat/agent/sandbox.clj
@@ -1,0 +1,1244 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.agent.sandbox
+  "JS1 bounded evaluator seam: EvaluatorSpec / Instance / Binding.
+
+   Three distinct coordinates, never conflated:
+
+     EvaluatorSpec — INERT data (jolt.sandbox receipt domain): preset,
+       profile, canonical root, sorted capabilities, bounds, timeout, and
+       :spec/coordinate, a deterministic self-certifying content coordinate
+       covering all of them (\"js1:\" + the JS0 canonical form).  Safe to
+       serialize, compare, and re-verify.
+
+     Instance — a LIVE jolt.sandbox context allocated from a spec, with a
+       stable :instance/id (\"inst:\" (name key)) that survives rebuild!
+       and a policy-assigned :instance/key.
+
+     Binding — the association of a work-id to an instance, minted by the
+       provider.  :binding/id is deterministic (\"bind:<key>:<work-id>\");
+       the map's identity fields are inert, plus the live instance ref.
+
+    Trust boundary: the controller owns spec/instantiate!/provider/acquire!/
+    bind!.  Model-facing evaluation is evaluate!/describe/capabilities
+    (and the host-derived discovery in operation-doc/complete-capability)
+    on a minted value — evaluate! REJECTS any profile/preset/capability/
+    root/instance-key option: authority is fixed at bind time, and the
+    preset catalog is closed, so a model cannot select or widen authority.
+
+   JS1 provider policy: ordinary work binds deterministically to one
+   persistent instance key, :main.  A controller that needs isolation
+   passes a distinct :instance/key and gets a separate live context.
+
+   Presets (trusted, closed catalog — see `presets`):
+     :project/read    — :agent/project-read,  capabilities read/list/search/stat
+     :project/develop — :agent/project-develop, read/list/search/stat + edit
+
+   Five semantic ops projected as project/read, project/list,
+   project/search, project/stat, project/edit — all rooted at the trusted
+   host root with relative nonescaping paths, symlink escape prevention,
+   bounded reads, deterministic digest stat, and anchored edit
+   (base-digest or :absent, stale conflict detection, no blind overwrite).
+   All returned data is inert/canonical via jolt.sandbox.
+
+   Timeout uses Jolt cooperative interrupt with an unraiseable host
+   ceiling: jolt.host/run-interruptible checks the token from the host
+   side; SCI code cannot catch or suppress the interruption.
+
+   Legacy direct API (preserved): new / evaluate! / rebuild! / describe.
+   Note: the original draft named the constructor `registry/new`; under
+   Jolt a multi-segment defn name interns under its final segment, so it
+   was always callable only as plain `new` — that name is kept.
+
+   See samizdat.sandbox-test docstring for the direct invocation.
+
+   Blockers:
+     - jolt.sandbox requires SCI (sci.core) - not available on plain JVM.
+     - jolt.host/run-interruptible and make-interrupt are Jolt host fns."
+  (:require [clojure.string :as str]
+            [jolt.fs :as fs]
+            [jolt.sandbox :as sandbox]
+            [samizdat.agent.files :as files]))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Defaults
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(def ^:const default-max-read-chars 60000)
+(def ^:const default-max-list-entries 1000)
+(def ^:const default-max-search-results 500)
+(def ^:const default-search-max-chars 500000)
+(def ^:const default-timeout-ms 30000)
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Trusted preset catalog (closed)
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(def presets
+  "Trusted, closed catalog of named JS1 evaluator presets.  Only controller
+   code selects a preset (via spec/bind!); the model-facing evaluation path
+   never accepts a profile, capability, or preset selection.  Each preset
+   fixes the exact jolt.sandbox profile and the exact maximum capability
+   set; a controller may only attenuate (narrow) from here, never widen."
+  {:project/read
+   {:preset/id :project/read
+    :profile :agent/project-read
+    :capabilities #{:project/read :project/list :project/search :project/stat}}
+   :project/develop
+   {:preset/id :project/develop
+    :profile :agent/project-develop
+    :capabilities #{:project/read :project/list :project/search :project/stat
+                    :project/edit}}})
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Path resolution (symlink-safe, fail-closed)
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- resolve-root
+  "Resolve root to its canonical absolute path string."
+  [root]
+  (str (fs/canonicalize root)))
+
+(defn- resolve-under-root
+  "Resolve relative path under canonical root. Returns the absolute
+   path, or nil if the path escapes, is blank, or causes any I/O error.
+   Canonicalize follows symlinks so any chain that lands outside root
+   is caught.  For non-existing leaf paths the existing prefix is
+   resolved; a symlink in that prefix that points outside root is
+   still caught because canonicalize resolves it before appending the
+   remaining (non-existing) segments."
+  [root-canonical path]
+  (when (and (string? path) (not (str/blank? path)))
+    (try
+      (let [target (str (fs/canonicalize (fs/path root-canonical path)))]
+        (when (or (= target root-canonical)
+                  (str/starts-with? target (str root-canonical "/")))
+          target))
+      (catch Exception _ nil))))
+
+(defn- require-under-root!
+  "Resolve relative path under canonical root; throws on escape or
+   missing path with {:samizdat.sandbox/error} in ex-data."
+  [root-canonical rel-path label]
+  (if-let [abs (resolve-under-root root-canonical rel-path)]
+    abs
+    (throw (ex-info (str label ": path escapes root or is invalid: " rel-path)
+                    {:samizdat.sandbox/error :path-escape
+                     :path rel-path}))))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Digest
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- file-digest-str
+  "SHA-256 hex digest string prefixed with 'sha256:', or nil."
+  [abs-path]
+  (when-let [hex (files/file-digest abs-path)]
+    (str "sha256:" hex)))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Operation descriptors
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- make-read-op
+  "project/read — bounded file read. Returns {:path :content :truncated}"
+  [root-canonical max-chars]
+  {:id :project/read :name 'read :effect :observation
+   :fn (fn [rel-path]
+         (let [abs (require-under-root! root-canonical rel-path "project/read")]
+           (when-not (fs/regular-file? abs {:nofollow-links true})
+             (throw (ex-info "project/read: not a regular file"
+                             {:samizdat.sandbox/error :not-file :path rel-path})))
+           (let [content (slurp abs)
+                 truncated? (> (count content) max-chars)
+                 shown (if truncated? (subs content 0 max-chars) content)]
+             {:path rel-path :content shown :truncated truncated?})))})
+
+(defn- make-list-op
+  "project/list — bounded directory listing.
+   Optional rel-path argument defaults to the root."
+  [root-canonical max-entries]
+  {:id :project/list :name 'list :effect :observation
+   :fn (fn [& args]
+         (let [rel-path (or (first args) ".")
+               abs (resolve-under-root root-canonical rel-path)]
+           (if (and abs (fs/directory? abs {:nofollow-links true}))
+             {:path rel-path
+              :entries (files/safe-list-dir root-canonical rel-path max-entries)}
+             {:path rel-path :entries []})))})
+
+(defn- make-search-op
+  "project/search — bounded regex search. Returns {:pattern :matches}."
+  [root-canonical max-results max-chars]
+  {:id :project/search :name 'search :effect :observation
+   :fn (fn [pattern & args]
+         (let [rel-path (or (first args) ".")]
+           {:pattern pattern
+            :path rel-path
+            :matches (files/safe-search-files
+                       root-canonical rel-path pattern max-results max-chars)}))})
+
+(defn- make-stat-op
+  "project/stat — deterministic stat with coordinate/digest.
+   Returns {:path :exists :type :size :digest}."
+  [root-canonical]
+  {:id :project/stat :name 'stat :effect :observation
+   :fn (fn [rel-path]
+         (if-let [abs (resolve-under-root root-canonical rel-path)]
+           (let [exists? (fs/exists? abs {:nofollow-links true})]
+             (if exists?
+               (let [sym? (fs/sym-link? abs)
+                     dir? (fs/directory? abs {:nofollow-links true})
+                     reg? (and (not sym?) (not dir?) (fs/regular-file? abs))
+                     type (cond sym? :symlink dir? :dir reg? :file)
+                     size (when reg? (fs/size abs))
+                     digest (when reg? (file-digest-str abs))]
+                 {:path rel-path :exists true :type type
+                  :size size :digest digest})
+               {:path rel-path :exists false}))
+           {:path rel-path :exists false}))})
+
+(defn- make-edit-op
+  "project/edit — anchored edit requiring base digest or :absent.
+
+   Args: [rel-path base-digest new-content]
+
+   - base-digest is a sha256:… string (for an existing file) or :absent / nil
+     (for creation).  A string base-digest on a non-existing file, or
+     :absent on an existing file, is a conflict.
+   - Stale conflict: file exists but its current digest ≠ base-digest.
+   - No blind overwrite: base-digest must be supplied when the file exists.
+   - Returns {:path :digest :created?}"
+  [root-canonical]
+  {:id :project/edit :name 'edit :effect :actuation
+   :fn (fn [rel-path base-digest new-content]
+         (let [abs (require-under-root! root-canonical rel-path "project/edit")
+               new-content (str new-content)
+               exists? (fs/exists? abs {:nofollow-links true})
+               creating? (or (nil? base-digest) (= :absent base-digest))]
+           (cond
+             ;; Creation path
+             creating?
+             (when exists?
+               (throw (ex-info "project/edit: file already exists"
+                               {:samizdat.sandbox/error :already-exists
+                                :path rel-path
+                                :actual-digest (file-digest-str abs)})))
+
+             ;; Update path — base-digest must be a string
+              (string? base-digest)
+              (do
+                (when (not exists?)
+                  (throw (ex-info "project/edit: file does not exist"
+                                  {:samizdat.sandbox/error :not-found
+                                   :path rel-path})))
+                (let [current-digest (file-digest-str abs)]
+                  (when (not= base-digest current-digest)
+                    (throw (ex-info "project/edit: stale conflict"
+                                    {:samizdat.sandbox/error :stale-conflict
+                                     :path rel-path
+                                     :expected base-digest
+                                     :actual current-digest})))))
+
+             ;; Invalid base-digest
+             :else
+             (throw (ex-info "project/edit: invalid base-digest"
+                             {:samizdat.sandbox/error :invalid-base-digest
+                              :path rel-path
+                              :base-digest base-digest})))
+
+         ;; Perform the write
+         (when-let [parent (fs/parent abs)]
+           (fs/create-dirs parent))
+         (spit abs new-content)
+
+         ;; Return new digest
+         (let [new-digest (file-digest-str abs)]
+           {:path rel-path
+            :digest new-digest
+            :created? (not exists?)})))})
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Operation construction
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- build-operations
+  "Build the five semantic operation descriptors."
+  [root-canonical {:keys [max-read-chars max-list-entries
+                           max-search-results search-max-chars]}]
+  [(make-read-op  root-canonical (or max-read-chars default-max-read-chars))
+   (make-list-op  root-canonical (or max-list-entries default-max-list-entries))
+   (make-search-op root-canonical
+                     (or max-search-results default-max-search-results)
+                     (or search-max-chars default-search-max-chars))
+   (make-stat-op  root-canonical)
+   (make-edit-op  root-canonical)])
+
+(def ^:private operation-docs
+  "Host-owned inert documentation for the five projected operations — the
+   same knowledge the constructors above encode, kept beside them so safe
+   discovery (operation-doc) can describe authority without evaluating any
+   form inside the sandbox."
+  {:project/read
+   {:arglists '([rel-path])
+    :doc "Bounded read of one file under the sandbox root. Returns {:path :content :truncated}."}
+   :project/list
+   {:arglists '([rel-path?])
+    :doc "Bounded listing of a directory under the sandbox root (default the root itself). Returns {:path :entries}."}
+   :project/search
+   {:arglists '([pattern rel-path?])
+    :doc "Bounded regex search under the sandbox root. Returns {:pattern :path :matches}."}
+   :project/stat
+   {:arglists '([rel-path])
+    :doc "Deterministic stat of one path, with content digest. Returns {:path :exists :type :size :digest}."}
+   :project/edit
+   {:arglists '([rel-path base-digest new-content])
+    :doc "Anchored write: base-digest is the file's current sha256:… digest, or :absent to create. A stale digest conflicts; existing files are never blindly overwritten. Returns {:path :digest :created?}."}})
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; EvaluatorSpec — inert, self-certifying coordinate
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- spec-coordinate
+  "Deterministic content coordinate for an inert EvaluatorSpec: the JS0
+   canonical form recomputed over the spec (sans :spec/coordinate),
+   retagged for the JS1 seam.  The coordinate covers preset, profile,
+   canonical root, capabilities, bounds, and timeout.  It is
+   self-certifying: instantiate!/acquire! recompute and compare before
+   allocating authority."
+  [inert-spec]
+  (let [c (sandbox/canonical-coordinate (dissoc inert-spec :spec/coordinate))]
+    (when-not (str/starts-with? c "js0:")
+      (throw (ex-info "Unexpected JS0 canonical coordinate form"
+                      {:samizdat.sandbox/error :coordinate})))
+    (str "js1:" (subs c 4))))
+
+(defn- require-positive-int! [label v]
+  (when-not (and (integer? v) (pos? v))
+    (throw (ex-info (str label " must be a positive integer, got: " (pr-str v))
+                    {:samizdat.sandbox/error :invalid-bound
+                     :value (pr-str v)})))
+  v)
+
+(defn- resolve-bounds
+  "Validate the four bound options (defaults applied).  Fail-closed: every
+   bound must be a positive integer."
+  [{:keys [max-read-chars max-list-entries max-search-results search-max-chars]}]
+  (let [bounds {:max-read-chars (or max-read-chars default-max-read-chars)
+                :max-list-entries (or max-list-entries default-max-list-entries)
+                :max-search-results (or max-search-results default-max-search-results)
+                :search-max-chars (or search-max-chars default-search-max-chars)}]
+    (doseq [[k v] bounds]
+      (require-positive-int! (str "bound " (name k)) v))
+    bounds))
+
+(defn- resolve-timeout
+  [timeout-ms]
+  (let [timeout (or timeout-ms default-timeout-ms)]
+    (when-not (and (integer? timeout) (not (neg? timeout)))
+      (throw (ex-info "timeout-ms must be a non-negative integer"
+                      {:samizdat.sandbox/error :invalid-timeout
+                       :timeout-ms (pr-str timeout)})))
+    timeout))
+
+(defn spec
+  "Resolve an inert EvaluatorSpec from a trusted named preset (controller
+   API; the closed catalog is `presets`).
+
+   Required opts:
+     :root — trusted host root directory (string)
+
+   Optional controller attenuation / bounds:
+     :capabilities — subset of the preset's capabilities (default: the
+                     preset's exact set).  Anything beyond the preset is a
+                     fail-closed :over-request.
+     :max-read-chars / :max-list-entries / :max-search-results /
+     :search-max-chars — bounds (positive integers; defaults apply)
+     :timeout-ms — cooperative interrupt ceiling (non-negative integer;
+                   0 disables; default 30000)
+
+   The returned map is fully inert (jolt.sandbox receipt domain): no
+   functions, atoms, or host values.  :capabilities is a sorted vector;
+   :spec/coordinate is the deterministic js1: content coordinate."
+  [preset-key {:keys [root capabilities timeout-ms] :as opts}]
+  (let [preset (get presets preset-key)]
+    (when-not preset
+      (throw (ex-info "Unknown sandbox preset"
+                      {:samizdat.sandbox/error :unknown-preset
+                       :preset preset-key})))
+    (when-not (and (string? root) (not (str/blank? root)))
+      (throw (ex-info "EvaluatorSpec requires a trusted host :root"
+                      {:samizdat.sandbox/error :missing-root})))
+    (let [preset-caps (:capabilities preset)
+          caps (if (nil? capabilities)
+                 preset-caps
+                 (let [c (set capabilities)
+                       excess (remove preset-caps c)]
+                   (when (seq excess)
+                     (throw (ex-info "Controller-selected capabilities exceed the preset"
+                                     {:samizdat.sandbox/error :over-request
+                                      :preset preset-key
+                                      :excess (vec (sort-by str excess))})))
+                   c))
+          bounds (resolve-bounds opts)
+          timeout (resolve-timeout timeout-ms)
+          base {:samizdat.sandbox/kind :evaluator-spec
+                :preset preset-key
+                :profile (:profile preset)
+                :root (resolve-root root)
+                :capabilities (vec (sort-by str caps))
+                :bounds bounds
+                :timeout-ms timeout}]
+      (assoc base :spec/coordinate (spec-coordinate base)))))
+
+(defn- verify-spec!
+  "Fail-closed integrity check: an EvaluatorSpec must be of the right kind
+   and its coordinate must recompute exactly.  The coordinate covers root,
+   bounds, timeout and capabilities, so a hand-edited spec cannot smuggle
+   authority past this gate."
+  [spec]
+  (when-not (and (map? spec)
+                 (= :evaluator-spec (:samizdat.sandbox/kind spec))
+                 (string? (:spec/coordinate spec))
+                 (= (:spec/coordinate spec) (spec-coordinate spec)))
+    (throw (ex-info "Invalid or non-canonical EvaluatorSpec"
+                    {:samizdat.sandbox/error :invalid-spec})))
+  spec)
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Context and Instance allocation
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- instrument-operation
+  "Give one operation a controller-owned, dynamically installed effect hook.
+   The hook is absent for the ordinary JS1 API.  Recorded evaluation installs
+   it only while it owns the instance, so unchanged callers still use the
+   normal Jolt operation API and pay no durable-store dependency at load time."
+  [effect-hook operation]
+  (let [op-fn (:fn operation)]
+    (assoc operation :fn
+           (fn [& args]
+             (if-let [hook @effect-hook]
+               (hook operation (vec args))
+               (apply op-fn args))))))
+
+(defn- context-from-spec
+  "Allocate the live jolt.sandbox state for a verified inert EvaluatorSpec.
+   All five semantic ops are projected (fixture presence); the per-dispatch
+   recheck in jolt.sandbox gates them down to the spec's capabilities."
+  [spec]
+  (verify-spec! spec)
+  (let [root-canonical (:root spec)
+        effect-hook (atom nil)
+        operations (mapv (fn [operation]
+                           (instrument-operation effect-hook operation))
+                         (build-operations root-canonical (:bounds spec)))
+        caps (set (:capabilities spec))
+        state (sandbox/create-context
+                {:operations operations
+                 :profile (:profile spec)
+                 :requested-capabilities caps
+                 :authorized-capabilities caps})]
+    {:root-canonical root-canonical
+     :operations operations
+     ::state (atom state)
+     ::effect-hook effect-hook
+     ;; A hook changes how every effect in a persistent SCI context is
+     ;; dispatched.  Evaluation ownership therefore belongs to the instance,
+     ;; not to a caller thread or a DB record.  Contention fails closed rather
+     ;; than letting an unrecorded evaluation pass through somebody else's
+     ;; hook.
+     ::evaluation-owner (atom nil)}))
+
+(defn instantiate!
+  "Allocate a live Instance from an inert EvaluatorSpec (controller API).
+
+   opts:
+     :instance/key — stable key naming the instance (default :standalone)
+
+   The instance id is stable and deterministic: \"inst:\" (name key).  It
+   survives rebuild! (which returns a fresh value; the provider registry
+   is updated so later acquire!/bind! calls see the rebuilt instance).
+   Give distinct keys to distinct coexisting instances (the provider
+   enforces this by keying its registry on :instance/key); two standalone
+   instances share the id :standalone."
+  ([spec] (instantiate! spec nil))
+  ([spec {:keys [instance/key] :or {key :standalone}}]
+   (let [c (context-from-spec spec)]
+     {:samizdat.sandbox/kind :instance
+      :instance/key key
+       :instance/id (str "inst:" (name key))
+       :spec spec
+       :root-canonical (:root-canonical c)
+       :timeout-ms (:timeout-ms spec)
+       :operations (:operations c)
+       ::state (::state c)
+       ::effect-hook (::effect-hook c)
+       ::evaluation-owner (::evaluation-owner c)})))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Provider — JS1 acquire/bind policy
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn provider
+  "Create a JS1 evaluator provider (controller API).
+
+   opts:
+     :root — default trusted host root for bind!/acquire! specs
+
+   JS1 policy: ordinary work binds deterministically to one persistent
+   instance key, :main.  A controller that needs isolation passes a
+   distinct :instance/key and gets a separate live context."
+  ([] (provider nil))
+  ([{:keys [root]}]
+   {:samizdat.sandbox/kind :provider
+    :provider/default-root root
+    ::registry (atom {:instances {} :bindings {}})}))
+
+(defn- registry-acquire-instance
+  "Registry update for acquire!: get or create the instance for key.
+   Fail-closed on spec conflict.  Top-level (values in, new registry out)
+   so the swap! closure stays flat — see note in bind!."
+  [r key spec reg]
+  (if-let [inst (get-in r [:instances key])]
+    (do (when-not (= (:spec/coordinate (:spec inst))
+                     (:spec/coordinate spec))
+          (throw (ex-info "Instance spec conflict: instance key already holds a different EvaluatorSpec"
+                          {:samizdat.sandbox/error :instance-spec-conflict
+                           :instance/key key})))
+        r)
+    (assoc-in r [:instances key]
+              (assoc (instantiate! spec {:instance/key key})
+                     ::registry reg))))
+
+(defn acquire!
+  "Get or create the provider instance for :instance/key (default :main)
+   from an inert EvaluatorSpec.  An existing instance is returned only
+   when its spec coordinate matches exactly; a mismatch throws
+   {:samizdat.sandbox/error :instance-spec-conflict} — never a silent
+   widening or rebinding."
+  ([provider spec] (acquire! provider spec nil))
+  ([provider spec {:keys [instance/key] :or {key :main}}]
+   (verify-spec! spec)
+   (let [reg (::registry provider)]
+     (when-not reg
+       (throw (ex-info "acquire! needs a samizdat.agent.sandbox provider"
+                       {:samizdat.sandbox/error :not-a-provider})))
+     (swap! reg (fn [r] (registry-acquire-instance r key spec reg)))
+     (get-in @reg [:instances key]))))
+
+(defn- registry-bind-work
+  "Registry update for bind!: idempotent per work-id — an existing binding
+   is kept when instance key and spec coordinate match, otherwise a
+   fail-closed conflict."
+  [r work-id entry]
+  (if-let [existing (get-in r [:bindings work-id])]
+    (do (when-not (and (= (:instance/key entry) (:instance/key existing))
+                       (= (:spec/coordinate (:spec entry))
+                          (:spec/coordinate (:spec existing))))
+          (throw (ex-info "Binding conflict: work-id already bound with a different instance key or spec"
+                          {:samizdat.sandbox/error :binding-conflict
+                           :work-id (pr-str work-id)})))
+        r)
+    (assoc-in r [:bindings work-id] entry)))
+
+(defn bind!
+  "Bind work-id to an instance acquired from a trusted named preset
+   (controller API).  Model code never calls this: it receives bindings.
+
+   Required opts:
+     :preset — a key of `presets` (the closed trusted catalog)
+     :root   — trusted host root (or the provider's default root)
+
+   Optional:
+     :instance/key — default :main.  JS1 policy: all ordinary work shares
+                     the persistent :main instance; a distinct key yields
+                     an isolated instance.
+     :capabilities — controller-selected subset of the preset's
+                     capabilities (attenuation only)
+     bounds/timeout opts as in `spec`
+
+   Idempotent per work-id: rebinding the same work-id with an equal key
+   and spec returns the existing binding; a conflicting key or spec throws
+   {:samizdat.sandbox/error :binding-conflict}.
+
+   Returns the live Binding map: inert :binding/id, :work-id,
+   :instance/key, :instance/id and :spec, plus the live instance ref."
+  [provider work-id {:keys [preset instance/key root] :as opts}]
+  (let [key (or key :main)
+        root (or root (:provider/default-root provider))
+        sp (spec preset (assoc opts :root root))
+        inst (acquire! provider sp {:instance/key key})
+        reg (::registry provider)
+        entry {:samizdat.sandbox/kind :binding
+               :binding/id (str "bind:" (name key) ":" (str work-id))
+               :work-id work-id
+               :instance/key key
+               :instance/id (:instance/id inst)
+               :spec sp
+               ::instance inst
+               ::registry reg}]
+    ;; Flat swap! closures only: a let-bound local captured under
+    ;; fn > if-let > let currently breaks resolution of the fn's other
+    ;; locals in Jolt's analyzer, so registry updates are top-level fns.
+    (swap! reg (fn [r] (registry-bind-work r work-id entry)))
+    (get-in @reg [:bindings work-id])))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Public API
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn new
+  "Create a bounded JS1 project sandbox context directly (legacy API;
+   prefer the preset/spec/provider seam for new code).
+
+   Required opts:
+     :root    — trusted host root directory (string)
+     :profile — :agent/minimal, :agent/project-read, or
+                :agent/project-develop
+
+   Optional opts:
+     :authorized-capabilities — explicit subset of the profile's maximum
+                                (default: the profile maximum itself)
+     :max-read-chars    — bounded read limit (default 60000)
+     :max-list-entries  — bounded list limit (default 1000)
+     :max-search-results — bounded search result limit (default 500)
+     :search-max-chars  — bounded search scan limit (default 500000)
+     :timeout-ms        — cooperative interrupt ceiling (default 30000)
+
+   Returns an opaque context map for use with evaluate!, rebuild!,
+   describe, and capabilities."
+  [{:keys [root profile timeout-ms authorized-capabilities] :as opts}]
+  (when-not profile
+    (throw (ex-info "new requires an explicit :profile"
+                    {:samizdat.sandbox/error :missing-profile})))
+  (let [profile-data (get sandbox/profiles profile)]
+    (when-not profile-data
+      (throw (ex-info "Unknown profile"
+                      {:samizdat.sandbox/error :unknown-profile
+                       :profile profile})))
+    (let [max-caps (:profile/max-capabilities profile-data)
+          caps (set (or authorized-capabilities max-caps))
+          excess (remove max-caps caps)]
+      (when (seq excess)
+        (throw (ex-info "Authorized capabilities exceed profile maximum"
+                        {:samizdat.sandbox/error :profile-exceeded
+                         :profile profile
+                         :excess (vec (sort-by str excess))})))
+      ;; An ad-hoc inert spec through the same coordinate machinery, so
+      ;; describe is uniform.  No :preset key — distinguishable from
+      ;; catalog-minted specs.
+      (let [base {:samizdat.sandbox/kind :evaluator-spec
+                  :profile profile
+                  :root (resolve-root root)
+                  :capabilities (vec (sort-by str caps))
+                  :bounds (resolve-bounds opts)
+                  :timeout-ms (resolve-timeout timeout-ms)}
+            sp (assoc base :spec/coordinate (spec-coordinate base))
+            c (context-from-spec sp)]
+        {:samizdat.sandbox/kind :context
+         :root root
+         :root-canonical (:root-canonical c)
+         :profile profile
+         :timeout-ms (:timeout-ms sp)
+         :operations (:operations c)
+         :spec sp
+         ::state (::state c)
+         ::effect-hook (::effect-hook c)
+         ::evaluation-owner (::evaluation-owner c)}))))
+
+(def ^:private authority-selection-keys
+  "evaluate! is the model-facing entry: authority was fixed when the
+   controller minted the spec/instance/binding, so any profile, preset,
+   capability, root, or instance-key option here is a selection attempt
+   and is rejected rather than ignored."
+  #{:profile :preset :capabilities :authorized-capabilities
+    :requested-capabilities :instance/key :root})
+
+(def ^:dynamic *eval-store*
+  "Optional trusted durable-eval adapter.  Production leaves this nil and the
+   bridge dynamically resolves samizdat.store.evals, keeping this namespace
+   directly loadable on the small Jolt+SCI classpath.  A controller/test may
+   bind a map containing :begin!, :record-intent!, :record-outcome!,
+   :complete!, :load-eval, and :verify-binding! to supply the same contract."
+  nil)
+
+(def ^:private eval-store-symbols
+  {:begin! 'samizdat.store.evals/begin!
+   :record-intent! 'samizdat.store.evals/record-intent!
+   :record-outcome! 'samizdat.store.evals/record-outcome!
+   :complete! 'samizdat.store.evals/complete!
+   :load-eval 'samizdat.store.evals/load-eval
+   :verify-binding! 'samizdat.store.evals/verify-binding!})
+
+(defn- eval-store
+  "Resolve the complete durable-store surface at call time.  Resolution is
+   all-or-nothing: a partial/old store cannot silently produce a record that
+   this bridge would later be unable to verify."
+  []
+  (if *eval-store*
+    (do
+      (doseq [k (keys eval-store-symbols)]
+        (when-not (ifn? (get *eval-store* k))
+          (throw (ex-info "Incomplete durable evaluation store adapter"
+                          {:samizdat.sandbox/error :incomplete-eval-store
+                           :missing k}))))
+      *eval-store*)
+    (into {}
+          (map (fn [[k sym]]
+                 (let [f (try
+                           (requiring-resolve sym)
+                           (catch Throwable e
+                             (throw (ex-info
+                                     (str "Durable evaluation store function is unavailable: " sym)
+                                     {:samizdat.sandbox/error :eval-store-unavailable
+                                      :symbol sym}
+                                     e))))]
+                   (when-not (ifn? f)
+                     (throw (ex-info "Resolved durable evaluation store value is not callable"
+                                     {:samizdat.sandbox/error :invalid-eval-store
+                                      :symbol sym})))
+                   [k f])))
+          eval-store-symbols)))
+
+(defn- evaluation-target
+  [x label]
+  (let [target (if (::instance x) (::instance x) x)]
+    (when-not (and (::state target)
+                   (::effect-hook target)
+                   (::evaluation-owner target))
+      (throw (ex-info (str label " needs a sandbox context, instance, or binding")
+                      {:samizdat.sandbox/error :not-a-context})))
+    target))
+
+(defn- reject-authority-selection!
+  [label opts]
+  (let [bad (filterv authority-selection-keys (keys (or opts {})))]
+    (when (seq bad)
+      (throw (ex-info (str label " does not accept authority selection; authority is fixed at bind time")
+                      {:samizdat.sandbox/error :authority-selection-forbidden
+                       :keys bad})))))
+
+(defn- claim-evaluation!
+  [target]
+  (let [owner (::evaluation-owner target)
+        claim (str (random-uuid))]
+    (when-not (compare-and-set! owner nil claim)
+      (throw (ex-info "Sandbox instance already has an evaluation in progress"
+                      {:samizdat.sandbox/error :instance-busy
+                       :instance/id (:instance/id target)})))
+    claim))
+
+(defn- release-evaluation!
+  [target claim]
+  ;; Never clear a different owner's claim.  That should be impossible, but a
+  ;; poisoned ownership cell is safer than opening an effect hook to races.
+  (compare-and-set! (::evaluation-owner target) claim nil))
+
+(defn- evaluate-state!
+  "Run source after ownership has been acquired."
+  [target source opts]
+  (let [state-atom (::state target)
+        timeout-ms (:timeout-ms target)
+        token (:token opts)]
+    (if (or token (not timeout-ms) (zero? timeout-ms))
+      (sandbox/evaluate! @state-atom source token)
+      (let [tok (jolt.host/make-interrupt)
+            _ (let [t (Thread. (fn []
+                                (try
+                                  (Thread/sleep timeout-ms)
+                                  (jolt.host/interrupt! tok)
+                                  (catch Exception _ nil))))]
+                (.setDaemon t true)
+                (.start t))]
+        (try
+          (sandbox/evaluate! @state-atom source tok)
+          (catch Throwable e
+            (if (:jolt/interrupted (ex-data e))
+              (throw (ex-info "Sandbox evaluation timed out"
+                              {:samizdat.sandbox/error :timeout
+                               :timeout-ms timeout-ms}
+                              e))
+              (throw e))))))))
+
+(defn evaluate!
+  "Evaluate `source` in `x` — a context (new), an Instance, or a Binding.
+
+   Optional opts:
+     :token — a Jolt interrupt token (jolt.host/make-interrupt).
+              When supplied, evaluation uses jolt.host/run-interruptible
+              so the token's interruption is an unraiseable host ceiling.
+              If no token is given and the target has a timeout, one is
+              created and scheduled automatically via a daemon thread.
+
+   No authority selection: authority is fixed at construction/bind time.
+   Passing any of :profile, :preset, :capabilities,
+   :authorized-capabilities, :requested-capabilities, :instance/key, or
+   :root throws {:samizdat.sandbox/error :authority-selection-forbidden}.
+
+   The sandbox's jolt.sandbox/evaluate! runs SCI eval-string* with the
+   token, which cooperatively checks the interrupt at safe points.  The
+   interruption cannot be caught or suppressed from within SCI code."
+  ([x source] (evaluate! x source nil))
+  ([x source opts]
+   (reject-authority-selection! "evaluate!" opts)
+   (let [target (evaluation-target x "evaluate!")
+         claim (claim-evaluation! target)]
+     (try
+       (evaluate-state! target source opts)
+       (finally
+         (release-evaluation! target claim))))))
+
+(defn- require-binding!
+  [binding label]
+  (when-not (and (= :binding (:samizdat.sandbox/kind binding))
+                 (::instance binding)
+                 (string? (:binding/id binding))
+                 (string? (:instance/id binding))
+                 (string? (:spec/coordinate (:spec binding))))
+    (throw (ex-info (str label " requires a controller-minted Binding")
+                    {:samizdat.sandbox/error :not-a-binding})))
+  binding)
+
+(defn- binding-identity
+  [binding]
+  {:spec-id (:spec/coordinate (:spec binding))
+   :instance-id (:instance/id binding)
+   :binding-id (:binding/id binding)})
+
+(defn- current-coordinate
+  [target]
+  (sandbox/canonical-coordinate
+   (sandbox/effective-authority @(::state target))))
+
+(defn- run-recorded-effect!
+  "Persist intent, run exactly once, then persist exactly one outcome.  A
+   failure to append the outcome is deliberately not converted into an error
+   outcome: the existing intent stays unsettled because the real world's state
+   is then unknown."
+  [store conn eval-id {:keys [id fn]} args]
+  (let [intent ((:record-intent! store) conn eval-id
+                {:op id :args (sandbox/inert args)})
+        outcome (try
+                  {:ok true :value (apply fn args)}
+                  (catch Throwable e
+                    {:ok false :error e}))]
+    (if (:ok outcome)
+      (let [value (sandbox/inert (:value outcome))]
+        ((:record-outcome! store) conn eval-id intent {:result value})
+        value)
+      (let [error (:error outcome)]
+        ((:record-outcome! store) conn eval-id intent {:error (str error)})
+        (throw error)))))
+
+(defn- complete-failed-evaluation!
+  [store conn eval-id error]
+  ((:complete! store) conn eval-id
+   {:status :failed :result {:error (str error)}}))
+
+(defn evaluate-recorded!
+  "Evaluate source in a controller-minted Binding while appending a durable
+   JS1 record to trusted `conn`.
+
+   The evaluation row (spec/instance/binding ids, exact current authority
+   coordinate, and source) lands before source runs.  Every semantic operation
+   appends intent before touching the project and outcome afterward.  The
+   terminal row is appended only after evaluation returns and all outcomes have
+   settled.  Returns {:eval-id id :value value}.
+
+   If an outcome append fails after an operation, completion also fails closed
+   and the durable record remains pending with its unsettled intent."
+  ([conn binding source] (evaluate-recorded! conn binding source nil))
+  ([conn binding source opts]
+   (require-binding! binding "evaluate-recorded!")
+   (reject-authority-selection! "evaluate-recorded!" opts)
+   (let [store (eval-store)
+         target (evaluation-target binding "evaluate-recorded!")
+         claim (claim-evaluation! target)]
+     (try
+       (let [identity (binding-identity binding)
+             eval-id ((:begin! store) conn
+                      (assoc identity
+                             :coordinate (current-coordinate target)
+                             :source source))
+             hook (::effect-hook target)]
+         (reset! hook (fn [operation args]
+                        (run-recorded-effect! store conn eval-id operation args)))
+         (sandbox/set-mode! @(::state target) :normal)
+         (try
+           (let [outcome (try
+                           (let [value (evaluate-state! target source opts)]
+                             {:ok true
+                              :value value
+                              :inert-value (sandbox/inert value)})
+                           (catch Throwable evaluation-error
+                             {:ok false :error evaluation-error}))]
+             (if (:ok outcome)
+               (do
+                 ;; Completion persistence is not part of source evaluation.
+                 ;; If it fails, do not attempt a contradictory :failed row;
+                 ;; leave the original record pending.
+                 ((:complete! store) conn eval-id
+                  {:status :completed
+                   :result {:value (:inert-value outcome)}})
+                 {:eval-id eval-id :value (:value outcome)})
+               (let [evaluation-error (:error outcome)]
+                 (try
+                   (complete-failed-evaluation! store conn eval-id evaluation-error)
+                   (catch Throwable completion-error
+                     (throw (ex-info
+                             "Evaluation failed and its durable record could not be completed; the record remains pending"
+                             {:samizdat.sandbox/error :durable-evaluation-incomplete
+                              :eval-id eval-id}
+                             completion-error))))
+                 (throw evaluation-error))))
+           (finally
+             (reset! hook nil))))
+       (finally
+         (release-evaluation! target claim))))))
+
+(defn- receipt->jolt
+  [known-ops expected-seq receipt]
+  (when-not (= expected-seq (:seq receipt))
+    (throw (ex-info "Durable receipts are not a contiguous operation sequence"
+                    {:samizdat.sandbox/error :malformed-receipts
+                     :expected-seq expected-seq
+                     :actual-seq (:seq receipt)})))
+  (when-not (contains? known-ops (:op receipt))
+    (throw (ex-info "Durable receipt names an operation outside this instance"
+                    {:samizdat.sandbox/error :unknown-recorded-operation
+                     :op (:op receipt)})))
+  (when-not (vector? (:args receipt))
+    (throw (ex-info "Durable receipt arguments are not a vector"
+                    {:samizdat.sandbox/error :malformed-receipts
+                     :seq expected-seq})))
+  (let [base {:op/id (:op receipt)
+              :op/args (sandbox/inert (:args receipt))}]
+    (case (:phase receipt)
+      :done (assoc base :op/result (sandbox/inert (:result receipt)))
+      :error (do
+               (when-not (string? (:error receipt))
+                 (throw (ex-info "Durable error receipt has no error message"
+                                 {:samizdat.sandbox/error :malformed-receipts
+                                  :seq expected-seq})))
+               (assoc base :op/error (:error receipt)))
+      :intent (throw (ex-info
+                      "Durable evaluation contains an unsettled effect intent"
+                      {:samizdat.sandbox/error :unsettled-recorded-effect
+                       :seq expected-seq
+                       :op (:op receipt)}))
+      (throw (ex-info "Durable receipt has an unknown phase"
+                      {:samizdat.sandbox/error :malformed-receipts
+                       :seq expected-seq
+                       :phase (:phase receipt)})))))
+
+(defn- replay-receipts
+  [target record]
+  (let [known-ops (set (map :id (:operations target)))]
+    (mapv (fn [[n receipt]] (receipt->jolt known-ops n receipt))
+          (map-indexed vector (:receipts record)))))
+
+(defn- fresh-target
+  "Allocate an independent context from the same spec, attenuated to the
+   source target's current authority.  It intentionally does not publish into
+   a provider registry until replay has succeeded exactly."
+  [target]
+  (let [c (context-from-spec (:spec target))
+        old-state @(::state target)
+        authorized (:authorized @old-state)
+        fresh-state @(::state c)
+        fresh (assoc target
+                     :root-canonical (:root-canonical c)
+                     :operations (:operations c)
+                     ::state (::state c)
+                     ::effect-hook (::effect-hook c)
+                     ::evaluation-owner (::evaluation-owner c))]
+    (doseq [capability (remove authorized (set (:capabilities (:spec target))))]
+      (sandbox/revoke! fresh-state capability))
+    fresh))
+
+(defn- registry-publish-recorded
+  [r old-instance fresh-instance]
+  (let [key (:instance/key old-instance)
+        registered (get-in r [:instances key])]
+    (when-not (= (::state registered) (::state old-instance))
+      (throw (ex-info "Binding points at a superseded provider instance"
+                      {:samizdat.sandbox/error :stale-binding
+                       :instance/key key})))
+    (assoc (assoc-in r [:instances key] fresh-instance)
+           :bindings
+           (into {}
+                 (map (fn [[work-id binding]]
+                        [work-id
+                         (if (= key (:instance/key binding))
+                           (assoc binding
+                                  ::instance fresh-instance
+                                  :instance/id (:instance/id fresh-instance))
+                           binding)]))
+                 (:bindings r)))))
+
+(defn- publish-recorded-rebuild!
+  [binding fresh-instance]
+  (let [fresh-binding (assoc binding
+                             ::instance fresh-instance
+                             :instance/id (:instance/id fresh-instance))]
+    (if-let [reg (::registry binding)]
+      (do
+        (swap! reg (fn [r]
+                     (registry-publish-recorded r (::instance binding) fresh-instance)))
+        (get-in @reg [:bindings (:work-id binding)]))
+      fresh-binding)))
+
+(defn rebuild-recorded!
+  "Verify and replay completed durable evaluation `eval-id` into a fresh
+   context for `binding`, returning the rebuilt Binding.
+
+   Binding identity is verified by samizdat.store.evals before the record is
+   loaded or any source can run.  Pending, failed, malformed, non-contiguous,
+   or authority-coordinate-mismatched records fail closed.  During replay Jolt
+   serves every observation and actuation from the ordered historical
+   receipts; the real project operation functions are never called.  The fresh
+   instance is published only after source result and receipt consumption both
+   match exactly."
+  [conn binding eval-id]
+  (require-binding! binding "rebuild-recorded!")
+  (let [store (eval-store)
+        identity (binding-identity binding)
+        target (evaluation-target binding "rebuild-recorded!")
+        claim (claim-evaluation! target)]
+    (try
+      ;; This must remain the first store action and precede allocation/eval.
+      ;; The identity carries all four durable fields the store compares,
+      ;; including the exact current spec coordinate: without it the store's
+      ;; verify-binding! sees a blank expected coordinate and denies every
+      ;; replay, and with a stale one it must deny this one.
+      ((:verify-binding! store) conn eval-id
+       (assoc identity :coordinate (current-coordinate target)))
+      (let [record ((:load-eval store) conn eval-id)]
+        (when-not record
+          (throw (ex-info "No durable evaluation record"
+                          {:samizdat.sandbox/error :unknown-evaluation
+                           :eval-id eval-id})))
+        (when-not (= :completed (:status record))
+          (throw (ex-info "Only a completed durable evaluation can be rebuilt"
+                          {:samizdat.sandbox/error :incomplete-evaluation
+                           :eval-id eval-id
+                           :status (:status record)})))
+        (when-not (= (:coordinate record) (current-coordinate target))
+          (throw (ex-info "Durable evaluation authority coordinate does not match the binding"
+                          {:samizdat.sandbox/error :coordinate-mismatch
+                           :eval-id eval-id})))
+        (let [fresh-instance (fresh-target target)
+              receipts (replay-receipts fresh-instance record)
+              state @(::state fresh-instance)]
+          (sandbox/load-receipts! state receipts)
+          (sandbox/set-mode! state :replay)
+          (let [value (evaluate-state! fresh-instance (:source record) nil)
+                inert-value (sandbox/inert value)
+                result (:result record)]
+            (when-not (and (map? result)
+                           (contains? result :value)
+                           (= (sandbox/inert (:value result)) inert-value))
+              (throw (ex-info "Replayed source result does not match its durable completion"
+                              {:samizdat.sandbox/error :replay-result-mismatch
+                               :eval-id eval-id})))
+            ;; Historical evidence remains in the DB, not in the now-live
+            ;; context.  Clearing it also prevents a later mode change from
+            ;; accidentally treating history as a new replay program.
+            (sandbox/load-receipts! state [])
+            (sandbox/set-mode! state :normal)
+            (publish-recorded-rebuild! binding fresh-instance))))
+      (finally
+        (release-evaluation! target claim)))))
+
+(defn- registry-rebind
+  "Registry update for rebuild! on a binding: point the work-id's binding
+   at the rebuilt instance, if the binding is still registered."
+  [r work-id b]
+  (if (get-in r [:bindings work-id])
+    (assoc-in r [:bindings work-id] b)
+    r))
+
+(defn- registry-replace-instance
+  "Registry update for rebuild! on an instance: replace the registered
+   instance under its key, if still registered."
+  [r key fresh]
+  (if (contains? (:instances r) key)
+    (assoc-in r [:instances key] fresh)
+    r))
+
+(defn rebuild!
+  "Create a fresh sandbox context with the same configuration and
+   effective authority as `x` (a context, Instance, or Binding), but with
+   a clean SCI context (no definitions or receipts).  Forks from current
+   effective authority, never the creation-time grant.
+
+   Identity is stable: an Instance keeps its :instance/id, a Binding
+   keeps its :binding/id.  Provider-registered instances and bindings
+   update the provider registry, so a later bind! sees the rebuilt
+   instance.  Returns the rebuilt value; previously returned maps still
+   reference the superseded context (persistent value semantics)."
+  [x]
+  (cond
+    (::instance x)
+    (let [inst (rebuild! (::instance x))
+          b (assoc x ::instance inst :instance/id (:instance/id inst))]
+      (when-let [reg (::registry x)]
+        (swap! reg (fn [r] (registry-rebind r (:work-id x) b))))
+      b)
+
+    (::state x)
+    (let [fresh (assoc x ::state (atom (sandbox/fork-context @(::state x))))]
+      (when-let [reg (::registry x)]
+        (swap! reg (fn [r] (registry-replace-instance r (:instance/key x) fresh))))
+      fresh)
+
+    :else
+    (throw (ex-info "rebuild! needs a sandbox context, instance, or binding"
+                    {:samizdat.sandbox/error :not-a-context}))))
+
+(defn describe
+  "Return an inert, data-only description of the current effective
+   authority of `x` (a context, Instance, or Binding).  Reads the live
+   state's current :authorized set, so attenuation/revocation is
+   reflected.  Suitable for serialization, comparison, coordination,
+   and capability discovery.  The description is fully canonical:
+   all collections are sorted and contain only receipt-domain values.
+
+   jolt.sandbox keys:
+     :jolt.sandbox/profile — the context profile
+     :jolt.sandbox/requested — requested capability IDs
+     :jolt.sandbox/authorized — authorized capability IDs
+     :jolt.sandbox/operations — authorized operation descriptors
+
+   JS1 seam coordinates:
+     :samizdat.sandbox/kind — :context / :instance / :binding
+     :samizdat.sandbox/root-canonical — the trusted root
+     :samizdat.sandbox/timeout-ms — the configured ceiling
+     :samizdat.sandbox/bounds — the four bounds
+     :samizdat.sandbox/preset — the trusted preset (catalog specs only)
+     :samizdat.sandbox/spec-coordinate — the inert js1: content coordinate
+     :samizdat.sandbox/instance-key / :samizdat.sandbox/instance-id
+       (instances and bindings)
+     :samizdat.sandbox/binding-id / :samizdat.sandbox/work-id
+       (bindings only)"
+  [x]
+  (let [binding (when (::instance x) x)
+        target (if binding (::instance x) x)
+        state-atom (::state target)]
+    (when-not state-atom
+      (throw (ex-info "describe needs a sandbox context, instance, or binding"
+                      {:samizdat.sandbox/error :not-a-context})))
+    (let [base (sandbox/effective-authority @state-atom)
+          spec (:spec target)]
+      (sandbox/inert
+        (cond-> (assoc base
+                  :samizdat.sandbox/kind (:samizdat.sandbox/kind x)
+                  :samizdat.sandbox/root-canonical (:root-canonical target)
+                  :samizdat.sandbox/timeout-ms (:timeout-ms target)
+                  :samizdat.sandbox/bounds (:bounds spec)
+                  :samizdat.sandbox/spec-coordinate (:spec/coordinate spec))
+          (:preset spec)
+          (assoc :samizdat.sandbox/preset (:preset spec))
+          (:instance/id target)
+          (assoc :samizdat.sandbox/instance-key (:instance/key target)
+                 :samizdat.sandbox/instance-id (:instance/id target))
+          binding
+          (assoc :samizdat.sandbox/binding-id (:binding/id binding)
+                 :samizdat.sandbox/work-id (:work-id binding)))))))
+
+(defn capabilities
+  "Safe capability discovery from effective authority: the currently
+    authorized capability IDs as a sorted vector of keywords, read from
+    the same live authority source that dispatch rechecks — so revocation
+    is reflected and the result never attests authority the target no
+    longer has.  Accepts anything describe accepts, or an
+    already-computed describe map."
+  [x]
+  (let [d (if (and (map? x) (contains? x :jolt.sandbox/authorized))
+             x
+             (describe x))]
+    ;; effective-authority renders capability IDs as strings like
+    ;; ":project/read"; strip the leading colon to re-keyword them.
+    (vec (sort-by str
+                  (map (fn [s] (keyword (if (str/starts-with? s ":")
+                                          (subs s 1)
+                                          s)))
+                       (:jolt.sandbox/authorized d))))))
+
+;; ═══════════════════════════════════════════════════════════════════════════
+;; Safe discovery — host-derived, never sandbox-evaluated
+;; ═══════════════════════════════════════════════════════════════════════════
+
+(defn- describe-for-discovery
+  "A describe map for `x`: the map itself when already described, else a
+   fresh host-side describe.  Pure data out; nothing is ever evaluated."
+  [x]
+  (if (and (map? x) (contains? x :jolt.sandbox/authorized))
+    x
+    (describe x)))
+
+(defn- discovery-symbol
+  "Normalize model-supplied symbol text to a capability keyword, or nil.
+   Accepts \"project/read\" and \":project/read\" (optionally surrounded by
+   whitespace); everything else — bare names, hostile splices, non-strings —
+   is nil, because the text is data to match against, never source to run."
+  [sym]
+  (when (string? sym)
+    (let [s (str/trim sym)
+          s (if (str/starts-with? s ":") (subs s 1) s)]
+      (when (re-matches #"[A-Za-z0-9*+!_'?<>=./-]+" s)
+        (keyword s)))))
+
+(defn operation-doc
+  "Host-derived safe capability discovery for `doc`: an inert doc-style map
+   for the projected operation named by `sym` (e.g. \"project/read\"), or
+   nil when no authorized operation matches.
+
+   Derived ONLY from the target's effective authority (describe) plus the
+   host-owned operation-docs table.  No resolve/find-ns/ns-publics/meta
+   form is ever evaluated inside the sandbox: the sandbox vocabulary
+   forbids them, and splicing untrusted symbol text into evaluated source
+   would be an injection seam, so discovery never evaluates at all — the
+   symbol text is matched as inert data.  Ungranted capabilities are not
+   discoverable."
+  [x sym]
+  (when-let [cap (discovery-symbol sym)]
+    (let [d (describe-for-discovery x)
+          ;; :op/id is the string form ":project/read"; re-keyword it.
+          op (some (fn [o] (when (= cap (keyword (subs (:op/id o) 1))) o))
+                   (:jolt.sandbox/operations d))]
+      (when op
+        (let [docs (or (get operation-docs cap) {})]
+          {:name (str "project/" (:op/name op))
+           :arglists (vec (or (:arglists docs) '([& args])))
+           :doc (str (:doc docs)
+                     "  Effect: " (name (:op/effect op)) ".")})))))
+
+(defn complete-capability
+  "Host-derived safe capability discovery for `complete`: the sorted
+   projected operation names (\"project/…\") authorized for `x` whose full
+   name starts with `prefix`.  Pure filtering over effective authority —
+   nothing is evaluated inside the sandbox, so untrusted prefix text can
+   only narrow the answer, never widen it or run."
+  [x prefix]
+  (let [p (str prefix)]
+    (vec (sort (filter #(str/starts-with? % p)
+                       (map (fn [cap] (str "project/" (name cap)))
+                            (capabilities x)))))))

--- a/src/samizdat/agent/tools.clj
+++ b/src/samizdat/agent/tools.clj
@@ -66,5 +66,8 @@
 (def unavailable base/unavailable)
 (def phase-refusal base/phase-refusal)
 (def tool-names base/tool-names)
+(def js1-profile? base/js1-profile?)
+(def js1-allowed? base/js1-allowed?)
+(def js1-tool-vocabulary base/js1-tool-vocabulary)
 (def answer-tokens ship/answer-tokens)
 (def uncovered-tokens ship/uncovered-tokens)

--- a/src/samizdat/agent/tools/base.clj
+++ b/src/samizdat/agent/tools/base.clj
@@ -28,7 +28,15 @@
   name not in js1-allowed-tools before dispatch.  The model sees eval,
   doc, complete, and done; file/shell/manifest/mutate etc. are refused
   as policy. The live REPL is never reached in a JS1 context — eval
-  routes to the persistent SCI binding instead."
+  routes to the persistent SCI binding instead.
+
+  The ctx's :js1/binding may be the Binding map itself or an ATOM holding
+  it (js1-binding derefs either).  The atom is the wiring workflow/resume/
+  beam use: a rollback or rebuild supersedes a Binding in the provider
+  registry, and the eval tool refreshes the holder in place (see
+  tools.repl) so the NEXT eval runs on the binding the registry currently
+  publishes — the ctx map a tool receives is immutable, the cell it holds
+  is not."
   (:require [clojure.string :as str]))
 
 ;; ─── JS1 profile ─────────────────────────────────────────────────────────
@@ -51,9 +59,38 @@
   the ctx.  Tool restriction (phase-refusal below) and eval routing (the
   repl tools) both derive their decision from this accessor — never from
   :js1/profile, which is a display/journal label only.  One signal means
-  the two gates can never disagree about whether a context is sandboxed."
+  the two gates can never disagree about whether a context is sandboxed.
+
+  Accepts the binding as a plain map (legacy/test wiring) or as the atom
+  holder the run drivers install: a failed recorded evaluation rolls the
+  instance back, the rollback publishes a fresh binding into the provider
+  registry, and the holder is reset to it — so this always derefs to the
+  binding the registry currently publishes."
   [ctx]
-  (:js1/binding ctx))
+  (let [b (:js1/binding ctx)]
+    (cond
+      (nil? b) nil
+      (map? b) b
+      :else (deref b))))
+
+(defn update-js1-binding!
+  "Install `binding` as the ctx's held JS1 binding.  No-op when the ctx
+  holds a plain map (an immutable ctx cannot be refreshed from inside a
+  tool; a driver that wants refreshable bindings wires the atom holder).
+  Returns `binding` so callers can thread it."
+  [ctx binding]
+  (let [b (:js1/binding ctx)]
+    (when (and b (not (map? b)))
+      (reset! b binding)))
+  binding)
+
+(defn js1-provider
+  "The controller-owned provider the binding was minted from, when the
+  driver wired one.  Re-binding through it is how a superseded binding is
+  re-acquired after a rollback: bind! is idempotent per work-id and returns
+  the registry's CURRENT binding."
+  [ctx]
+  (:js1/provider ctx))
 
 (defn js1-profile?
   "True when the context is JS1-constrained.
@@ -76,6 +113,26 @@
   For diagnostics and prompt rendering only."
   []
   (sort js1-allowed-tools))
+
+(defn js1-assert-single-branch!
+  "Refuse a JS1-profiled run at multi-branch width, BEFORE any model work.
+
+  A JS1 binding is one persistent :main instance per work-id, and the
+  beam's branches would all evaluate into it: one branch's (def x) is
+  another branch's surprise, and a whole-history rebuild replays one
+  binding's record while the other branches wrote interleaved evals into
+  the same instance.  That is not a capability boundary that can be
+  enforced mid-run; it is a shape that must not start.  The guard throws
+  {:js1/error :multi-branch-not-supported} at the drivers' entry points,
+  before a run row is opened, a branch is spawned, or a provider call is
+  made — JS1 is single-player by construction."
+  [js1-active? width]
+  (when (and js1-active? (> (long width) 1))
+    (throw (ex-info (str "JS1 profile cannot run a multi-branch run (width "
+                         width "): a JS1 binding is one single-player SCI"
+                         " instance per work-id")
+                    {:js1/error :multi-branch-not-supported
+                     :beam-width width}))))
 
 ;; ─── Tool multimethod ─────────────────────────────────────────────────────
 

--- a/src/samizdat/agent/tools/base.clj
+++ b/src/samizdat/agent/tools/base.clj
@@ -21,8 +21,63 @@
   "The tool multimethod and what every tool method shares: result helpers,
   missing-argument complaints, the :default method, tool-names, and the
   per-phase refusal the branch loop consults before dispatch. Tool groups
-  require this namespace; nothing here requires a group back."
+  require this namespace; nothing here requires a group back.
+
+  JS1 profile: when the context carries a JS1 binding (the canonical
+  signal — see js1-binding), the phase-refusal gate rejects every tool
+  name not in js1-allowed-tools before dispatch.  The model sees eval,
+  doc, complete, and done; file/shell/manifest/mutate etc. are refused
+  as policy. The live REPL is never reached in a JS1 context — eval
+  routes to the persistent SCI binding instead."
   (:require [clojure.string :as str]))
+
+;; ─── JS1 profile ─────────────────────────────────────────────────────────
+
+(def ^:private js1-allowed-tools
+  "The EXACT set of tool names a JS1-profiled context may dispatch.
+
+  eval, doc, complete — sandboxed REPL via the persistent SCI binding.
+  done — the only controller-event tool the model may emit.
+
+  Everything else (file, shell, manifest, mutate, lsp, ship, knowledge,
+  journal, messages, tasks, skills, introspect) is rejected before
+  dispatch by phase-refusal.  The list is deliberately minimal and
+  closed: adding a name here is a trust decision that grants the model
+  a new capability path inside the sandbox."
+  #{"eval" "doc" "complete" "done"})
+
+(defn js1-binding
+  "The ONE canonical JS1 signal: the controller-minted sandbox binding in
+  the ctx.  Tool restriction (phase-refusal below) and eval routing (the
+  repl tools) both derive their decision from this accessor — never from
+  :js1/profile, which is a display/journal label only.  One signal means
+  the two gates can never disagree about whether a context is sandboxed."
+  [ctx]
+  (:js1/binding ctx))
+
+(defn js1-profile?
+  "True when the context is JS1-constrained.
+
+  The canonical signal is the binding (js1-binding).  A ctx whose
+  :js1/profile flag is set but whose binding is nil is inconsistent —
+  and is still treated as JS1-constrained, so it stays tool-restricted
+  and the repl tools refuse it rather than falling through to live eval.
+  Set only by trusted config or workflow, never by model input."
+  [ctx]
+  (boolean (or (js1-binding ctx) (some? (:js1/profile ctx)))))
+
+(defn js1-allowed?
+  "True when tool-name is in the JS1 allowed vocabulary."
+  [tool-name]
+  (contains? js1-allowed-tools tool-name))
+
+(defn js1-tool-vocabulary
+  "The sorted list of tool names the JS1 profile permits.
+  For diagnostics and prompt rendering only."
+  []
+  (sort js1-allowed-tools))
+
+;; ─── Tool multimethod ─────────────────────────────────────────────────────
 
 (defmulti run-tool
   (fn [ctx] (:tool-name ctx)))
@@ -69,8 +124,8 @@
   requires are exactly what this function is already handed."
   [ctx & ks]
   (let [absent (remove #(let [v (arg ctx %)]
-                          (and (some? v) (not (and (string? v) (str/blank? v)))))
-                       ks)]
+                            (and (some? v) (not (and (string? v) (str/blank? v)))))
+                         ks)]
     (when (seq absent)
       (str "Missing required argument(s): " (str/join ", " (map name absent)) "."
            "\n\nA call to `" (:tool-name ctx) "` looks like:\n"
@@ -90,9 +145,22 @@
   the loop still asks — and the coding loop's phase policy plugs back in here
   when the loop-as-manifest work defines it. Any refusal returned from here
   must carry `:policy-refusal? true` so the cull record can tell a declined
-  call from a malformed fence."
-  [_ctx]
-  nil)
+  call from a malformed fence.
+
+  JS1 gate: when the ctx is JS1-constrained (js1-profile?, derived from
+  the canonical binding signal), the tool name is checked against the
+  closed JS1 vocabulary. A refused tool returns a :policy-refusal? result
+  explaining the JS1 constraint. This is the single enforcement point; no
+  JS1 tool method needs its own guard."
+  [ctx]
+  (when (js1-profile? ctx)
+    (let [tn (:tool-name ctx)]
+      (when-not (js1-allowed? tn)
+        (fail (:branch ctx)
+              (str "Tool `" tn "` is not available in this context."
+                   " JS1 profile permits only: "
+                   (str/join ", " (js1-tool-vocabulary)) ".")
+              :policy-refusal? true)))))
 
 
 ;; --- unknown ----------------------------------------------------------------

--- a/src/samizdat/agent/tools/repl.clj
+++ b/src/samizdat/agent/tools/repl.clj
@@ -15,45 +15,189 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 
 (ns samizdat.agent.tools.repl
   "The REPL tools: eval, doc, complete.
 
-  Evaluating Clojure in the live image is the primary feedback loop; these
-  three methods only dispatch it. See samizdat.agent.tools.base for the
-  shared result helpers and the run-tool multimethod."
+   In a JS1-profiled context (ctx carries a JS1 binding — the canonical
+   signal shared with the phase-refusal gate), these three tools route
+   through the persistent SCI sandbox binding instead of the live harness
+   image.  The model's `eval` lands in SCI, not in the JVM process, and is
+   durably recorded (intent before each effect, outcome after).
+   `doc` and `complete` are HOST-DERIVED safe capability discovery over
+   the binding's effective authority (samizdat.agent.sandbox/operation-doc
+   and complete-capability): no resolve/find-ns/ns-publics/meta form is
+   ever evaluated inside the sandbox, and untrusted symbol/prefix text is
+   matched as inert data, never spliced into evaluated source.
+
+   When no JS1 binding is present the tools fall through to the existing
+   live-REPL path (samizdat.repl), preserving every non-JS1 workflow.
+
+   The live REPL is NEVER reached in a JS1 context: routing consults the
+   same signal the tool gate consults, and a JS1 context whose binding is
+   missing is refused outright instead of falling through to live eval."
   (:require [clojure.string :as str]
             [samizdat.agent.tools.base :as base]
             [samizdat.repl :as repl]))
 
-(defmethod base/run-tool "eval" [{:keys [branch repl-session] :as ctx}]
-  ;; Evaluate Clojure in the live harness image. REPL-first development: the
-  ;; agent tries a form, sees the value and output, and iterates before
-  ;; committing it to a file. :neutral — evaluating establishes nothing on its
-  ;; own; a define-and-test is exploration, and progress is the file it leads
-  ;; to. Defs persist across evals within a run (the session is per-run).
+;; --- JS1 sandbox path --------------------------------------------------------
+
+(defn- sandbox-var
+  "Resolve a samizdat.agent.sandbox var at call time, so this namespace
+   stays loadable where the sandbox (and its SCI dependency) is absent —
+   non-JS1 workflows pay no dependency cost.  Returns the var, or nil
+   when the sandbox namespace is unavailable."
+  [var-name]
+  (try
+    (requiring-resolve (symbol "samizdat.agent.sandbox" var-name))
+    (catch Throwable _ nil)))
+
+(defn- js1-route
+  "Resolve eval/doc/complete routing from the ONE canonical JS1 signal,
+   the same accessor the phase-refusal gate reads (base/js1-binding).
+
+   Returns the binding for a JS1 context, ::unbound for a JS1 context
+   whose binding is missing — impossible when workflow/resume wired the
+   ctx, and refused rather than routed to the live REPL — or nil for a
+   plain non-JS1 context."
+  [ctx]
+  (cond
+    (some? (base/js1-binding ctx)) (base/js1-binding ctx)
+    (base/js1-profile? ctx) ::unbound
+    :else nil))
+
+(defn- js1-refusal
+  "The fail-closed result for a JS1 context that cannot be routed to its
+   sandbox.  Never a live-eval fallthrough: authority was fixed at bind
+   time, so a missing binding is a wiring fault to surface, not a seam
+   to route around."
+  [branch]
+  (base/fail branch
+             (str "This is a JS1-sandboxed context but its sandbox binding"
+                  " is missing; refusing to evaluate outside the sandbox.")))
+
+(defn- js1-eval-result
+  "Evaluate `code` in the JS1 sandbox binding, appending a durable JS1
+   record via the store adapter (evaluate-recorded!).  Returns the same
+   shape as repl/eval-code: {:ok true/false, :value/:error, :out}.
+
+   The interrupt ceiling is the spec's :timeout-ms, fixed at bind time —
+   a model-supplied timeout is not an option here, exactly as it cannot
+   select any other authority."
+  [conn binding code]
+  (try
+    (let [evaluate! (sandbox-var "evaluate-recorded!")]
+      (if (nil? evaluate!)
+        {:ok false
+         :error "JS1 sandbox is unavailable; refusing live-eval fallback"
+         :error-type "sandbox-unavailable"
+         :out nil}
+        {:ok true :value (pr-str (:value (evaluate! conn binding code))) :out nil}))
+    (catch ExceptionInfo e
+      (let [d (ex-data e)]
+        (if (:samizdat.sandbox/error d)
+          {:ok false
+           :error (ex-message e)
+           :error-type (str (:samizdat.sandbox/error d))
+           :out nil}
+          {:ok false :error (ex-message e)
+           :error-type (str (type e)) :out nil})))
+    (catch Throwable e
+      {:ok false :error (or (ex-message e) (str e))
+       :error-type (str (type e)) :out nil})))
+
+(defn- js1-doc-result
+  "Doc lookup inside the JS1 sandbox: host-derived safe capability
+   discovery ONLY.  Delegates to samizdat.agent.sandbox/operation-doc,
+   which describes authorized projected operations from inert authority
+   data and never evaluates any form inside the sandbox.  Returns the
+   same shape as repl/doc-sym, or {:not-found true}."
+  [binding sym-str]
+  (or (when-let [doc-fn (sandbox-var "operation-doc")]
+        (doc-fn binding sym-str))
+      {:not-found true :symbol (str sym-str)}))
+
+(defn- js1-complete-result
+  "Completion inside the JS1 sandbox: host-derived safe capability
+   discovery ONLY.  Delegates to samizdat.agent.sandbox/complete-capability
+   (inert prefix filtering over effective authority); never evaluates
+   ns-publics or any other form inside the sandbox.  Returns a seq of
+   strings."
+  [binding prefix]
+  (if-let [complete-fn (sandbox-var "complete-capability")]
+    (complete-fn binding (str prefix))
+    []))
+
+;; --- Tool dispatch methods ----------------------------------------------------
+
+(defn- eval-format-result
+  "Format an eval result map for the model. Shared by JS1 and live paths."
+  [branch r]
+  (if (:ok r)
+    (base/ok branch (str "=> " (:value r)
+                     (when (seq (:out r)) (str "\n" (:out r)))))
+    (base/fail branch (str "Eval error: " (:error r)
+                      (when (seq (:out r)) (str "\n" (:out r)))))))
+
+(defmethod base/run-tool "eval" [{:keys [branch] :as ctx}]
   (if-let [m (base/missing ctx :code)]
     (base/malformed branch m)
-    (let [timeout (some-> (base/arg ctx :timeout-ms) str str/trim not-empty parse-long)
-          r (repl/eval-code (str (base/arg ctx :code)) repl-session timeout)]
-      (if (:ok r)
-        (base/ok branch (str "=> " (:value r)
-                        (when (seq (:out r)) (str "\n" (:out r)))))
-        (base/fail branch (str "Eval error: " (:error r)
-                          (when (seq (:out r)) (str "\n" (:out r)))))))))
+    (let [code (str (base/arg ctx :code))
+          route (js1-route ctx)]
+      (cond
+        ;; JS1 path: evaluate in the persistent SCI binding, durably
+        ;; recorded.  The spec's timeout ceiling governs; a model-supplied
+        ;; timeout is not forwarded (authority is fixed at bind time).
+        (some? route) (if (= ::unbound route)
+                        (js1-refusal branch)
+                        (eval-format-result
+                          branch (js1-eval-result (:conn ctx) route code)))
+        ;; Non-JS1 path: live REPL (unchanged)
+        :else (eval-format-result
+                branch (repl/eval-code code (:repl-session ctx)
+                                       (some-> (base/arg ctx :timeout-ms)
+                                               str str/trim not-empty parse-long)))))))
 
 (defmethod base/run-tool "doc" [{:keys [branch] :as ctx}]
   (if-let [m (base/missing ctx :symbol)]
     (base/malformed branch m)
-    (let [d (repl/doc-sym (str (base/arg ctx :symbol)))]
-      (if (:not-found d)
-        (base/malformed branch (str "No var " (base/arg ctx :symbol) " is loaded."))
-        (base/ok branch (str (:name d) "\n" (pr-str (:arglists d)) "\n\n" (:doc d)))))))
+    (let [sym-str (str (base/arg ctx :symbol))
+          route (js1-route ctx)]
+      (cond
+        ;; JS1 path: host-derived safe capability discovery
+        (some? route) (if (= ::unbound route)
+                        (js1-refusal branch)
+                        (let [d (js1-doc-result route sym-str)]
+                          (if (:not-found d)
+                            (base/malformed
+                              branch (str "No var " sym-str " is available in this context."
+                                          " Authorized sandbox operations: "
+                                          (str/join ", " (js1-complete-result route "")) "."))
+                            (base/ok branch (str (:name d) "\n" (pr-str (:arglists d))
+                                                 "\n\n" (:doc d))))))
+        ;; Non-JS1 path: live REPL var resolution (unchanged)
+        :else (let [d (repl/doc-sym sym-str)]
+                (if (:not-found d)
+                  (base/malformed branch (str "No var " sym-str " is loaded."))
+                  (base/ok branch (str (:name d) "\n" (pr-str (:arglists d))
+                                       "\n\n" (:doc d)))))))))
 
 (defmethod base/run-tool "complete" [{:keys [branch] :as ctx}]
   (if-let [m (base/missing ctx :prefix)]
     (base/malformed branch m)
-    (let [ms (repl/complete (str (base/arg ctx :prefix)))]
-      (base/ok branch (if (seq ms)
-                   (str/join "\n" (take 50 ms))
-                   (str "No symbols match " (base/arg ctx :prefix) "."))))))
+    (let [prefix-str (str (base/arg ctx :prefix))
+          route (js1-route ctx)]
+      (cond
+        ;; JS1 path: host-derived safe capability discovery
+        (some? route) (if (= ::unbound route)
+                        (js1-refusal branch)
+                        (let [ms (js1-complete-result route prefix-str)]
+                          (base/ok branch (if (seq ms)
+                                       (str/join "\n" (take 50 ms))
+                                       (str "No symbols match " prefix-str ".")))))
+        ;; Non-JS1 path: live REPL (unchanged)
+        :else (let [ms (repl/complete prefix-str)]
+                (base/ok branch (if (seq ms)
+                             (str/join "\n" (take 50 ms))
+                             (str "No symbols match " prefix-str "."))))))))

--- a/src/samizdat/agent/tools/repl.clj
+++ b/src/samizdat/agent/tools/repl.clj
@@ -31,12 +31,19 @@
    ever evaluated inside the sandbox, and untrusted symbol/prefix text is
    matched as inert data, never spliced into evaluated source.
 
-   When no JS1 binding is present the tools fall through to the existing
-   live-REPL path (samizdat.repl), preserving every non-JS1 workflow.
+    When no JS1 binding is present the tools fall through to the existing
+    live-REPL path (samizdat.repl), preserving every non-JS1 workflow.
 
-   The live REPL is NEVER reached in a JS1 context: routing consults the
-   same signal the tool gate consults, and a JS1 context whose binding is
-   missing is refused outright instead of falling through to live eval."
+    The live REPL is NEVER reached in a JS1 context: routing consults the
+    same signal the tool gate consults, and a JS1 context whose binding is
+    missing is refused outright instead of falling through to live eval.
+
+    Commit-only rollback: a failed recorded evaluation supersedes the
+    binding in the provider registry, so after any sandbox-domain
+    evaluation error the eval tool re-acquires the current binding and
+    installs it into the ctx's holder (base/update-js1-binding!) — the
+    NEXT eval works.  An observed :stale-binding is retried once on the
+    fresh binding."
   (:require [clojure.string :as str]
             [samizdat.agent.tools.base :as base]
             [samizdat.repl :as repl]))
@@ -69,22 +76,39 @@
 
 (defn- js1-refusal
   "The fail-closed result for a JS1 context that cannot be routed to its
-   sandbox.  Never a live-eval fallthrough: authority was fixed at bind
-   time, so a missing binding is a wiring fault to surface, not a seam
-   to route around."
+  sandbox.  Never a live-eval fallthrough: authority was fixed at bind
+  time, so a missing binding is a wiring fault to surface, not a seam
+  to route around."
   [branch]
   (base/fail branch
              (str "This is a JS1-sandboxed context but its sandbox binding"
                   " is missing; refusing to evaluate outside the sandbox.")))
 
-(defn- js1-eval-result
-  "Evaluate `code` in the JS1 sandbox binding, appending a durable JS1
-   record via the store adapter (evaluate-recorded!).  Returns the same
-   shape as repl/eval-code: {:ok true/false, :value/:error, :out}.
+(defn- js1-reacquire
+  "Re-acquire the CURRENT binding for the held one's work-id from the
+  ctx's provider.  bind! is idempotent per work-id — equal key and spec
+  return the registry's present binding — and a rollback/rebuild is
+  exactly a registry publication of a fresh instance under the same
+  identity, so this is the sanctioned way back to a usable binding.
+  Reconstructs the bind options from the held binding's own spec, so the
+  coordinate matches and the call cannot widen anything.  Returns the
+  fresh binding, or nil when there is no provider or no sandbox."
+  [ctx stale]
+  (when-let [provider (base/js1-provider ctx)]
+    (when-let [bind-fn (sandbox-var "bind!")]
+      (let [spec (:spec stale)
+            opts (-> {:preset (:preset spec)
+                      :root (:root spec)
+                      :instance/key (:instance/key stale)}
+                     (into (:bounds spec))
+                     (assoc :capabilities (set (:capabilities spec))
+                            :timeout-ms (:timeout-ms spec)))]
+        (bind-fn provider (:work-id stale) opts)))))
 
-   The interrupt ceiling is the spec's :timeout-ms, fixed at bind time —
-   a model-supplied timeout is not an option here, exactly as it cannot
-   select any other authority."
+(defn- js1-eval-once
+  "One recorded evaluation attempt against `binding`.  Returns the repl
+  result shape plus, on a sandbox-domain failure, the structured error
+  data so the caller can decide whether the binding was superseded."
   [conn binding code]
   (try
     (let [evaluate! (sandbox-var "evaluate-recorded!")]
@@ -100,12 +124,65 @@
           {:ok false
            :error (ex-message e)
            :error-type (str (:samizdat.sandbox/error d))
+           :sandbox-error (:samizdat.sandbox/error d)
            :out nil}
           {:ok false :error (ex-message e)
            :error-type (str (type e)) :out nil})))
     (catch Throwable e
       {:ok false :error (or (ex-message e) (str e))
        :error-type (str (type e)) :out nil})))
+
+(defn- js1-eval-result
+  "Evaluate `code` in the ctx's JS1 binding, appending a durable JS1
+  record via the store adapter (evaluate-recorded!).  Returns the same
+  shape as repl/eval-code: {:ok true/false, :value/:error, :out}.
+
+  The interrupt ceiling is the spec's :timeout-ms, fixed at bind time —
+  a model-supplied timeout is not an option here, exactly as it cannot
+  select any other authority.
+
+  Commit-only state means a FAILED evaluation rolled the instance back
+  and published a fresh binding into the provider registry: the binding
+  this call held is superseded, and the next evaluate-recorded! on it
+  would be refused as :stale-binding.  So after any FAILED recorded
+  evaluation the tool re-acquires the current binding and installs it
+  into the ctx's holder (update-js1-binding!) — the next eval works.
+  The re-acquire is best-effort: it cannot widen anything (the options
+  come from the held binding's own spec), and a refresh that itself
+  fails must not mask the evaluation's real error.  An observed
+  :stale-binding (a supersession this harness did not witness, e.g. a
+  concurrent rebuild) additionally retries the evaluation ONCE on the
+  fresh binding, because the model asked for an evaluation, not for an
+  error about wiring it cannot see."
+  [ctx code]
+  (let [conn (:conn ctx)
+        binding (base/js1-binding ctx)
+        refresh! (fn [stale]
+                   (try
+                     (when-let [fresh (js1-reacquire ctx stale)]
+                       (base/update-js1-binding! ctx fresh))
+                     (catch Throwable _ nil)))]
+    (loop [binding binding, retried? false]
+      (let [r (js1-eval-once conn binding code)]
+        (cond
+          (:ok r) r
+
+          ;; A supersession this harness did not witness.  Re-acquire and
+          ;; retry once — never twice, an unbounded retry would spend the
+          ;; turn laundering a genuinely broken wiring.
+          (and (= :stale-binding (:sandbox-error r)) (not retried?))
+          (if-let [fresh (js1-reacquire ctx binding)]
+            (do (base/update-js1-binding! ctx fresh)
+                (recur fresh true))
+            r)
+
+          ;; Any other failure ran the commit-only rollback (or never
+          ;; reached the sandbox at all): the held binding may be
+          ;; superseded even though THIS result is a legitimate evaluation
+          ;; error the model must see.  Refresh the holder so the NEXT
+          ;; eval works; report the original error untouched.
+          :else (do (refresh! binding)
+                    r))))))
 
 (defn- js1-doc-result
   "Doc lookup inside the JS1 sandbox: host-derived safe capability
@@ -145,19 +222,19 @@
     (base/malformed branch m)
     (let [code (str (base/arg ctx :code))
           route (js1-route ctx)]
-      (cond
-        ;; JS1 path: evaluate in the persistent SCI binding, durably
-        ;; recorded.  The spec's timeout ceiling governs; a model-supplied
-        ;; timeout is not forwarded (authority is fixed at bind time).
-        (some? route) (if (= ::unbound route)
-                        (js1-refusal branch)
-                        (eval-format-result
-                          branch (js1-eval-result (:conn ctx) route code)))
-        ;; Non-JS1 path: live REPL (unchanged)
-        :else (eval-format-result
-                branch (repl/eval-code code (:repl-session ctx)
-                                       (some-> (base/arg ctx :timeout-ms)
-                                               str str/trim not-empty parse-long)))))))
+       (cond
+         ;; JS1 path: evaluate in the persistent SCI binding, durably
+         ;; recorded.  The spec's timeout ceiling governs; a model-supplied
+         ;; timeout is not forwarded (authority is fixed at bind time).
+         (some? route) (if (= ::unbound route)
+                         (js1-refusal branch)
+                         (eval-format-result
+                           branch (js1-eval-result ctx code)))
+         ;; Non-JS1 path: live REPL (unchanged)
+         :else (eval-format-result
+                 branch (repl/eval-code code (:repl-session ctx)
+                                        (some-> (base/arg ctx :timeout-ms)
+                                                str str/trim not-empty parse-long)))))))
 
 (defmethod base/run-tool "doc" [{:keys [branch] :as ctx}]
   (if-let [m (base/missing ctx :symbol)]

--- a/src/samizdat/agent/tools/ship.clj
+++ b/src/samizdat/agent/tools/ship.clj
@@ -10,6 +10,7 @@
             [samizdat.agent.tools.base :as base]
             [samizdat.agent.state :as state]
             [samizdat.agent.verify :as verify]
+            [samizdat.engine.proc :as proc]
             [samizdat.store.journal :as journal]))
 
 
@@ -275,36 +276,78 @@
                      " the question that was asked."))
         ;; The test rung — what makes the loop test-driven rather than one-shot.
         ;; `done` is not terminal until the unit's tests actually pass: run the
-        ;; unit's tests, and a red / hollow / untested result is fed back so the
-        ;; branch keeps iterating. Verification is FOCUSED — it runs only the
-        ;; test namespaces the branch touched, so the loop iterates in seconds
-        ;; against its own new test. On when a :verify-cmd is set or
-        ;; :verify-focused? is true; loops with neither behave exactly as before.
+        ;; unit's tests, and a red / hollow / untested / REFUSED result is fed
+        ;; back so the branch keeps iterating. Verification is FOCUSED — it
+        ;; runs only the test namespaces the branch touched, so the loop
+        ;; iterates in seconds against its own new test — and it is a
+        ;; STRUCTURED request end to end (verify/verify-request -> verify/
+        ;; run-verify -> proc/scope-run): the model's only input is this
+        ;; `done` call, the changed paths it influenced are validated against
+        ;; verify's narrow namespace grammar (unrepresentable paths REFUSE
+        ;; focused verification), the operator's :verify-cmd is the sole
+        ;; fallback and receives no model input, and execution is argv/cwd/
+        ;; scrubbed-allowlist-env/timeout/caps with a process-tree kill
+        ;; guarantee — no shell composes anything. On when a :verify-cmd is
+        ;; set or :verify-focused? is true; loops with neither behave exactly
+        ;; as before.
         verify-cmd (get-in ctx [:config :run :verify-cmd])
         verify-focused? (get-in ctx [:config :run :verify-focused?] false)
         require-test? (get-in ctx [:config :run :require-test?] true)
         verify-on? (and (nil? block)
                         (or verify-focused? (not (str/blank? (str verify-cmd)))))
+        ;; The execution boundary, probed ONCE up front (capability probe,
+        ;; no spawn): without the scoped primitive, gitdiff already answered
+        ;; cannot-tell (its git calls go through the same primitive) and
+        ;; run-verify would report unavailable — but the DECISION and the
+        ;; journal need the fact here, so the trust fallthrough for
+        ;; cannot-tell can never absorb a missing executor. An unavailable
+        ;; gate blocks; it never silently permits a ship.
+        unsupported? (and verify-on? (not (proc/scope-supported?)))
         changed (when verify-on? (gitdiff/changed-files (:root ctx) (:git-baseline ctx)))
-        ;; Prefer the focused command; fall back to the configured one. Run only
-        ;; when the cheap pre-checks (nothing changed / no test yet) haven't
-        ;; already doomed the ship — a wasted suite run is a wasted minute.
-        cmd (when verify-on? (or (and verify-focused? (verify/focused-cmd changed)) verify-cmd))
+        ;; The structured request, derived (never composed): focused over
+        ;; validated namespaces, the operator's configured fallback, a
+        ;; refusal, an :invalid misconfiguration, or nothing to run.
+        vrequest (when verify-on?
+                   (verify/verify-request {:changed changed
+                                           :focused? verify-focused?
+                                           :fallback-cmd verify-cmd}))
+        ;; Run only when the cheap pre-checks (nothing changed / no test yet)
+        ;; haven't already doomed the ship. A :refused or :invalid request
+        ;; still goes through run-verify — which spawns NOTHING for them —
+        ;; so the refusal/misconfiguration lands in the result AND the
+        ;; durable ship-verify journal record, not just the block message.
         pre-doomed? (or (and (some? changed) (empty? changed))
                         (and require-test? (some? changed) (seq changed)
                              (not (some verify/test-file? changed))))
-        vresult (when (and verify-on? cmd (not pre-doomed?))
-                  (verify/run-verify (:root ctx) cmd
+        vresult (when (and verify-on? vrequest (not pre-doomed?))
+                  (verify/run-verify (:root ctx) vrequest
                                      (get-in ctx [:config :run :verify-timeout-ms])))
         verify-block (verify/verify-block
                       {:verify-on? verify-on? :result vresult
+                       :request vrequest :unsupported? unsupported?
                        :changed changed :require-test? require-test?})
-        block (or block verify-block)]
-    (when (and vresult (:conn ctx) (:run-id ctx))
+        block (or block verify-block)
+        ;; The durable verification record: written whenever the rung had
+        ;; something to say — a run happened, a request was REFUSED, the
+        ;; config was invalid, or the runtime cannot verify at all. Every
+        ;; one of those is a ship-verification FACT the run record must
+        ;; keep, and each one blocks the ship it describes.
+        vrecord (when verify-on?
+                  (or vresult (when unsupported? {:unsupported? true})))
+        vdata (when vrecord
+                {:green (:green? vrecord) :timeout (:timeout? vrecord)
+                 :exit (:exit vrecord)
+                 :kind (:kind vrequest)
+                 :refused (when (= :refused (:kind vrequest))
+                            (vec (take 8 (map str (:refused vrequest)))))
+                 :refused? (boolean (:refused? vrecord))
+                 :invalid-config? (boolean (:invalid-config? vrecord))
+                 :unsupported? (boolean (:unsupported? vrecord))
+                 :blocked (some? verify-block)})]
+    (when (and vdata (:conn ctx) (:run-id ctx))
       (journal/note! (:conn ctx) (:run-id ctx) :ship-verify
                      {:branch-id (:id branch) :turn (:turn ctx)
-                      :data {:green (:green? vresult) :timeout (:timeout? vresult)
-                             :blocked (some? verify-block)}}))
+                      :data vdata}))
     ;; Journalled whether or not anything blocked, so the run record still
     ;; shows what the lexical check saw even though words no longer decide.
     (when-let [words (and (:conn ctx) (:run-id ctx)

--- a/src/samizdat/agent/verify.clj
+++ b/src/samizdat/agent/verify.clj
@@ -4,20 +4,68 @@
 (ns samizdat.agent.verify
   "The ship gate's test rung — what makes the worker loop TEST-DRIVEN instead of
   one-shot. A `done` is not terminal until the unit's tests actually pass: the
-  gate runs the verify command, and a red run (or a hollow / untested change) is
-  fed back so the branch keeps iterating (edit -> run -> observe -> fix) rather
-  than shipping unverified work.
+  gate runs the verification, and a red run (or a hollow / untested / REFUSED
+  change) is fed back so the branch keeps iterating (edit -> run -> observe ->
+  fix) rather than shipping unverified work.
 
-  Verification is FOCUSED by default: it runs only the test namespaces the branch
-  actually touched, so the loop iterates in seconds against its own new test
-  rather than paying for the whole suite each time. A configured :verify-cmd is
-  the fallback when nothing focusable changed.
+  Verification is FOCUSED by default: it runs only the test namespaces the
+  branch actually touched, so the loop iterates in seconds against its own new
+  test rather than paying for the whole suite each time. A configured
+  :verify-cmd is the fallback when nothing focusable changed — or when a
+  changed path cannot be SAFELY represented (below).
 
-  The runner is a thin effect; the DECISION (`verify-block`) and the command
-  derivation (`focused-cmd`) are pure, so the gate is testable without spawning a
-  process. Same split as planner.clj vs cells/team.clj."
+  Trust shape (the critical finding of docs/code-review-2026-08-3.md): the
+  model's only input to verification is the `done` call itself. The paths
+  focused verification reads come from git, and a path a model can name is
+  attacker-controlled data, so they are validated against a NARROW namespace
+  grammar and every unrepresentable path REFUSES focused verification —
+  falling back to the operator's configured command only when one already
+  exists, never to anything derived from the paths. Execution is one
+  STRUCTURED request — argv vector, cwd, explicit scrubbed allowlist
+  environment, timeout, independent stdout/stderr byte caps — through
+  samizdat.engine.proc/scope-run (jolt.host's scoped process primitive),
+  so no shell composes anything and no controller environment is
+  inherited; the process TREE is bounded by the primitive's
+  TERM/grace/KILL//proc-confirmed-empty ladder; and the ENTIRE output is
+  redacted (samizdat.security.secrets) before any model-visible
+  rendering of it happens.
+
+  The runner is a thin effect; the DECISION (`verify-block`) and the
+  derivations (`verify-request`, `ns-from-test-path`) are pure, so the gate is
+  testable without spawning a process. Same split as planner.clj vs
+  cells/team.clj."
   (:require [clojure.string :as str]
-            [samizdat.engine.proc :as proc]))
+            [samizdat.engine.proc :as proc]
+            [samizdat.security.secrets :as secrets]
+            [samizdat.util :as util]))
+
+(def default-timeout-ms
+  "The verify timeout when :run :verify-timeout-ms is not configured — the
+  same 10 minutes the rung always allowed."
+  600000)
+
+(def term-grace-ms
+  "How long a timed-out verification tree gets to die of SIGTERM before the
+  KILL wave — generous enough for a Clojure runtime to flush, short enough
+  that the rung still decides in seconds."
+  2000)
+
+(def out-bytes
+  "The independent stdout byte cap for a verification run. A suite flooding
+  past this is truncated, marked as such in the model-visible output, and
+  ENDED (the overflow runs the same kill ladder a timeout runs) — a flooded
+  log is not a green one."
+  131072)
+
+(def err-bytes
+  "The independent stderr byte cap — same semantics, separate stream: neither
+  flood can starve the other's drain."
+  131072)
+
+(def render-chars
+  "How much of the (already redacted, already capped) output the block
+  message renders — the failure tail the branch acts on, bounded."
+  6000)
 
 (defn test-file?
   "Whether a changed path is a test/spec file — the evidence that a change was
@@ -25,38 +73,156 @@
   [path]
   (boolean (re-find #"(?i)(^|/)(test|spec)s?/|[_-](test|spec)\.[a-z]+$" (str path))))
 
+;; --- focused derivation, against a narrow grammar -----------------------------
+;;
+;; The old derivation replaced _ and / in a changed path and interpolated the
+;; result into a shell string; the safety argument was that the expression
+;; carries no quote of its own — which assumes away exactly the character a
+;; model-chosen file name can carry. The derivation is still _ and / — but its
+;; OUTPUT is now checked against a grammar narrow enough that nothing derived
+;; from a changed path can mean anything but a namespace, and anything that
+;; fails is REFUSED (named, fed back, fail-closed), never skipped silently and
+;; never passed through.
+
+(def ^:private ns-segment-re
+  "One segment of the narrow namespace grammar focused verification will
+  materialize into an argv: a lowercase letter, then lowercase alphanumerics
+  and single hyphens. Anything a changed path derives outside this — quotes,
+  semicolons, any shell metacharacter, whitespace, casing, Unicode, leading
+  digits or dashes, dot or traversal segments — is unrepresentable."
+  #"[a-z][a-z0-9]*(-[a-z0-9]+)*")
+
+(def ^:private ns-re
+  "A whole derived namespace: dot-joined narrow segments (ns-segment-re —
+  keep the two literals in sync). This is the entire safety argument for
+  the focused argv: a string matching it is inert as Clojure data and
+  inert as an argv element."
+  #"^[a-z][a-z0-9]*(-[a-z0-9]+)*(\.[a-z][a-z0-9]*(-[a-z0-9]+)*)*$")
+
+(def ^:private clj-ext-any
+  "Detection of a Clojure test path is case-insensitive, so a name like
+  x_test.CLJ still counts as a test claim (and is then refused — the strict
+  strip below will not take the extension)."
+  #"(?i)\.cljc?$")
+
+(def ^:private clj-ext-strict
+  "The extension the derivation can actually strip: lowercase .clj/.cljc."
+  #"\.cljc?$")
+
 (defn ns-from-test-path
   "The Clojure namespace a test file defines: strip the leading source root
-  (test/ or gui/), drop the extension, '/'->'.', '_'->'-'. Returns nil for a
-  non-Clojure path.
+  (test/ or gui/ or src/), drop the extension, '/'->'.', '_'->'-'. Returns
+  the namespace ONLY when the whole derivation stays inside the narrow
+  grammar — nil otherwise, and the caller REFUSES the path: a changed test
+  path that cannot be represented is an adversarial or broken name, and the
+  honest outcomes are the operator's configured fallback or a blocked ship,
+  never a silent skip and never a passthrough.
   e.g. \"test/samizdat/agent/decompose_test.clj\" -> \"samizdat.agent.decompose-test\"."
   [path]
-  (let [p (str path)]
-    (when (re-find #"\.cljc?$" p)
-      (-> p
-          (str/replace #"^(test|gui|src)/" "")
-          (str/replace #"\.cljc?$" "")
-          (str/replace "_" "-")
-          (str/replace "/" ".")
-          not-empty))))
+  (when (and (string? path)
+             (re-find clj-ext-any path)
+             (re-find clj-ext-strict path))
+    (let [ns (-> path
+                 (str/replace #"^(test|gui|src)/" "")
+                 (str/replace #"\.cljc?$" "")
+                 (str/replace "_" "-")
+                 (str/replace "/" ".")
+                 not-empty)]
+      (when (and ns (re-matches ns-re ns))
+        ns))))
 
-(defn focused-cmd
-  "A test command that runs ONLY the test namespaces among `changed`, with an
-  exit code that reflects pass/fail (jolt's bare -e does not exit non-zero on a
-  failed assertion, so the expression sets the code itself). nil when no test
-  namespace changed — the caller then falls back to the configured :verify-cmd."
+(defn focused-namespaces
+  "Split the Clojure test paths among `changed` into {:nses […]} — the
+  namespaces focused verification may run — and {:refused […]} — the paths it
+  must refuse. Only paths that both claim to be tests (test-file?) and claim
+  to be Clojure (a .clj/.cljc extension, any case) are classified; a non-
+  Clojure test path (a fixture under tests/) is neither focusable nor
+  suspicious, exactly as before. A nil `changed` (git cannot tell) classifies
+  to nothing."
   [changed]
-  (let [nses (->> changed (filter test-file?) (keep ns-from-test-path) distinct vec)]
-    (when (seq nses)
-      (let [quoted (str/join " " (map #(str "(quote " % ")") nses))
-            expr (str "(require (quote clojure.test) " quoted ")"
-                      "(let [s (clojure.test/run-tests " quoted ")]"
-                      "(clojure.core/println s)"
-                      "(clojure.core/flush)"
-                      "(java.lang.System/exit (if (clojure.core/pos? (+ (:fail s) (:error s))) 1 0)))")]
-        ;; single-quote the whole -e expression for sh -c; the expr has no single
-        ;; quotes of its own (quote, not '), so this is safe.
-        (str "jolt -A:test -e '" expr "'")))))
+  (reduce (fn [acc path]
+            (if-let [n (ns-from-test-path path)]
+              (update acc :nses conj n)
+              (update acc :refused conj (str path))))
+          {:nses [] :refused []}
+          (filter #(and (test-file? %) (re-find clj-ext-any (str %)))
+                  (or changed []))))
+
+(defn- focused-argv
+  "The argv that runs ONLY `nses`: jolt's -A:test classpath with an -e
+  expression that requires the namespaces, runs them, prints the summary and
+  exits non-zero on any failure or error (a bare -e does not set the code).
+  The namespace strings are already grammar-validated — inert as data — and
+  the whole expression is ONE argv element handed to the scoped primitive:
+  there is no shell to quote it for, so quoting cannot be gotten wrong."
+  [nses]
+  (let [quoted (str/join " " (map #(str "(quote " % ")") (distinct nses)))
+        expr (str "(require (quote clojure.test) " quoted ")"
+                  "(let [s (clojure.test/run-tests " quoted ")]"
+                  "(clojure.core/println s)"
+                  "(clojure.core/flush)"
+                  "(java.lang.System/exit (if (clojure.core/pos? (+ (:fail s) (:error s))) 1 0)))")]
+    ["jolt" "-A:test" "-e" expr]))
+
+(defn- fallback-argv
+  "The trusted operator fallback as argv: the configured :verify-cmd string,
+  VERBATIM, as the single operand of sh -c. This is the only shell anywhere
+  on the verify path, and it is structurally composition-free: nothing —
+  root, cwd, changed path, namespace, timeout — is ever interpolated into
+  the string, which comes from operator config alone (verify-request is its
+  only caller and passes the config value untouched). The cwd is the
+  request's :dir, the environment is the scrubbed allowlist, and the process
+  tree is scoped and bounded exactly like the focused run — the operator's
+  fallback POLICY (a shell command, run in the project root, exit 0 passes)
+  is preserved whole, while the model's input stays outside it."
+  [cmd]
+  ["sh" "-c" cmd])
+
+(defn verify-request
+  "Derive the STRUCTURED verification request for a `done` from `changed`
+  (the git-reported changed paths), `focused?` (the :verify-focused?
+  config) and `fallback-cmd` (the operator's :verify-cmd — used only when
+  a non-blank string is ALREADY configured; nothing is ever invented here).
+
+  Returns one of:
+    {:kind :focused  :argv […] :nses […]}   run only the changed tests
+    {:kind :fallback :argv […] }            run the operator's command
+    {:kind :refused  :refused […]}          unrepresentable changed paths
+                                            and NO trusted fallback —
+                                            nothing may run
+    {:kind :invalid  :reason …}              the configured :verify-cmd is
+                                            present but not a command
+                                            STRING — an operator error,
+                                            which FAILS CLOSED (blocks)
+                                            rather than silently
+                                            skipping verification
+    nil                                     focused? off with no fallback,
+                                            or nothing focusable changed
+                                            with no fallback — the rung's
+                                            existing not-run semantics.
+
+  Model input enters ONLY through `changed`, and it can only choose between
+  focused-over-validated-namespaces and the refused / configured-fallback
+  outcomes — never an executable, argv element, env var, cwd or timeout of
+  its own. The one non-model input that can refuse the request is a
+  malformed OPERATOR config, and that refusal is a block, not a skip."
+  [{:keys [changed focused? fallback-cmd]}]
+  (let [invalid (when (and (some? fallback-cmd) (not (string? fallback-cmd)))
+                  {:kind :invalid
+                   :reason (str ":run :verify-cmd must be a shell-command"
+                                " string when configured; got a "
+                                (type fallback-cmd))})
+        fallback (when (and (string? fallback-cmd) (seq (str/trim fallback-cmd)))
+                   {:kind :fallback :argv (fallback-argv fallback-cmd)})]
+    (or invalid
+        (if-not focused?
+          fallback
+          (let [{:keys [nses refused]} (focused-namespaces changed)]
+            (cond
+              (seq refused) (or fallback {:kind :refused :refused refused})
+              (seq nses)    {:kind :focused :argv (focused-argv nses)
+                             :nses (vec (distinct nses))}
+              :else         fallback))))))
 
 (defn- tail
   "The last n non-blank lines of s — enough of a failure to act on without
@@ -64,19 +230,129 @@
   [s n]
   (->> (str/split-lines (str s)) (remove str/blank?) (take-last n) (str/join "\n")))
 
+(defn- annotate-stream
+  "The captured stream with an honest marker when the cap or the kill cut it
+  short — the model must be able to tell a truncated log from a complete one
+  (and a truncated run is never green, so the marker explains the red)."
+  [s status cap which]
+  (str (or s "")
+       (case status
+         :truncated (str "\n… [" which " truncated at " cap " bytes]")
+         :partial   (str "\n… [" which " capture incomplete]")
+         nil)))
+
+(defn run-verify
+  "Execute a structured verification REQUEST (verify-request's shape) in
+  `root` and report whether it is green. The request's :argv is exec'd
+  DIRECTLY by the scoped primitive — cwd is `root`, the child environment is
+  the explicit scrubbed allowlist (nothing inherited from the controller),
+  the whole process TREE is bounded by `timeout-ms` (default
+  default-timeout-ms) through the primitive's TERM/grace/KILL ladder with
+  a /proc-confirmed-empty scope, and stdout/stderr are captured under the
+  independent out-bytes / err-bytes caps. The ENTIRE combined output is
+  redacted — existing secrets discipline: vendor-shaped credentials plus
+  every name-sensitive value the source environment holds — BEFORE any
+  model-visible rendering happens.
+
+  Fail-closed boundaries, checked before anything spawns: a :refused or
+  :invalid request returns a clear not-green result naming why (nothing
+  runs); a runtime without the scoped primitive returns an :unsupported?
+  result (proc/scope-supported? — verification NEVER degrades to an
+  inherited-env or unscoped spawn, and the caller blocks the ship); a
+  `timeout-ms` that is present but not a positive integer returns an
+  :invalid-config? result rather than defaulting or skipping.
+
+  Optional `env` (the source environment for the allowlist and the redaction
+  known-set) defaults to the controller's own; it is an operator/test seam,
+  never model input. Never throws — every failure mode reads as not-green,
+  which sends the branch back rather than shipping."
+  ([root request timeout-ms] (run-verify root request timeout-ms nil))
+  ([root request timeout-ms env]
+   (let [not-green (fn [m] (merge {:green? false :timeout? false} m))]
+     (cond
+       (= :refused (:kind request))
+       (not-green {:refused? true
+                   :output (str "verification refused: changed test path(s)"
+                                " cannot be represented safely and no"
+                                " trusted fallback is configured")})
+
+       (= :invalid (:kind request))
+       (not-green {:invalid-config? true
+                   :output (str "verification misconfigured: "
+                                (:reason request))})
+
+       ;; The scoped primitive is the only execution path this rung has;
+       ;; absent it, verification is UNAVAILABLE — never silently
+       ;; downgraded to an unscoped spawn or an inherited environment.
+       (not (proc/scope-supported?))
+       (not-green {:unsupported? true
+                   :output (str "verification unavailable: the scoped process"
+                                " execution primitive is not supported on"
+                                " this runtime (Linux with posix_spawn"
+                                " process-group and poll(2) support is"
+                                " required). Verification cannot run, so"
+                                " the ship is blocked rather than trusted.")})
+
+       (and (some? timeout-ms)
+            (or (not (int? timeout-ms)) (not (pos? timeout-ms))))
+       (not-green {:invalid-config? true
+                   :output (str "verification misconfigured: :run"
+                                " :verify-timeout-ms must be a positive"
+                                " integer milliseconds value when set; got "
+                                (pr-str timeout-ms) ". The ship is blocked"
+                                " rather than defaulted.")})
+
+       :else
+       (try
+         (let [env (or env (into {} (System/getenv)))
+               r (proc/scope-run {:cmd (:argv request)
+                                  :dir (str root)
+                                  :env (proc/scrubbed-allowlist-env env)
+                                  :timeout-ms (or timeout-ms default-timeout-ms)
+                                  :term-grace-ms term-grace-ms
+                                  :out-bytes out-bytes
+                                  :err-bytes err-bytes})
+               out (annotate-stream (:out r) (:out-status r) out-bytes "stdout")
+               err (annotate-stream (:err r) (:err-status r) err-bytes "stderr")]
+           {:green? (and (not (:timed-out r)) (zero? (or (:exit r) 1)))
+            :timeout? (boolean (:timed-out r))
+            :exit (:exit r)
+            ;; known-values returns a set; secrets/redact canonicalizes any
+            ;; seqable itself (longest-first, since the jolt
+            ;; distinct-over-set fix), and vec just keeps the call shape
+            ;; explicitly a seq of values.
+            :output (secrets/redact (str out "\n" err)
+                                    (vec (secrets/known-values env)))})
+         (catch Throwable e
+           (not-green {:output (str "verify command failed to run: "
+                                    (ex-message e))})))))))
+
 (defn verify-block
   "The pure ship decision. Returns nil when `done` may ship, or a block message
   explaining what to fix (which becomes the tool result the branch reads and
   iterates on).
 
-    :verify-on?   whether this loop verifies at all (a :verify-cmd or focused
-                  verification is configured). When false the rung is inert.
-    :result       {:green? :timeout? :output} from run-verify, or nil when the
-                  tests were not run (e.g. git could not tell what changed).
-    :changed      changed-files since the attempt baseline: a vector, [] for
-                  'genuinely nothing', or nil for 'git cannot tell'.
-    :require-test? enforce TDD — a change that includes no test file is refused."
-  [{:keys [verify-on? result changed require-test?]}]
+    :verify-on?     whether this loop verifies at all (a :verify-cmd or
+                    focused verification is configured). When false the
+                    rung is inert.
+    :request        the structured request verify-request derived — its
+                    :kind explains a refusal (:refused names the offending
+                    paths) or an operator misconfiguration (:invalid).
+    :result         {:green? :timeout? :output} from run-verify, or nil
+                    when the tests were not run (e.g. git could not tell
+                    what changed). :unsupported? / :invalid-config?
+                    results carry their own fail-closed branches below.
+    :changed        changed-files since the attempt baseline: a vector, []
+                    for 'genuinely nothing', or nil for 'git cannot tell'.
+    :require-test?  enforce TDD — a change that includes no test file is
+                    refused.
+    :unsupported?   the runtime cannot execute scoped verification at all
+                    (proc/scope-supported? false — off Linux / missing
+                    primitive). Verification is UNAVAILABLE, and an
+                    unavailable gate BLOCKS: the trust-without-verify
+                    fallthrough must never fire just because the executor
+                    is missing."
+  [{:keys [verify-on? result request changed require-test? unsupported?]}]
   (cond
     (not verify-on?) nil
 
@@ -94,34 +370,62 @@
          "test that FAILS without your change and passes with it, get it green, "
          "then call done.")
 
+    ;; The execution boundary is missing: scoped verification cannot run on
+    ;; this runtime at all, so nothing ran and nothing MAY run. This is a
+    ;; harness/runtime condition, not a worker error — but the ship still
+    ;; fails closed: an unverifiable `done` is not a shipped `done`, and the
+    ;; git-cannot-tell trust fallthrough below must not absorb it.
+    (or unsupported? (and result (:unsupported? result)))
+    (str "Verification UNAVAILABLE: this runtime does not provide the scoped "
+         "process execution primitive verification depends on (Linux with "
+         "posix_spawn process-group and poll(2) support is required), so the "
+         "tests cannot be run here.\n\nThis is not a failure of your change — "
+         "but an unverified `done` cannot ship. Fix the runtime (or run on a "
+         "supported one) and call done again.")
+
+    ;; An operator misconfiguration in the verify wiring itself: a
+    ;; :verify-cmd that is not a command string. Surfaced loudly rather
+    ;; than silently skipped — the operator asked for verification and
+    ;; would otherwise believe it happened.
+    (= :invalid (:kind request))
+    (str "Verification MISCONFIGURED: " (:reason request)
+         ". A configured verify command must be a string; fix the :run "
+         ":verify-cmd setting. Until then `done` is blocked rather than "
+         "shipping unverified.")
+
+    ;; The same fail-closed rule for a nonpositive/invalid configured
+    ;; timeout, reported by run-verify rather than defaulted.
+    (and result (:invalid-config? result))
+    (str "Verification MISCONFIGURED — the ship is blocked, not defaulted:\n"
+         (tail (:output result) 4))
+
+    ;; A changed test path that cannot be represented safely, with no trusted
+    ;; fallback configured: nothing ran, and nothing MAY run — fail closed
+    ;; rather than ship unverified (the model cannot un-refuse itself).
+    (= :refused (:kind request))
+    (str "Verification REFUSED: the changed test file(s) "
+         (str/join ", " (map #(str "`" % "`") (take 4 (:refused request))))
+         " cannot be represented safely for focused verification — a test path "
+         "has to be plain ASCII Clojure namespace segments (lowercase "
+         "[a-z0-9-], no quotes, shell metacharacters, spaces, Unicode, casing "
+         "or traversal). No trusted fallback :verify-cmd is configured, so "
+         "nothing was run. Rename the file to a representable namespace path "
+         "and call done again.")
+
     (and result (:timeout? result))
     (str "Your test run TIMED OUT. Something you changed likely loops or blocks. "
          "Narrow it down — run a smaller piece at the REPL — then call done again.")
 
     (and result (not (:green? result)))
-    (str "Your tests are not green yet:\n\n" (tail (:output result) 25)
+    (str "Your tests are not green yet:\n\n"
+         (util/truncate-middle (tail (:output result) 25) render-chars)
          "\n\nYou are NOT done until they pass. Read the failure, change the code, "
          "re-run the test, and call done again only once it is green.")
 
     ;; Ran and green.
     (and result (:green? result)) nil
 
-    ;; verify on and the change looked fine, but the tests could not be run
-    ;; (git could not tell what changed) — trust rather than deadlock the loop.
+    ;; verify on and the change looked fine, but the tests were not run
+    ;; (refused with a fallback that ran green is handled above; this is the
+    ;; git-cannot-tell trust case) — trust rather than deadlock the loop.
     :else nil))
-
-(defn run-verify
-  "Run `cmd` in the project root and report whether it is green. Bounded by
-  `timeout-ms` (default 10 min). Never throws — a spawn failure reads as
-  not-green, which sends the branch back rather than shipping."
-  [root cmd timeout-ms]
-  (try
-    (let [r (proc/run {:timeout-ms (or timeout-ms 600000)}
-                      "sh" "-c" (str "cd " (str root) " && " cmd))]
-      {:green? (and (not (:timeout r)) (zero? (or (:exit r) 1)))
-       :timeout? (boolean (:timeout r))
-       :exit (:exit r)
-       :output (str (:out r) "\n" (:err r))})
-    (catch Throwable e
-      {:green? false :timeout? false
-       :output (str "verify command failed to run: " (ex-message e))})))

--- a/src/samizdat/engine/proc.clj
+++ b/src/samizdat/engine/proc.clj
@@ -22,8 +22,16 @@
   Every engine call is bounded. An unbounded one is not a slow call, it is a
   branch that never returns its turn, and with five branches in the beam that
   is the whole run. `run` kills the process tree on timeout rather than
-  leaving an orphan holding a pipe."
-  (:require [jolt.process :as p]))
+  leaving an orphan holding a pipe.
+
+  `scope-run` is the STRUCTURED execution seam for paths a model can
+  influence: argv + cwd + explicit environment + timeout + independent
+  output byte caps, straight to jolt.host's scoped process primitive — no
+  shell is built anywhere in the API, so there is no quoting to get right.
+  See its docstring for the request contract."
+  (:require [clojure.string :as str]
+            [jolt.process :as p]
+            [samizdat.security.secrets :as secrets]))
 
 (def ^:private sigterm-grace-ms
   "How long a process gets to die of SIGTERM before it is sent SIGKILL."
@@ -98,3 +106,141 @@
     (let [{:keys [exit timeout]} (run {:timeout-ms 5000} bin "--version")]
       (and (not timeout) (some? exit)))
     (catch Throwable _ false)))
+
+;; --- scoped structured execution ---------------------------------------------
+;;
+;; The trusted controller primitive is the jolt.host scoped run (Linux,
+;; posix_spawn with POSIX_SPAWN_SETPGROUP): a STRUCTURED request — argv
+;; vector, cwd, explicit envp, controller timeout, independent output byte
+;; caps — exec'd with no shell anywhere in the API. The ownership guarantee
+;; is the reason this and not ProcessBuilder: when the call returns, the
+;; owned process TREE is empty — TERM wave, grace, KILL wave, then a /proc
+;; scan that keeps signalling until it agrees — and that guarantee holds for
+;; timeouts, output overflows and clean exits alike. Everything below is a
+;; checked, fail-closed Clojure doorway onto it.
+
+(def ^:dynamic *scope-run*
+  "The trusted controller process-scope primitive `scope-run` hands its
+  checked request to (the jolt.host scoped run at the pinned runtime).
+  Dynamic ONLY so tests can capture the exact structured request or fake
+  results without spawning; production code never rebinds it, and nothing
+  outside this namespace reaches around it to the primitive directly."
+  jolt.host/process-scope-run)
+
+(def ^:private scope-env-allowlist
+  "The ONLY controller-environment names a scoped child may ever see. A
+  scoped run hands the primitive an explicit envp, so inheritance is a
+  caller choice — and the only choice offered here is this short list of
+  names a build tool genuinely needs, each still subject to the value
+  scrub below. Everything else the controller holds (provider keys above
+  all) never crosses the spawn boundary at all."
+  ["PATH" "HOME" "LANG" "LC_ALL" "LC_CTYPE" "TERM" "TMPDIR"])
+
+(defn scrubbed-allowlist-env
+  "The explicit child environment for a scoped run: `env` (default: the
+  controller's own environment) intersected with the allowlist, then
+  scrubbed by the existing secrets discipline (samizdat.security.secrets —
+  name-sensitive names are gone by construction, and any value-shaped
+  credential surviving under an allowed name is redacted). The result is
+  the COMPLETE environment the child sees: nothing else is inherited."
+  ([] (scrubbed-allowlist-env (into {} (System/getenv))))
+  ([env] (secrets/scrub-env (select-keys (or env {}) scope-env-allowlist))))
+
+(defn- bad-env-entry?
+  "Whether one env entry cannot be represented as an honest envp NAME=VALUE
+  pair — a non-string, an empty or '='-bearing name (it would corrupt the
+  pair), or a NUL in either half."
+  [[k v]]
+  (or (not (string? k)) (not (string? v)) (str/blank? k)
+      (str/includes? k "=") (str/includes? k "\0") (str/includes? v "\0")))
+
+(defn scope-run
+  "Execute one STRUCTURED request through the trusted controller scope
+  primitive. Request keys — exactly these, all checked before anything
+  spawns:
+
+    :cmd           argv vector of non-empty strings. Exec'd DIRECTLY: the
+                   primitive builds no shell, so no quoting question exists
+                   and no metacharacter in an argv element can become
+                   syntax.
+    :timeout-ms    REQUIRED positive integer — the controller clock. When
+                   it fires, the owned process TREE is TERMed, given
+                   :term-grace-ms, KILLed, and /proc-confirmed empty
+                   before this returns.
+    :env           REQUIRED map of string to string — the COMPLETE child
+                   environment (envp replaces; nothing is inherited from
+                   the controller). Required on purpose: a future caller
+                   cannot silently inherit the controller's secrets by
+                   forgetting the key. Hand scrubbed-allowlist-env output
+                   here unless you mean something narrower.
+    :dir           optional child cwd (absolute; relative resolves against
+                   the controller's project dir).
+    :term-grace-ms optional TERM-to-KILL grace (primitive default 200).
+    :out-bytes     optional positive integer byte cap on stdout capture.
+    :err-bytes     optional positive integer byte cap on stderr capture —
+                   independent of :out-bytes; neither stream's flood can
+                   stall the other's drain or the wait.
+
+  Returns the primitive's map {:pid :exit :timed-out}, plus per REQUESTED
+  stream {:out :out-status} / {:err :err-status} where the status is
+  :complete (EOF seen — the string is the entire stream), :truncated (the
+  cap was reached — the run was ENDED through the same kill ladder, with
+  :timed-out still false), or :partial (a prefix; a writer escaped the
+  scope's nets). Throws IllegalArgumentException on a malformed request,
+  IOException when the program cannot run at all, and
+  UnsupportedOperationException off Linux — callers that must not throw
+  catch."
+  [{:keys [cmd dir env timeout-ms term-grace-ms out-bytes err-bytes]}]
+  (let [cmd (vec cmd)]
+    (when (or (empty? cmd) (not (every? #(and (string? %) (seq %)) cmd)))
+      (throw (IllegalArgumentException.
+               "scope-run: :cmd must be a non-empty argv vector of strings")))
+    (when (or (nil? env) (not (map? env)) (some bad-env-entry? env))
+      (throw (IllegalArgumentException.
+               (str "scope-run: :env must be an explicit map of non-empty string"
+                    " names (no =, no NUL) to NUL-free string values"))))
+    (when (or (not (int? timeout-ms)) (<= timeout-ms 0))
+      (throw (IllegalArgumentException.
+               "scope-run: :timeout-ms must be a positive integer")))
+    (doseq [[who cap] [[:out-bytes out-bytes] [:err-bytes err-bytes]]]
+      (when (and (some? cap) (or (not (int? cap)) (<= cap 0)))
+        (throw (IllegalArgumentException.
+                 (str "scope-run: " who " must be a positive integer byte cap")))))
+    (when (and (some? dir) (or (str/blank? (str dir)) (str/includes? (str dir) "\0")))
+      (throw (IllegalArgumentException. "scope-run: :dir must be a non-empty path")))
+    (*scope-run*
+      (cond-> {:cmd cmd :timeout-ms timeout-ms :env env}
+        dir           (assoc :dir (str dir))
+        term-grace-ms (assoc :term-grace-ms term-grace-ms)
+        out-bytes     (assoc :out-bytes out-bytes)
+        err-bytes     (assoc :err-bytes err-bytes)))))
+
+(defn scope-supported?
+  "Whether the trusted scoped process primitive exists on THIS runtime —
+  the capability the verify/gitdiff boundary depends on to fail closed.
+
+  Probed by capability, never by platform string-matching: the primitive
+  refuses an unsupported runtime (non-Linux, or a runtime without the
+  posix_spawn/poll facilities) BEFORE it validates or spawns anything,
+  so an intentionally incomplete request — a lone :cmd with no
+  :timeout-ms — separates the two answers cleanly:
+
+    UnsupportedOperationException  the scope facility itself is absent;
+    anything else (a request-shape complaint, or success)  it is present
+    and enforcing.
+
+  Neither arm spawns a process: the absent case throws before any
+  request checking, the present case rejects the malformed request
+  before any spawn. A test fake bound to *scope-run* answers 'supported'
+  the same way (it returns or throws something other than
+  UnsupportedOperationException), so the probe composes with stubs.
+
+  The contract for callers: `false` MUST mean 'refuse to verify', never
+  'verify without the scope'. samizdat.agent.verify and the ship gate
+  turn it into a blocked ship with an explicit unsupported result; they
+  never fall back to a permissive path. Never throws."
+  []
+  (try (*scope-run* {:cmd ["samizdat-scope-capability-probe"]})
+       true
+       (catch UnsupportedOperationException _ false)
+       (catch Throwable _ true)))

--- a/src/samizdat/security/secrets.clj
+++ b/src/samizdat/security/secrets.clj
@@ -102,11 +102,36 @@
 
 (def ^:private redacted "[REDACTED]")
 
+(defn- known-value-seq
+  "Known values as a canonical, deduplicated seq of non-blank strings,
+  longest first (lexicographic tiebreak) — so what gets replaced never
+  depends on the caller's collection type or iteration order, and a value
+  that contains another cannot consume its prefix first and leave residue.
+
+  jolt port note: this exists because `distinct` is not safe on a set here.
+  jolt's `distinct` destructures its argument positionally, and positional
+  access on a raw SET answers nil — so (distinct #{v}) evaluated to (nil):
+  the one secret a run holds was erased from the redaction set, and the
+  injected nil was blank-dropped in turn, so nothing crashed and the value
+  leaked. Vectors destructure positionally, which is why vector inputs
+  tested clean while real callers — every one hands `redact` a SET
+  (known-values, stripped-values) — leaked. Normalize through str +
+  blank? + a set + an explicit sort instead of `distinct`."
+  [known-values]
+  (->> known-values
+       (map str)
+       (remove str/blank?)
+       (into #{})
+       (sort-by (fn [v] [(- (count v)) v]))))
+
 (defn redact
   "Redact known secrets from an arbitrary model-bound string. URL passwords
   and vendor-prefix tokens by regex; any value in `known-values` by substring
-  (for opaque secrets with no recognizable shape). Returns the string
-  unchanged when nothing matched."
+  (for opaque secrets with no recognizable shape). `known-values` may be nil
+  or any seqable of strings — vector, list, set — and is normalized to a
+  canonical longest-first order, so the result is deterministic regardless of
+  the caller's collection type. Returns the string unchanged when nothing
+  matched."
   ([text] (redact text nil))
   ([text known-values]
    (let [t (str text)
@@ -120,11 +145,11 @@
              (str/replace t vendor-prefix-re redacted)
              t)]
      (reduce (fn [s v]
-               (if (and (seq v) (str/includes? s v))
+               (if (str/includes? s v)
                  (str/replace s v redacted)
                  s))
              t
-             (remove str/blank? (distinct (or known-values [])))))))
+             (known-value-seq known-values)))))
 
 ;; --- scrubbing the child environment ----------------------------------------
 

--- a/src/samizdat/store/evals.clj
+++ b/src/samizdat/store/evals.clj
@@ -29,7 +29,7 @@
   The lifecycle mirrors how an evaluation actually happens:
 
     (begin! conn {:spec-id s :instance-id i :binding-id b
-                  :coordinate c :source src})        ; before anything runs
+                  :coordinate c :runtime r :source src}) ; before anything runs
     (record-intent! conn id {:op op :args [...]})    ; before each effect
     (record-outcome! conn id n {:result v}|:error)   ; after it
     (complete! conn id {:status :completed :result m}) ; at the end
@@ -41,6 +41,20 @@
   it fails closed when any identity field differs from what the caller holds,
   or when the row is a legacy row that carries no identity at all. The full
   ContextSpec is not duplicated here; only the three ids that name it.
+
+  Two further fields pin the record to the exact runtime and total order:
+
+    :runtime — the versioned RuntimeCoordinate string naming the
+      Jolt/SCI/evaluator-protocol/language-surface/capability-catalog/
+      receipt-protocol stack the evaluation ran under. Receipts are only
+      meaningful under the runtime that produced them, so verification
+      compares it exactly and a process upgraded past a record fails closed
+      instead of replaying across the change. Opaque text here, like
+      :coordinate.
+    :binding_seq — the binding's durable total order, assigned by begin!
+      as one more than the binding's previous maximum. `history` reads a
+      binding's evaluations back in this order, which is the order
+      whole-history rebuild replays them in.
 
   Append-only in the strict sense: no row here is ever updated or deleted.
   Settlement is a second row, so a crashed evaluation's record is exactly
@@ -121,24 +135,38 @@
 (defn begin!
   "Record the intent to evaluate `source` under the canonical
   evaluator/context `coordinate` (the string jolt.sandbox/canonical-coordinate
-  produces), bound to a trusted evaluator identity: the `:spec-id`,
-  `:instance-id`, and `:binding-id` of the ContextSpec/binding that produced
-  the coordinate. All five fields are required and must be non-blank. Returns
-  the evaluation id. The record is pending from this moment: until `complete!`
-  appends a terminal row, `pending` reports it."
-  [conn {:keys [spec-id instance-id binding-id coordinate source]}]
+  produces) and the versioned `runtime` coordinate (the string naming the
+  Jolt/SCI/protocol stack), bound to a trusted evaluator identity: the
+  `:spec-id`, `:instance-id`, and `:binding-id` of the ContextSpec/binding
+  that produced the coordinate. All six fields are required and must be
+  non-blank. Returns the evaluation id.
+
+  The row also claims the binding's next `binding_seq` — 0 for the binding's
+  first evaluation, else one more than its current maximum — so the binding's
+  evaluations form a durable total order in registration order. The
+  (binding_id, binding_seq) unique index makes the order structural: a
+  duplicate is rejected by the database, not by convention. A refused begin
+  is validated before the insert, so it consumes no sequence number.
+
+  The record is pending from this moment: until `complete!` appends a
+  terminal row, `pending` reports it."
+  [conn {:keys [spec-id instance-id binding-id coordinate runtime source]}]
   (doseq [[k v] {:spec-id spec-id
                  :instance-id instance-id
                  :binding-id binding-id
                  :coordinate coordinate
+                 :runtime runtime
                  :source source}]
     (when (str/blank? (str v))
       (throw (ex-info (str "an evaluation needs " (name k)) {k v}))))
   (db/with-writer
-    (db/execute! conn ["INSERT INTO evals (spec_id, instance_id, binding_id, coordinate, source, created_at)
-                        VALUES (?, ?, ?, ?, ?, ?)"
-                       (str spec-id) (str instance-id) (str binding-id)
-                       (str coordinate) (str source) (db/now)])
+    (let [n (:next (db/fetch-one conn ["SELECT COALESCE(MAX(binding_seq) + 1, 0) AS next
+                                        FROM evals WHERE binding_id = ?"
+                                       (str binding-id)]))]
+      (db/execute! conn ["INSERT INTO evals (spec_id, instance_id, binding_id, binding_seq, coordinate, runtime, source, created_at)
+                          VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                         (str spec-id) (str instance-id) (str binding-id) n
+                         (str coordinate) (str runtime) (str source) (db/now)]))
     (db/last-insert-id conn)))
 
 (defn record-intent!
@@ -252,13 +280,14 @@
            (-> row
                (update :status keyword)
                (update :result edn->value)))
-         (db/fetch conn ["SELECT e.id, e.spec_id, e.instance_id, e.binding_id,
-                                 e.coordinate, e.source, e.created_at,
-                                 c.status, c.result, c.created_at AS completed_at
-                          FROM evals e
-                          JOIN eval_completions c ON c.eval_id = e.id
-                          ORDER BY e.id LIMIT ?"
-                         (long limit)]))))
+          (db/fetch conn ["SELECT e.id, e.spec_id, e.instance_id, e.binding_id,
+                                  e.binding_seq, e.coordinate, e.runtime, e.source,
+                                  e.created_at,
+                                  c.status, c.result, c.created_at AS completed_at
+                           FROM evals e
+                           JOIN eval_completions c ON c.eval_id = e.id
+                           ORDER BY e.id LIMIT ?"
+                          (long limit)]))))
 
 (defn unsettled-effects
   "The effects of one evaluation recorded as intended and never settled,
@@ -313,16 +342,33 @@
               :receipts (mapv (fn [[_ receipt-rows]] (fold-receipt receipt-rows))
                               (sort-by key (group-by :seq rows)))))))
 
+(defn history
+  "Every evaluation recorded for `binding-id`, in the binding's durable total
+  order (binding_seq ascending) — the sequence whole-history rebuild replays.
+  Each entry is the full `load-eval` projection: the identity fields,
+  :binding_seq, :runtime, :status (:pending included, so an unfinished record
+  is visible for what it is), :result read back as data, and the ordered
+  structured :receipts. Completed, failed, and pending rows all appear; what
+  may be replayed is the caller's semantic decision. Returns [] for a binding
+  with no recorded evaluations."
+  [conn binding-id]
+  (mapv (fn [row] (load-eval conn (:id row)))
+        (db/fetch conn ["SELECT id FROM evals WHERE binding_id = ?
+                         ORDER BY binding_seq"
+                        (str binding-id)])))
+
 (defn verify-binding!
   "Fail closed unless the durable evaluation names exactly the trusted
-   EvaluatorSpec, EvaluatorInstance, EvaluatorBinding, and coordinate supplied
-   by the controller. Legacy/partial records are not resumable."
-  [conn eval-id {:keys [spec-id instance-id binding-id coordinate]}]
+   EvaluatorSpec, EvaluatorInstance, EvaluatorBinding, authority coordinate,
+   and runtime coordinate supplied by the controller. Legacy/partial records
+   are not resumable."
+  [conn eval-id {:keys [spec-id instance-id binding-id coordinate runtime]}]
   (let [row (load-eval conn eval-id)
         expected {:spec_id (str spec-id)
                   :instance_id (str instance-id)
                   :binding_id (str binding-id)
-                  :coordinate (str coordinate)}
+                  :coordinate (str coordinate)
+                  :runtime (str runtime)}
         actual (select-keys row (keys expected))]
     (when-not row
       (throw (ex-info "evaluation record is missing" {:eval-id eval-id})))

--- a/src/samizdat/store/evals.clj
+++ b/src/samizdat/store/evals.clj
@@ -1,0 +1,334 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.store.evals
+  "Durable receipt storage for bounded SCI evaluations — the JS1 record of a
+  JS0 evaluation.
+
+  jolt.sandbox (JS0) evaluates source in a persistent, capability-bounded SCI
+  context and keeps the evaluation's receipts in an in-process atom: ordered
+  {op args result|error} entries, one per observation or actuation, consumed
+  in order at replay. This namespace is the durable version of that model,
+  for callers that need the record to survive the process.
+
+  The lifecycle mirrors how an evaluation actually happens:
+
+    (begin! conn {:spec-id s :instance-id i :binding-id b
+                  :coordinate c :source src})        ; before anything runs
+    (record-intent! conn id {:op op :args [...]})    ; before each effect
+    (record-outcome! conn id n {:result v}|:error)   ; after it
+    (complete! conn id {:status :completed :result m}) ; at the end
+
+  Every evaluation is bound to a trusted evaluator identity — the
+  :spec-id/:instance-id/:binding-id of the ContextSpec/binding that produced
+  the coordinate — so a recovery caller can confirm a durable record is the
+  one it thinks it is before reconciling it. `verify-binding!` is that gate:
+  it fails closed when any identity field differs from what the caller holds,
+  or when the row is a legacy row that carries no identity at all. The full
+  ContextSpec is not duplicated here; only the three ids that name it.
+
+  Append-only in the strict sense: no row here is ever updated or deleted.
+  Settlement is a second row, so a crashed evaluation's record is exactly
+  what the process managed to append. That is the incomplete-actuation
+  semantics: an eval with no completion row is PENDING, and an intent with
+  no outcome is an effect whose actuation state is unknown. `pending` and
+  `unsettled-effects` exist so the caller can fail closed on both — a
+  pending actuation may or may not have happened, and the honest answer is
+  to refuse to pretend either way. complete! enforces the same rule from
+  the inside: an evaluation with unsettled effects cannot be completed.
+
+  Receipt payloads are structured canonical EDN, never transcript text:
+  written from the receipt domain (nil, booleans, strings, exact integers,
+  keywords, symbols, vectors, and maps sorted canonically by key — the same
+  domain jolt.sandbox/inert defines, reimplemented here because samizdat's
+  classpath does not carry SCI), printed unbounded, and read back with
+  clojure.edn (which parses and never evaluates). What goes in as data
+  comes back as data."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [samizdat.store.db :as db]))
+
+;; --- canonical EDN ------------------------------------------------------------
+
+(defn- canonical
+  "Canonicalize a value into the receipt domain, or throw.
+
+  Accepted: nil, boolean, string, exact integer, keyword, symbol, vector of
+  canonical values, map with canonical keys and values (entries sorted
+  canonically by pr-str of key). Everything else — floats, lazy seqs, atoms,
+  functions, host objects — is refused rather than stringified, because a
+  receipt that cannot round-trip as data is not a receipt."
+  [x]
+  (cond
+    (nil? x) nil
+    (boolean? x) x
+    (string? x) x
+    (keyword? x) x
+    (symbol? x) x
+    (and (integer? x) (not (float? x))) x
+    (vector? x) (mapv canonical x)
+    (map? x) (into {}
+                   (map (fn [[k v]] [(canonical k) (canonical v)]))
+                   (sort-by (comp pr-str key) x))
+    :else (throw (ex-info "Non-canonical receipt value"
+                          {:samizdat.store.evals/value-type (str (type x))
+                           :samizdat.store.evals/value (pr-str x)}))))
+
+(defn- ->edn
+  "Canonical EDN text for a receipt-domain value. Unbounded printing: a
+  truncated receipt would silently no longer be the receipt."
+  [v]
+  (binding [*print-length* nil *print-level* nil]
+    (pr-str (canonical v))))
+
+(defn- edn->value
+  "Read a stored EDN column back into data. clojure.edn parses and never
+  evaluates, which is what makes loading receipts safe."
+  [s]
+  (when s (edn/read-string s)))
+
+;; --- writes -------------------------------------------------------------------
+
+(defn- open-eval!
+  "The evals row for id, throwing when there is no such evaluation. Also
+  throws when the evaluation already has a terminal record — the record of
+  an evaluation is not rewritten, so receipts can only be appended while
+  the evaluation is pending."
+  [conn id]
+  (let [row (db/fetch-one conn ["SELECT * FROM evals WHERE id = ?" id])]
+    (when-not row
+      (throw (ex-info "no such evaluation" {:eval-id id})))
+    (when (db/fetch-one conn ["SELECT id FROM eval_completions WHERE eval_id = ?" id])
+      (throw (ex-info "evaluation already has a terminal record; a settled record is not rewritten"
+                      {:eval-id id})))
+    row))
+
+(defn begin!
+  "Record the intent to evaluate `source` under the canonical
+  evaluator/context `coordinate` (the string jolt.sandbox/canonical-coordinate
+  produces), bound to a trusted evaluator identity: the `:spec-id`,
+  `:instance-id`, and `:binding-id` of the ContextSpec/binding that produced
+  the coordinate. All five fields are required and must be non-blank. Returns
+  the evaluation id. The record is pending from this moment: until `complete!`
+  appends a terminal row, `pending` reports it."
+  [conn {:keys [spec-id instance-id binding-id coordinate source]}]
+  (doseq [[k v] {:spec-id spec-id
+                 :instance-id instance-id
+                 :binding-id binding-id
+                 :coordinate coordinate
+                 :source source}]
+    (when (str/blank? (str v))
+      (throw (ex-info (str "an evaluation needs " (name k)) {k v}))))
+  (db/with-writer
+    (db/execute! conn ["INSERT INTO evals (spec_id, instance_id, binding_id, coordinate, source, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?)"
+                       (str spec-id) (str instance-id) (str binding-id)
+                       (str coordinate) (str source) (db/now)])
+    (db/last-insert-id conn)))
+
+(defn record-intent!
+  "Record the intent to run one effect — `op` (a keyword, symbol, or string
+  operation id) with `args` (a vector of receipt-domain values) — BEFORE it
+  executes. Returns the effect's seq: effects are numbered 0, 1, 2, ... in
+  the order their intents are recorded, which is the order replay consumes
+  them in."
+  [conn eval-id {:keys [op args]}]
+  (when (or (nil? op) (and (string? op) (str/blank? op)))
+    (throw (ex-info "an effect intent needs an op" {:eval-id eval-id})))
+  (db/with-writer
+    (open-eval! conn eval-id)
+    (let [n (:next (db/fetch-one conn ["SELECT COALESCE(MAX(seq) + 1, 0) AS next
+                                        FROM eval_receipts
+                                        WHERE eval_id = ? AND phase = 'intent'"
+                                       eval-id]))]
+      (db/execute! conn ["INSERT INTO eval_receipts (eval_id, seq, phase, op, args, created_at)
+                          VALUES (?, ?, 'intent', ?, ?, ?)"
+                         eval-id n (->edn op) (->edn (vec (or args []))) (db/now)])
+      n)))
+
+(defn record-outcome!
+  "Record the outcome of the effect whose intent is (eval-id, seq) — exactly
+  one of :result (a receipt-domain value; nil is a real result) or :error
+  (a message). The intent must already exist and not already be settled: an
+  outcome without an intent would be an effect nobody recorded running, and
+  a second outcome would rewrite one."
+  [conn eval-id seqn {:keys [result error] :as outcome}]
+  (when (= (contains? outcome :result) (contains? outcome :error))
+    (throw (ex-info "an outcome is exactly one of :result or :error"
+                    {:eval-id eval-id :seq seqn})))
+  (db/with-writer
+    (open-eval! conn eval-id)
+    (let [intent (db/fetch-one conn ["SELECT * FROM eval_receipts
+                                      WHERE eval_id = ? AND seq = ? AND phase = 'intent'"
+                                     eval-id seqn])]
+      (when-not intent
+        (throw (ex-info "no intent recorded for this effect; intent precedes outcome"
+                        {:eval-id eval-id :seq seqn})))
+      (when (db/fetch-one conn ["SELECT id FROM eval_receipts
+                                 WHERE eval_id = ? AND seq = ? AND phase = 'outcome'"
+                                eval-id seqn])
+        (throw (ex-info "effect already has an outcome; a receipt is not rewritten"
+                        {:eval-id eval-id :seq seqn})))
+      (db/execute! conn ["INSERT INTO eval_receipts (eval_id, seq, phase, op, result, error, created_at)
+                          VALUES (?, ?, 'outcome', ?, ?, ?, ?)"
+                         eval-id seqn (:op intent)
+                         (when (contains? outcome :result) (->edn result))
+                         (when (contains? outcome :error) (str error))
+                         (db/now)]))
+    seqn))
+
+(defn- unsettled-seqs
+  [conn eval-id]
+  (mapv :seq (db/fetch conn ["SELECT seq FROM eval_receipts
+                              WHERE eval_id = ? AND phase = 'intent'
+                                AND seq NOT IN (SELECT seq FROM eval_receipts
+                                                WHERE eval_id = ? AND phase = 'outcome')
+                              ORDER BY seq"
+                             eval-id eval-id])))
+
+(defn complete!
+  "Append the terminal record for a pending evaluation: `status` is
+  :completed or :failed, and `result` is receipt-domain result metadata
+  (nil allowed when there is nothing structured to say). Returns true.
+
+  Refuses while any of the evaluation's effects is still an unsettled
+  intent: completing would claim the record is whole when an actuation's
+  outcome is unknown. Such an evaluation stays pending instead, which is
+  the fail-closed answer — see `unsettled-effects`."
+  [conn eval-id {:keys [status result]}]
+  (when-not (#{:completed :failed} status)
+    (throw (ex-info "terminal status is :completed or :failed"
+                    {:eval-id eval-id :status status})))
+  (db/with-writer
+    (open-eval! conn eval-id)
+    (let [open (unsettled-seqs conn eval-id)]
+      (when (seq open)
+        (throw (ex-info "cannot complete: effects were recorded and never settled, so their actuation state is unknown; leave the record pending and fail closed"
+                        {:eval-id eval-id :unsettled-seqs open}))))
+    (db/execute! conn ["INSERT INTO eval_completions (eval_id, status, result, created_at)
+                        VALUES (?, ?, ?, ?)"
+                       eval-id (name status)
+                       (when (some? result) (->edn result))
+                       (db/now)])
+    true))
+
+;; --- reads --------------------------------------------------------------------
+
+(defn pending
+  "Evaluations with no terminal record, oldest first — every record a caller
+  must fail closed on, because their actuations may or may not have run.
+  Bounded by `limit` (default 100); rows are the raw evals table."
+  ([conn] (pending conn 100))
+  ([conn limit]
+   (db/fetch conn ["SELECT e.* FROM evals e
+                    WHERE NOT EXISTS (SELECT 1 FROM eval_completions c
+                                      WHERE c.eval_id = e.id)
+                    ORDER BY e.id LIMIT ?"
+                   (long limit)])))
+
+(defn completed
+  "Completed evaluation records in strict sequence (insertion order, not
+  completion order), each with its terminal :status (keyword) and :result
+  metadata read back as data. Receipt bodies are not in this projection —
+  `load-eval` carries them. Bounded by `limit` (default 100)."
+  ([conn] (completed conn 100))
+  ([conn limit]
+   (mapv (fn [row]
+           (-> row
+               (update :status keyword)
+               (update :result edn->value)))
+         (db/fetch conn ["SELECT e.id, e.spec_id, e.instance_id, e.binding_id,
+                                 e.coordinate, e.source, e.created_at,
+                                 c.status, c.result, c.created_at AS completed_at
+                          FROM evals e
+                          JOIN eval_completions c ON c.eval_id = e.id
+                          ORDER BY e.id LIMIT ?"
+                         (long limit)]))))
+
+(defn unsettled-effects
+  "The effects of one evaluation recorded as intended and never settled,
+  in seq order — actuations whose effect on the world is unknown. This is
+  the per-effect fail-closed signal: a caller reconciling a pending record
+  must assume each of these MAY have happened."
+  [conn eval-id]
+  (->> (db/fetch conn ["SELECT seq, op, args FROM eval_receipts
+                        WHERE eval_id = ? AND phase = 'intent'
+                          AND seq NOT IN (SELECT seq FROM eval_receipts
+                                          WHERE eval_id = ? AND phase = 'outcome')
+                        ORDER BY seq"
+                       eval-id eval-id])
+       (mapv (fn [row]
+               {:seq (:seq row)
+                :op (edn/read-string (:op row))
+                :args (edn/read-string (:args row))}))))
+
+(defn- fold-receipt
+  "One effect's intent and (absent while unsettled) outcome rows folded into
+  a single receipt entry. :phase is :done or :error once settled, and stays
+  :intent while the effect's actuation state is unknown."
+  [rows]
+  (let [intent (first (filter #(= "intent" (:phase %)) rows))
+        outcome (first (filter #(= "outcome" (:phase %)) rows))]
+    (cond-> {:seq (:seq intent)
+             :op (edn/read-string (:op intent))
+             :args (edn/read-string (:args intent))
+             :phase (if outcome (if (:error outcome) :error :done) :intent)
+             :intended-at (:created_at intent)}
+      outcome (assoc :settled-at (:created_at outcome))
+      (and outcome (:result outcome)) (assoc :result (edn/read-string (:result outcome)))
+      (and outcome (:error outcome)) (assoc :error (:error outcome)))))
+
+(defn load-eval
+  "The full durable record of one evaluation, or nil when there is no such
+  id: the evals row plus :status (:pending, :completed, or :failed),
+  :result metadata read back as data, :completed_at, and :receipts — the
+  ordered structured receipt entries as data (never transcript text), in
+  strict seq order, each carrying its :phase so an unsettled intent is
+  visible for what it is."
+  [conn eval-id]
+  (when-let [row (db/fetch-one conn ["SELECT * FROM evals WHERE id = ?" eval-id])]
+    (let [completion (db/fetch-one conn ["SELECT * FROM eval_completions
+                                          WHERE eval_id = ?" eval-id])
+          rows (db/fetch conn ["SELECT * FROM eval_receipts
+                                WHERE eval_id = ? ORDER BY seq, id" eval-id])]
+      (assoc row
+             :status (if completion (keyword (:status completion)) :pending)
+             :result (edn->value (:result completion))
+             :completed_at (:created_at completion)
+              :receipts (mapv (fn [[_ receipt-rows]] (fold-receipt receipt-rows))
+                              (sort-by key (group-by :seq rows)))))))
+
+(defn verify-binding!
+  "Fail closed unless the durable evaluation names exactly the trusted
+   EvaluatorSpec, EvaluatorInstance, EvaluatorBinding, and coordinate supplied
+   by the controller. Legacy/partial records are not resumable."
+  [conn eval-id {:keys [spec-id instance-id binding-id coordinate]}]
+  (let [row (load-eval conn eval-id)
+        expected {:spec_id (str spec-id)
+                  :instance_id (str instance-id)
+                  :binding_id (str binding-id)
+                  :coordinate (str coordinate)}
+        actual (select-keys row (keys expected))]
+    (when-not row
+      (throw (ex-info "evaluation record is missing" {:eval-id eval-id})))
+    (when (or (some #(str/blank? (str (get actual %)))
+                    (keys expected))
+              (not= expected actual))
+      (throw (ex-info "evaluator binding does not match durable evaluation"
+                      {:eval-id eval-id :expected expected :actual actual})))
+    row))

--- a/src/samizdat/store/migrations.clj
+++ b/src/samizdat/store/migrations.clj
@@ -340,30 +340,43 @@
   ;; The shape is append-only in the strict sense: nothing here is ever
   ;; updated or deleted. An evaluation is registered BEFORE it runs (intent:
   ;; the trusted evaluator identity — spec/instance/binding ids — plus the
-  ;; canonical evaluator/context coordinate and the source), each effect
-  ;; is recorded as an intent row before it executes and an outcome row
-  ;; after, and completion is a row of its own appended afterward. A crashed
-  ;; evaluation's record is then exactly what the process managed to append
-  ;; — a pending eval row, and an intent with no outcome for the effect that
-  ;; was in flight — which is what a caller needs to fail closed: the
-  ;; actuation may or may not have happened, and the record says so honestly
-  ;; instead of reconstructing a story.
+  ;; canonical evaluator/context coordinate, the versioned RuntimeCoordinate
+  ;; naming the Jolt/SCI/protocol stack the receipts are meaningful under,
+  ;; and the source), each effect is recorded as an intent row before it
+  ;; executes and an outcome row after, and completion is a row of its own
+  ;; appended afterward. A crashed evaluation's record is then exactly what
+  ;; the process managed to append — a pending eval row, and an intent with
+  ;; no outcome for the effect that was in flight — which is what a caller
+  ;; needs to fail closed: the actuation may or may not have happened, and
+  ;; the record says so honestly instead of reconstructing a story.
+  ;;
+  ;; binding_seq is the binding's durable total order: evaluations of one
+  ;; binding are numbered 0, 1, 2, ... in registration order at begin! time,
+  ;; so whole-history rebuild replays a binding's committed evaluations in
+  ;; exactly the order they committed, and a gap in the sequence is a torn
+  ;; record to fail closed on rather than a hole to replay across.
   ;;
   ;; Terminal status lives in eval_completions rather than as a status
   ;; column on evals so that "pending" is the ABSENCE of a row: there is no
   ;; status to set wrong, only a completion that has or has not been
-  ;; appended. The unique indexes make the two invariants structural — one
-  ;; terminal record per evaluation, and at most one intent and one outcome
-  ;; per (eval, seq) — rather than matters of caller discipline.
+  ;; appended. The unique indexes make the invariants structural — one
+  ;; terminal record per evaluation, at most one intent and one outcome
+  ;; per (eval, seq), and one row per (binding, binding_seq) — rather than
+  ;; matters of caller discipline.
   ["CREATE TABLE IF NOT EXISTS evals (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
       spec_id     TEXT NOT NULL,
       instance_id TEXT NOT NULL,
       binding_id  TEXT NOT NULL,
+      binding_seq INTEGER NOT NULL,
       coordinate  TEXT NOT NULL,
+      runtime     TEXT NOT NULL,
       source      TEXT NOT NULL,
       created_at  TEXT NOT NULL
     )"
+
+   "CREATE UNIQUE INDEX IF NOT EXISTS idx_evals_binding_seq
+      ON evals(binding_id, binding_seq)"
 
    "CREATE TABLE IF NOT EXISTS eval_completions (
       id         INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/samizdat/store/migrations.clj
+++ b/src/samizdat/store/migrations.clj
@@ -327,6 +327,70 @@
 
    "CREATE INDEX IF NOT EXISTS idx_messages_run ON messages(run_id, read_at)"])
 
+(def ^:private v11
+  ;; Durable evaluator receipts (the JS1 record of a JS0 evaluation).
+  ;;
+  ;; jolt.sandbox keeps an evaluation's receipts in an in-process atom:
+  ;; ordered {op args result|error} entries, one per observation or
+  ;; actuation, consumed in order at replay. A process that dies between an
+  ;; actuation and the end of its evaluation loses the atom while the world
+  ;; keeps the actuation, and nothing on record even says which window was
+  ;; open. These tables are the durable version of that model.
+  ;;
+  ;; The shape is append-only in the strict sense: nothing here is ever
+  ;; updated or deleted. An evaluation is registered BEFORE it runs (intent:
+  ;; the trusted evaluator identity — spec/instance/binding ids — plus the
+  ;; canonical evaluator/context coordinate and the source), each effect
+  ;; is recorded as an intent row before it executes and an outcome row
+  ;; after, and completion is a row of its own appended afterward. A crashed
+  ;; evaluation's record is then exactly what the process managed to append
+  ;; — a pending eval row, and an intent with no outcome for the effect that
+  ;; was in flight — which is what a caller needs to fail closed: the
+  ;; actuation may or may not have happened, and the record says so honestly
+  ;; instead of reconstructing a story.
+  ;;
+  ;; Terminal status lives in eval_completions rather than as a status
+  ;; column on evals so that "pending" is the ABSENCE of a row: there is no
+  ;; status to set wrong, only a completion that has or has not been
+  ;; appended. The unique indexes make the two invariants structural — one
+  ;; terminal record per evaluation, and at most one intent and one outcome
+  ;; per (eval, seq) — rather than matters of caller discipline.
+  ["CREATE TABLE IF NOT EXISTS evals (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      spec_id     TEXT NOT NULL,
+      instance_id TEXT NOT NULL,
+      binding_id  TEXT NOT NULL,
+      coordinate  TEXT NOT NULL,
+      source      TEXT NOT NULL,
+      created_at  TEXT NOT NULL
+    )"
+
+   "CREATE TABLE IF NOT EXISTS eval_completions (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      eval_id    INTEGER NOT NULL REFERENCES evals(id),
+      status     TEXT NOT NULL,
+      result     TEXT,
+      created_at TEXT NOT NULL
+    )"
+
+   "CREATE UNIQUE INDEX IF NOT EXISTS idx_eval_completions_once
+      ON eval_completions(eval_id)"
+
+   "CREATE TABLE IF NOT EXISTS eval_receipts (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      eval_id    INTEGER NOT NULL REFERENCES evals(id),
+      seq        INTEGER NOT NULL,
+      phase      TEXT NOT NULL,
+      op         TEXT NOT NULL DEFAULT '',
+      args       TEXT,
+      result     TEXT,
+      error      TEXT,
+      created_at TEXT NOT NULL
+    )"
+
+   "CREATE UNIQUE INDEX IF NOT EXISTS idx_eval_receipts_phase
+      ON eval_receipts(eval_id, seq, phase)"])
+
 (def migrations
   "Ordered. Index 0 is migration 1; PRAGMA user_version holds the count applied."
-  [v1 v2 v3 v4 v5 v6 v7 v8 v9 v10])
+  [v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11])

--- a/src/samizdat/workflow.clj
+++ b/src/samizdat/workflow.clj
@@ -219,6 +219,60 @@
       (assoc ctx :llm-adapter (registry/adapter-for provider) :llm-config llm))
     ctx))
 
+(defn- js1-binding
+  "Create a JS1 sandbox binding for the run, or nil.
+
+   Activated ONLY when config :run :js1/profile is set to a truthy value.
+   The profile string (e.g. \"single-player\") is stored in the ctx as
+   :js1/profile — a display/journal label; the BINDING this function
+   returns is the canonical signal the tool gate and eval routing both
+   read (:js1/binding).
+
+   Trust boundary: the config key is read once here by controller code;
+   the model never sees or sets it.  The preset is hardcoded to
+   :project/develop; the instance key is :main (persistent across turns);
+   the work-id is the run-id, binding one instance per run.
+
+   The sandbox provider, spec, instance, and binding IDs are journaled
+   so a resumed run can verify it reconstructs the same context.
+
+   JS1 is an explicit bounded workflow.  If its SCI dependency is absent,
+   creation FAILS CLOSED — it must never silently select the live REPL."
+  [conn run-id config root]
+  (when (get-in config [:run :js1/profile])
+    (try
+      (require 'samizdat.agent.sandbox)
+      (let [provider-fn (resolve 'samizdat.agent.sandbox/provider)
+            bind-fn     (resolve 'samizdat.agent.sandbox/bind!)
+            desc-fn     (resolve 'samizdat.agent.sandbox/describe)
+            prov (provider-fn {:root root})
+            profile-name (str (get-in config [:run :js1/profile]))
+            binding (bind-fn prov (str run-id)
+                            {:preset :project/develop
+                             :root root
+                             :instance/key :main})
+            desc (desc-fn binding)]
+        ;; Journal the binding identity for resume verification.  The preset
+        ;; keyword is written through data.json, which reads back as a plain
+        ;; string (colon form, or name-only under jolt's port); resume
+        ;; converts it back to the catalog keyword before binding.
+        (journal/note! conn run-id :js1-binding-created
+                       {:data {:profile profile-name
+                               :binding-id (:samizdat.sandbox/binding-id desc)
+                               :instance-id (:samizdat.sandbox/instance-id desc)
+                               :spec-coordinate (:samizdat.sandbox/spec-coordinate desc)
+                               :preset (:samizdat.sandbox/preset desc)}})
+        binding)
+      (catch Throwable e
+        ;; Fail closed either way; a sandbox-domain error (unknown preset,
+        ;; spec conflict, ...) keeps its own diagnostics instead of being
+        ;; relabeled, and only an unavailable sandbox is labeled as such.
+        (if (:samizdat.sandbox/error (ex-data e))
+          (throw e)
+          (throw (ex-info "JS1 sandbox unavailable; refusing live-eval fallback"
+                          {:js1/error :sandbox-unavailable :run-id run-id}
+                          e)))))))
+
 (defn run!
   "Run one branch to completion under the stored loop definition.
   Returns {:status :answer :branch :run-id (:residual)}."
@@ -238,6 +292,9 @@
         ;; The project root the file tools are confined to, and the shell tool
         ;; runs in. Configurable so a run can target another checkout.
         root (or (get-in config [:run :root]) (System/getProperty "user.dir"))
+         ;; JS1 binding: one persistent SCI instance for the whole run when
+         ;; explicitly configured. Its absence is allowed only for non-JS1.
+        js1 (js1-binding conn run-id config root)
         ctx {:conn conn :run-id run-id :config config
              :llm-adapter llm-adapter :llm-config llm-config
              :root root
@@ -247,10 +304,13 @@
              ;; skipping it keeps the common path off git entirely.
              :git-baseline (when (not= loop-nm loop-name) (gitdiff/baseline root))
              ;; A per-run eval session, so defs the agent makes with `eval`
-             ;; persist across its turns (define, then use) — REPL-first
+             ;; persist across their turns (define, then use) — REPL-first
              ;; development against the live image.
-             :repl-session (repl/new-session)
-             :max-turns max-turns}]
+             :repl-session (when-not js1 (repl/new-session))
+             :max-turns max-turns
+             ;; JS1 profile flags — set only here, read by phase-refusal.
+             :js1/profile (when js1 (str (get-in config [:run :js1/profile])))
+             :js1/binding js1}]
     (runs/open-branch! conn run-id {:branch-id "B1"})
     ;; Which loop drove this run, durably: an agent reading a surprising run
     ;; back needs to know which version of itself produced it.

--- a/src/samizdat/workflow.clj
+++ b/src/samizdat/workflow.clj
@@ -42,9 +42,10 @@
             [samizdat.cells :as cells]
             [samizdat.config :as config]
             [samizdat.llm.registry :as registry]
-            [samizdat.agent.gitdiff :as gitdiff]
-            [samizdat.agent.loop :as branch-loop]
-            [samizdat.repl :as repl]
+             [samizdat.agent.gitdiff :as gitdiff]
+             [samizdat.agent.loop :as branch-loop]
+             [samizdat.agent.tools.base :as js1-base]
+             [samizdat.repl :as repl]
             [samizdat.agent.state :as state]
             [samizdat.store.journal :as journal]
             [samizdat.store.runs :as runs]
@@ -219,50 +220,75 @@
       (assoc ctx :llm-adapter (registry/adapter-for provider) :llm-config llm))
     ctx))
 
+(defn js1-binding-journal-data
+  "The EXACT binding reconstruction information journaled when a JS1
+   binding is minted, and the only resume's reconstruction is allowed to
+   trust: everything a second process needs to re-mint an identical
+   binding and verify it did — the spec coordinate (which content-addresses
+   preset, root, capabilities, bounds and timeout), the explicit
+   capabilities/bounds/timeout values, the durable binding/instance ids,
+   and the versioned RuntimeCoordinate the receipts are meaningful under.
+   Capabilities are journaled as full name strings (\"project/read\")
+   because keyword serialization through the journal's JSON is ambiguous
+   about namespaces."
+  [profile-name binding runtime-coordinate]
+  (let [spec (:spec binding)]
+    {:profile profile-name
+     :binding-id (:binding/id binding)
+     :instance-id (:instance/id binding)
+     :preset (:preset spec)
+     :spec-coordinate (:spec/coordinate spec)
+     :capabilities (mapv name (:capabilities spec))
+     :bounds (:bounds spec)
+     :timeout-ms (:timeout-ms spec)
+     :runtime-coordinate runtime-coordinate}))
+
 (defn- js1-binding
   "Create a JS1 sandbox binding for the run, or nil.
 
-   Activated ONLY when config :run :js1/profile is set to a truthy value.
-   The profile string (e.g. \"single-player\") is stored in the ctx as
-   :js1/profile — a display/journal label; the BINDING this function
-   returns is the canonical signal the tool gate and eval routing both
-   read (:js1/binding).
+    Activated ONLY when config :run :js1/profile is set to a truthy value.
+    The profile string (e.g. \"single-player\") is stored in the ctx as
+    :js1/profile — a display/journal label; the BINDING this function
+    returns is the canonical signal the tool gate and eval routing both
+    read (:js1/binding).
 
-   Trust boundary: the config key is read once here by controller code;
-   the model never sees or sets it.  The preset is hardcoded to
-   :project/develop; the instance key is :main (persistent across turns);
-   the work-id is the run-id, binding one instance per run.
+    Trust boundary: the config key is read once here by controller code;
+    the model never sees or sets it.  The preset is hardcoded to
+    :project/develop; the instance key is :main (persistent across turns);
+    the work-id is the run-id, binding one instance per run.
 
-   The sandbox provider, spec, instance, and binding IDs are journaled
-   so a resumed run can verify it reconstructs the same context.
+    The journal event carries the exact reconstruction information
+    (js1-binding-journal-data): spec capabilities/bounds/timeout, the spec
+    and runtime coordinates, and the durable binding/instance ids — so a
+    resumed run can re-mint the same binding, verify it, and replay the
+    whole committed durable history into it (see agent.resume).
 
-   JS1 is an explicit bounded workflow.  If its SCI dependency is absent,
-   creation FAILS CLOSED — it must never silently select the live REPL."
+    JS1 is an explicit bounded workflow.  If its SCI dependency is absent,
+    creation FAILS CLOSED — it must never silently select the live REPL."
   [conn run-id config root]
   (when (get-in config [:run :js1/profile])
     (try
       (require 'samizdat.agent.sandbox)
       (let [provider-fn (resolve 'samizdat.agent.sandbox/provider)
             bind-fn     (resolve 'samizdat.agent.sandbox/bind!)
-            desc-fn     (resolve 'samizdat.agent.sandbox/describe)
+            rt-fn       (resolve 'samizdat.agent.sandbox/runtime-coordinate)
             prov (provider-fn {:root root})
             profile-name (str (get-in config [:run :js1/profile]))
             binding (bind-fn prov (str run-id)
-                            {:preset :project/develop
-                             :root root
-                             :instance/key :main})
-            desc (desc-fn binding)]
-        ;; Journal the binding identity for resume verification.  The preset
-        ;; keyword is written through data.json, which reads back as a plain
-        ;; string (colon form, or name-only under jolt's port); resume
-        ;; converts it back to the catalog keyword before binding.
+                             {:preset :project/develop
+                              :root root
+                              :instance/key :main})
+            runtime-coordinate (rt-fn)]
+        ;; Journal the exact binding identity + spec for resume
+        ;; verification.  The preset keyword is written through data.json,
+        ;; which reads back as a plain string (colon form, or name-only
+        ;; under jolt's port); resume converts it back to the catalog
+        ;; keyword before binding.
         (journal/note! conn run-id :js1-binding-created
-                       {:data {:profile profile-name
-                               :binding-id (:samizdat.sandbox/binding-id desc)
-                               :instance-id (:samizdat.sandbox/instance-id desc)
-                               :spec-coordinate (:samizdat.sandbox/spec-coordinate desc)
-                               :preset (:samizdat.sandbox/preset desc)}})
-        binding)
+                       {:data (js1-binding-journal-data profile-name
+                                                        binding
+                                                        runtime-coordinate)})
+        {:binding binding :provider prov :profile profile-name})
       (catch Throwable e
         ;; Fail closed either way; a sandbox-domain error (unknown preset,
         ;; spec conflict, ...) keeps its own diagnostics instead of being
@@ -277,6 +303,16 @@
   "Run one branch to completion under the stored loop definition.
   Returns {:status :answer :branch :run-id (:residual)}."
   [{:keys [conn config llm-adapter llm-config problem max-turns]}]
+  ;; JS1 is single-player by construction: one persistent :main instance,
+  ;; one branch, one durable history.  A team manifest's subtask fan-out
+  ;; (or an explicit multi-branch beam width) would share that instance
+  ;; across branches, so the shape is refused here — before the loop is
+  ;; compiled, before a run row exists, and above all before any model
+  ;; work is paid for.
+  (js1-base/js1-assert-single-branch!
+    (get-in config [:run :js1/profile])
+    (max (or (get-in config [:run :beam-width]) 1)
+         (count (get-in config [:run :subtasks]))))
   (let [max-turns (or max-turns (get-in config [:run :max-turns]) 40)
         loop-nm (active-loop-name config)
         {:keys [version compiled definition]} (load-loop! conn loop-nm)
@@ -309,8 +345,13 @@
              :repl-session (when-not js1 (repl/new-session))
              :max-turns max-turns
              ;; JS1 profile flags — set only here, read by phase-refusal.
-             :js1/profile (when js1 (str (get-in config [:run :js1/profile])))
-             :js1/binding js1}]
+             ;; The binding is installed as a refreshable holder: a failed
+             ;; recorded eval rolls the instance back and supersedes the
+             ;; binding, and the eval tool resets the holder to the
+             ;; registry's current one (tools.base/update-js1-binding!).
+             :js1/profile (:profile js1)
+             :js1/binding (when-let [b (:binding js1)] (atom b))
+             :js1/provider (:provider js1)}]
     (runs/open-branch! conn run-id {:branch-id "B1"})
     ;; Which loop drove this run, durably: an agent reading a surprising run
     ;; back needs to know which version of itself produced it.

--- a/test/fixtures/js1-dogfood/TASK.md
+++ b/test/fixtures/js1-dogfood/TASK.md
@@ -1,0 +1,55 @@
+# JS1 bounded live dogfood task
+
+This is a scripted recovery contract, not an open-ended coding task. Use one
+tool call per numbered step and do not improvise, combine steps, or repeat a
+semantic project operation. The run is single-player and has a total budget of
+14 turns across the crash and resume.
+
+Before the crash:
+
+1. Discover the JS1 project capability surface with `complete`, prefix
+   `project/`.
+2. Discover the reviewed pure language surface with `doc`, symbol `map`.
+3. Discover the anchored edit contract with `doc`, symbol `project/edit`.
+4. Inspect the project in one `eval`, in this exact order: call
+   `project/list` on `"."`; call `project/search` for `"DOGFOOD"` under
+   `{:path "."}`; then return a map containing `project/read` results for
+   `TASK.md`, `src/dogfood.clj`, and `test/dogfood_test.clj` (in that order).
+5. In one `eval`, define the persistent SCI helper exactly as
+   `(defn dogfood-helper [x] (str "DOGFOOD-HELPER:" x))`, then call it with
+   `"initial"`. Do not redefine this helper later.
+6. In one `eval`, call `project/stat` on `src/dogfood.clj` and define
+   `red-base` to its digest.
+7. In one `eval`, make the first anchored edit with `project/edit`, using
+   `red-base`, replacing the complete source with exactly:
+
+       (ns fixture.dogfood)
+
+       (def dogfood-state :red)
+
+8. Call `done` with an answer that mentions the dogfood task. The fixture-owned
+   focused verifier must deterministically report RED. Do not try to repair it
+   in this process: the controller will kill this process at the durable red
+   `ship-verify` checkpoint.
+
+After the fresh-process resume:
+
+9. First call `(dogfood-helper "resumed")` in `eval`. Its success proves the
+   helper was reconstructed; do not redefine it.
+10. In one `eval`, read `red-evidence.txt` exactly once. This is the red evidence
+   emitted by the fixture-owned focused verifier before the crash.
+11. In one `eval`, call `project/stat` on `src/dogfood.clj` and define
+    `green-base` to its digest.
+12. In one `eval`, make the second anchored edit with `project/edit`, using
+    `green-base`, replacing the complete source with exactly:
+
+        (ns fixture.dogfood)
+
+        (def dogfood-state :green)
+
+13. Call `done` with an answer that mentions the dogfood task. The same
+    operator-configured focused verifier must report GREEN.
+
+Never use a file or shell tool. All project inspection and both edits go only
+through the normal model-facing JS1 `eval` surface and its `project/*`
+operations.

--- a/test/fixtures/js1-dogfood/contract.edn
+++ b/test/fixtures/js1-dogfood/contract.edn
@@ -1,0 +1,39 @@
+{:contract/version 1
+ :opt-in {:flag "SAMIZDAT_JS1_DOGFOOD_TEST"
+          :preflight-flag "SAMIZDAT_JS1_DOGFOOD_PREFLIGHT"
+          :required {"HARNESS_PROVIDER" "local"
+                     "HARNESS_BASE_URL" "http://localhost:13305/v1"}
+          :operator-model-env "HARNESS_MODEL"}
+ :bounds {:max-turns 14
+          :beam-width 1
+          :phase-timeout-ms 900000
+          :total-timeout-ms 1800000}
+ :phases ["preflight" "start" "resume"]
+ :phase-markers ["JS1-DOGFOOD-PREFLIGHT-OK"
+                 "JS1-DOGFOOD-RED-QUIESCENT"
+                 "JS1-DOGFOOD-RED-CHECKPOINT"
+                 "JS1-DOGFOOD-RESUME-HELPER-OK"
+                 "JS1-DOGFOOD-GREEN-OK"]
+ :fixture-files ["TASK.md"
+                 "src/dogfood.clj"
+                 "test/dogfood_test.clj"
+                 "test/focused_test.sh"
+                 "verify-policy"]
+ :verify {:operator-command "./verify-policy"
+          :hardened-argv ["sh" "-c" "./verify-policy"]
+          :red-marker "JS1-DOGFOOD-FOCUSED-RED"
+          :green-marker "JS1-DOGFOOD-FOCUSED-GREEN"
+          :evidence-path "red-evidence.txt"}
+ :semantic-operations
+ {:before-resume [:project/list :project/search
+                  :project/read :project/read :project/read
+                  :project/stat :project/edit]
+  :after-resume [:project/read :project/stat :project/edit]}
+ :safety {:target-must-be-detached true
+          :target-must-be-outside-source true
+          :child-jolt-pwd-must-be-source true
+          :sandbox-root-must-be-target true
+          :red-checkpoint-must-be-quiescent true
+          :source-status-must-not-change true
+          :push-forbidden true
+          :live-repl-fallback-forbidden true}}

--- a/test/fixtures/js1-dogfood/contract.edn
+++ b/test/fixtures/js1-dogfood/contract.edn
@@ -25,10 +25,31 @@
           :green-marker "JS1-DOGFOOD-FOCUSED-GREEN"
           :evidence-path "red-evidence.txt"}
  :semantic-operations
- {:before-resume [:project/list :project/search
-                  :project/read :project/read :project/read
-                  :project/stat :project/edit]
-  :after-resume [:project/read :project/stat :project/edit]}
+ {:before-resume
+  {:required-subsequence
+   [{:op :project/list :args ["."]}
+    {:op :project/search :args ["DOGFOOD" {:path "."}]}
+    {:op :project/read :args ["TASK.md"]}
+    {:op :project/read :args ["src/dogfood.clj"]}
+    {:op :project/read :args ["test/dogfood_test.clj"]}
+    {:op :project/stat :args ["src/dogfood.clj"]}
+    {:op :project/edit
+     :path "src/dogfood.clj"
+     :base :sha256
+     :content "(ns fixture.dogfood)\n\n(def dogfood-state :red)\n"}]
+   :minimum-counts {:project/list 1
+                    :project/search 1
+                    :project/read 3}
+   :exact-counts {:project/stat 1
+                  :project/edit 1}
+   :additional-before-edit #{:project/list :project/search :project/read}}
+  :resume-exact
+  [{:op :project/read :args ["red-evidence.txt"]}
+   {:op :project/stat :args ["src/dogfood.clj"]}
+   {:op :project/edit
+    :path "src/dogfood.clj"
+    :base :sha256
+    :content "(ns fixture.dogfood)\n\n(def dogfood-state :green)\n"}]}
  :safety {:target-must-be-detached true
           :target-must-be-outside-source true
           :child-jolt-pwd-must-be-source true

--- a/test/fixtures/js1-dogfood/src/dogfood.clj
+++ b/test/fixtures/js1-dogfood/src/dogfood.clj
@@ -1,0 +1,3 @@
+(ns fixture.dogfood)
+
+(def dogfood-state :seed)

--- a/test/fixtures/js1-dogfood/test/dogfood_test.clj
+++ b/test/fixtures/js1-dogfood/test/dogfood_test.clj
@@ -1,0 +1,7 @@
+(ns fixture.dogfood-test
+  (:require [clojure.test :refer [deftest is]]
+            [fixture.dogfood]))
+
+;; JS1-DOGFOOD focused contract: the fixture is green only at :green.
+(deftest dogfood-state-is-green
+  (is (= :green fixture.dogfood/dogfood-state)))

--- a/test/fixtures/js1-dogfood/test/focused_test.sh
+++ b/test/fixtures/js1-dogfood/test/focused_test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+expected='(ns fixture.dogfood)
+
+(def dogfood-state :green)'
+actual=$(cat src/dogfood.clj)
+
+if [ "$actual" = "$expected" ]; then
+  printf '%s\n' 'JS1-DOGFOOD-FOCUSED-GREEN fixture.dogfood-test'
+  exit 0
+fi
+
+printf '%s\n' 'JS1-DOGFOOD-FOCUSED-RED fixture.dogfood-test expected dogfood-state :green'
+printf '%s\n' 'The first :red candidate is intentional; repair src/dogfood.clj with a second anchored edit.'
+cat > red-evidence.txt <<'EOF'
+JS1-DOGFOOD-FOCUSED-RED
+fixture.dogfood-test expected dogfood-state :green and observed the intentional :red candidate.
+Repair src/dogfood.clj with the second anchored project/edit, then call done again.
+EOF
+exit 1

--- a/test/fixtures/js1-dogfood/verify-policy
+++ b/test/fixtures/js1-dogfood/verify-policy
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+# Fixture-owned policy. The trusted controller config supplies only the fixed
+# command "./verify-policy"; no model text, changed path, or environment value
+# is interpolated into this executable or its argv.
+exec ./test/focused_test.sh

--- a/test/fixtures/js1/boundary_runner.clj
+++ b/test/fixtures/js1/boundary_runner.clj
@@ -1,0 +1,51 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns fixtures.js1.boundary-runner
+  "FIXTURE — the JS1 durable-restart boundary suite runner for the SmolVM
+  CI lane (ci/js1-smolvm). Immutable fixture definition; results are CI
+  artifacts only.
+
+  Invoked in the guest by ci/js1-smolvm/guest-setup.sh step `boundary`:
+
+    SAMIZDAT_JS1_BOUNDARY_TEST=1 SAMIZDAT_JOLT_BIN=$JOLT_HOME/bin/jolt \\
+      $JOLT_HOME/bin/jolt -Scp \"$(bin/js1 path)\" run <this file>
+
+  The -Scp roots are the recorded JS1 classpath replay (src + test + the
+  vendored SCI + jolt-crypto + SCI's four jars), so this file's ns path
+  (test/fixtures/js1/) resolves against the test root. It requires
+  samizdat.js1-boundary-test and runs exactly that namespace's suite mode,
+  which spawns the record/resume/mismatch/unsettled phases as FRESH jolt
+  OS processes and asserts on their exit codes and on-disk world. Exit 0
+  iff the suite is green; the guest wrapper prints GUEST-BOUNDARY-OK after
+  a zero exit and the host harness additionally requires clojure.test's
+  \"0 failures, 0 errors\" summary line.
+
+  Outside the lane this file does nothing unusual: without
+  SAMIZDAT_JS1_BOUNDARY_TEST=1 the boundary suite skips with its
+  documented reason, and the runner still exits 0 for a green (skipped)
+  run — the lane, not this fixture, decides whether a skip is acceptable
+  (it is not: the consumer asserts the boundary markers)."
+  (:require [clojure.test :as t]))
+
+(require 'samizdat.js1-boundary-test)
+
+(let [{:keys [fail error] :as summary}
+      (t/run-tests 'samizdat.js1-boundary-test)]
+  (println summary)
+  (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0)))

--- a/test/fixtures/js1/fixtures.edn
+++ b/test/fixtures/js1/fixtures.edn
@@ -1,0 +1,52 @@
+;; JS1 × SmolVM CI lane — fixture contract.
+;;
+;; Fixture DEFINITIONS live in the repo (immutable inputs to the lane);
+;; mutable RESULTS are CI artifacts only. test/samizdat/js1_harness_test.clj
+;; cross-checks this file against the real test sources, so a marker or
+;; phase renamed in the suite but not here fails the ordinary suite.
+{:fixtures/version 1
+
+ ;; bin/js1 check / smoke — the seam evidence lane invokes in the guest.
+ :wrapper {:path "bin/js1"
+           :check-marker "js1 runtime stack: OK"
+           :smoke-marker "SANDBOX-TEST OK"
+           ;; From docs/JS1_RUNTIME.md § Evidence at the pinned stack; the
+           ;; harness asserts the MARKER and records the summary line, it
+           ;; does not pin counts.
+           :evidence {:tests 28 :assertions 268}}
+
+ ;; The durable-restart boundary suite (test/samizdat/js1_boundary_test.clj)
+ ;; driven in the guest through boundary_runner.clj.
+ :boundary {:runner "test/fixtures/js1/boundary_runner.clj"
+            :suite-ns "samizdat.js1-boundary-test"
+            :suite-env "SAMIZDAT_JS1_BOUNDARY_TEST"
+            :phase-env "SAMIZDAT_JS1_BOUNDARY_PHASE"
+            :dir-env "SAMIZDAT_JS1_BOUNDARY_DIR"
+            :jolt-bin-env "SAMIZDAT_JOLT_BIN"
+            ;; The phases the suite-mode deftest spawns, in order.
+            :phases ["record" "resume" "mismatch-spec" "mismatch-runtime"
+                     "unsettled" "tool-refresh"]
+            ;; Child-phase stdout markers the suite asserts on; the lane's
+            ;; evidence value rests on these names staying exact.
+            :phase-markers {"record" ["RECORD-OK"]
+                            "resume" ["RESUME-OK"]
+                            "mismatch-spec" ["CLOSED-OK :coordinate-mismatch"]
+                            "mismatch-runtime" ["CLOSED-OK :runtime-mismatch"]
+                            "unsettled" [":pending-history" ":malformed-history"]
+                            "tool-refresh" ["TOOL-REFRESH-OK"]}
+            ;; The replay non-actuation witness: made.txt must still hold
+            ;; the tampered bytes after every post-record phase.
+            :non-actuation-witness "tampered-after-crash"
+            :summary-marker "0 failures, 0 errors"}
+
+ ;; Guest-side step markers printed by ci/js1-smolvm/guest-setup.sh; the
+ ;; host consumer requires each after a zero exit.
+ :guest-markers {:prepare "GUEST-PREPARE-OK"
+                 :check "GUEST-CHECK-OK"
+                 :smoke "GUEST-SMOKE-OK"
+                 :boundary "GUEST-BOUNDARY-OK"
+                 :manifest-prefix "GUEST-MANIFEST "}
+
+ ;; The consumer's smolvm status ready contract (verified against smolvm
+ ;; 1.7.5's status JSON shape by the ecosystem's live isolation suites).
+ :status-contract {:state "running" :network false :ports 0 :mounts 1}}

--- a/test/samizdat/agent_test.clj
+++ b/test/samizdat/agent_test.clj
@@ -35,6 +35,7 @@
             [samizdat.agent.resume :as resume]
             [samizdat.agent.state :as state]
             [samizdat.agent.tools :as tools]
+            [samizdat.agent.tools.base :as tbase]
             [samizdat.agent.verify :as verify]
             [samizdat.agent.gitdiff :as gitdiff]
             [samizdat.llm.client :as llm]
@@ -44,7 +45,8 @@
             [samizdat.store.failures :as failures]
             [samizdat.store.interventions :as interventions]
             [samizdat.store.journal :as journal]
-            [samizdat.store.runs :as runs]))
+            [samizdat.store.runs :as runs]
+            [samizdat.workflow :as wf]))
 
 ;; --- gates and the arbiter --------------------------------------------------
 
@@ -1555,4 +1557,143 @@
       (is (str/includes? msg "x"))
       (is (str/includes? msg "y"))
       (is (str/includes? msg "z") "the withheld claim is still shown too"))))
+;; --- JS1: single-player by construction --------------------------------------;; --- JS1: single-player by construction --------------------------------------
+;;
+;; A JS1 binding is one persistent :main SCI instance with one durable
+;; history per work-id. A width-N beam would evaluate N branches into that
+;; one instance and interleave N histories under one binding id — not a
+;; boundary that can be enforced mid-run, so the shape must be refused
+;; BEFORE the model is ever paid for. These tests pin the refusal at both
+;; drivers and the tool-surface behavior around the binding signal.
 
+(defn- ex-data-of [f]
+  (try (f) nil (catch Throwable e (ex-data e))))
+
+(defn- refusal-code [f]
+  "The {:js1/error ...} code of a closed refusal, or nil if `f` returned."
+  (:js1/error (ex-data-of f)))
+
+(def ^:private sci-present-in-suite?
+  (try (require 'samizdat.agent.sandbox) true
+       (catch Throwable _ false)))
+
+;; The refusal fixtures, named so each assertion line stays shallow enough
+;; to read: what is refused is visible in the name, how is visible in the
+;; defn, and neither buries the other.
+
+(defn- beam-profile-width-3 [c]
+  (beam/run! {:conn c :config {}
+              :llm-adapter :a :llm-config {}
+              :problem "p" :beam-width 3
+              :js1/profile "single-player"}))
+
+(defn- beam-wired-binding-width-2 [c]
+  (beam/run! {:conn c :config {}
+              :llm-adapter :a :llm-config {}
+              :problem "p" :beam-width 2
+              :js1/binding {:binding/id "b"}}))
+
+(defn- beam-config-width-5 [c]
+  (beam/run! {:conn c
+              :config {:run {:js1/profile "single-player"}}
+              :llm-adapter :a :llm-config {}
+              :problem "p" :beam-width 5}))
+
+(defn- workflow-subtasks [c]
+  (wf/run! {:conn c
+            :config {:run {:js1/profile "single-player"
+                           :subtasks ["a" "b"]}}
+            :llm-adapter :a :llm-config {}
+            :problem "p"}))
+
+(defn- workflow-beam-width [c]
+  (wf/run! {:conn c
+            :config {:run {:js1/profile "single-player"
+                           :beam-width 2}}
+            :llm-adapter :a :llm-config {}
+            :problem "p"}))
+
+(deftest js1-refuses-a-multi-branch-beam-before-any-work
+  (with-db [c]
+    (let [runs-before (count (db/fetch c ["SELECT id FROM runs"]))]
+      (testing "an explicit JS1 profile at width 3 is refused before a run row exists"
+        (is (= :multi-branch-not-supported (refusal-code #(beam-profile-width-3 c))))
+        (is (= runs-before (count (db/fetch c ["SELECT id FROM runs"])))
+            "no run row was opened: the refusal precedes the run itself"))
+      (testing "a wired binding is refused the same way"
+        (is (= :multi-branch-not-supported (refusal-code #(beam-wired-binding-width-2 c)))))
+      (testing "the config key alone is enough to refuse"
+        (is (= :multi-branch-not-supported (refusal-code #(beam-config-width-5 c))))))))
+
+(deftest js1-refuses-a-multi-branch-workflow-before-any-work
+  (with-db [c]
+    (let [runs-before (count (db/fetch c ["SELECT id FROM runs"]))]
+      (testing "a subtask fan-out under JS1 is refused"
+        (is (= :multi-branch-not-supported (refusal-code #(workflow-subtasks c))))
+        (is (= runs-before (count (db/fetch c ["SELECT id FROM runs"])))
+            "refused before the loop is compiled or the run row opened"))
+      (testing "an explicit multi-branch beam width is refused too"
+        (is (= :multi-branch-not-supported (refusal-code #(workflow-beam-width c))))))))
+
+(deftest the-js1-binding-signal-reads-through-the-refreshable-holder
+  ;; The holder is how a rollback between turns is absorbed: the eval tool
+  ;; resets it to the registry's current binding. Both wiring shapes must
+  ;; present the same canonical signal to the phase-refusal gate.
+  (let [plain {:js1/binding {:binding/id "plain"}}
+        held (update plain :js1/binding atom)]
+    (is (= {:binding/id "plain"} (tbase/js1-binding plain)))
+    (is (= {:binding/id "plain"} (tbase/js1-binding held))
+        "an atom holder derefs to the same signal")
+    (is (nil? (tbase/js1-binding {})))
+    (testing "update-js1-binding! writes through the holder only"
+      (let [fresh {:binding/id "fresh"}]
+        (is (= fresh (tbase/update-js1-binding! held fresh)))
+        (is (= fresh (tbase/js1-binding held))
+            "the next read sees the rollback's publication")
+        (is (= {:binding/id "plain"} (tbase/js1-binding plain))
+            "a plain map is immutable from a tool's point of view — no lie, just no refresh")))))
+
+(deftest a-js1-context-without-a-binding-refuses-eval
+  ;; The canonical signal is the binding; a ctx flagged JS1 whose binding
+  ;; is nil is refused outright, never routed to the live REPL.
+  (let [r (tools/run-tool {:branch (state/new-branch {:id "B1" :problem "p"})
+                           :tool-name "eval" :args {:code "(+ 1 2)"}
+                           :js1/profile "single-player"})]
+    (is (= :failure (:category r)))
+    (is (str/includes? (:result r) "refusing to evaluate outside the sandbox")
+        "the refusal names the trust boundary, not a missing feature")))
+
+(deftest a-js1-context-restricts-tools-through-either-signal-shape
+  (let [b (state/new-branch {:id "B1" :problem "p"})
+        refuse? (fn [ctx] (tbase/phase-refusal (assoc ctx :branch b)))]
+    (testing "a non-JS1 ctx is not restricted"
+      (is (nil? (refuse? {:tool-name "file"}))))
+    (testing "the holder shape restricts exactly like the plain shape"
+      (is (:policy-refusal? (refuse? {:tool-name "file" :js1/binding (atom {:x 1})})))
+      (is (:policy-refusal? (refuse? {:tool-name "file" :js1/binding {:x 1}}))))
+    (testing "the closed vocabulary holds: eval is permitted, file is not"
+      (is (nil? (refuse? {:tool-name "eval" :js1/binding (atom {:x 1})})))
+      (is (str/includes? (:result (refuse? {:tool-name "shell" :js1/profile "single-player"}))
+                         "JS1 profile permits only")))))
+
+(deftest a-js1-eval-without-a-loadable-sandbox-fails-closed
+  ;; Under the plain suite the sandbox ns cannot load, so a wired binding
+  ;; surfaces the unavailability as an eval error — never a live-eval
+  ;; fallthrough. (With SCI present the fake binding fails :not-a-binding,
+  ;; which is the same refusal one level down; both are asserted.)
+  (let [holder (atom {:binding/id "b" :work-id "w"
+                      :instance/key :main
+                      :spec {:preset :project/develop :root "/tmp"
+                             :capabilities [:project/read] :bounds {}
+                             :timeout-ms 30000}})
+        r (tools/run-tool {:branch (state/new-branch {:id "B1" :problem "p"})
+                           :conn ::no-conn :tool-name "eval"
+                           :args {:code "(+ 1 2)"}
+                           :js1/binding holder})
+        result (str (:result r))]
+    (is (str/includes? result "Eval error:"))
+    (if sci-present-in-suite?
+      (is (str/includes? result "Binding")
+          "with SCI present, a fake binding is refused as not-a-binding")
+      (is (str/includes? result "refusing live-eval fallback")
+          "without SCI the eval error names the trust boundary"))))

--- a/test/samizdat/evals_test.clj
+++ b/test/samizdat/evals_test.clj
@@ -35,10 +35,16 @@
   to the store."
   "js0:[:map [[:jolt.sandbox/profile \":agent/project-read\"]]]")
 
+(def ^:private runtime
+  "A RuntimeCoordinate of the shape samizdat.agent.sandbox emits. Opaque to
+  the store."
+  "js1-rt/v1:[:map [[:runtime/jolt \"test\"]]]")
+
 (def ^:private evaluator-identity
   {:spec-id "project/develop"
    :instance-id "inst:main"
-   :binding-id "bind:main:test"})
+   :binding-id "bind:main:test"
+   :runtime runtime})
 
 (defn- begin-eval! [conn opts]
   (evals/begin! conn (merge evaluator-identity opts)))
@@ -67,6 +73,91 @@
     (is (thrown? Exception (begin-eval! c {:coordinate "" :source "(+ 1 2)"})))
     (is (thrown? Exception (begin-eval! c {:coordinate coordinate :source "  "})))
     (is (empty? (evals/pending c)) "a refused intent records nothing")))
+
+(deftest intent-needs-a-runtime-coordinate
+  (with-db [c]
+    (is (thrown? Exception
+                 (evals/begin! c (merge (dissoc evaluator-identity :runtime)
+                                        {:coordinate coordinate :source "x"})))
+        "a missing runtime coordinate is refused")
+    (is (thrown? Exception
+                 (begin-eval! c {:coordinate coordinate :runtime " " :source "x"}))
+        "a blank runtime coordinate is refused")
+    (is (empty? (evals/pending c)) "a refused intent records nothing")))
+
+(deftest begin-assigns-a-durable-total-order-per-binding
+  (with-db [c]
+    (let [a (begin-eval! c {:coordinate coordinate :source "a"})
+          b (begin-eval! c {:coordinate coordinate :source "b"})
+          ;; An interleaved second binding has its own total order.
+          x (evals/begin! c (assoc evaluator-identity
+                                   :binding-id "bind:main:other"
+                                   :coordinate coordinate :source "x"))
+          d (begin-eval! c {:coordinate coordinate :source "d"})]
+      (is (= [0 1 2] (mapv (comp :binding_seq #(evals/load-eval c %)) [a b d]))
+          "one binding's evaluations number 0, 1, 2, ... in registration order")
+      (is (= 0 (:binding_seq (evals/load-eval c x)))
+          "a different binding starts its own order at 0")
+      (is (thrown? Exception (begin-eval! c {:coordinate "" :source "e"})))
+      (is (= 3 (:binding_seq (evals/load-eval
+                              c (begin-eval! c {:coordinate coordinate :source "e"}))))
+          "a refused begin consumes no sequence number"))))
+
+(deftest the-binding-total-order-is-structurally-unique
+  (with-db [c]
+    (begin-eval! c {:coordinate coordinate :source "a"})
+    (is (thrown? Exception
+                 (db/execute! c ["INSERT INTO evals (spec_id, instance_id, binding_id, binding_seq, coordinate, runtime, source, created_at)
+                                  VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                                 "s" "i" (:binding-id evaluator-identity) 0
+                                 coordinate runtime "dup" (db/now)]))
+        "a duplicate (binding_id, binding_seq) is rejected by the database, not by convention")))
+
+(deftest verify-binding-checks-the-runtime-coordinate
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "x"})]
+      (is (map? (evals/verify-binding! c id (assoc evaluator-identity
+                                                   :coordinate coordinate)))
+          "a full five-field identity match verifies")
+      (is (thrown? Exception
+                   (evals/verify-binding! c id (assoc evaluator-identity
+                                                      :coordinate coordinate
+                                                      :runtime "js1-rt/v1:WRONG")))
+          "a runtime mismatch fails closed")
+      (is (thrown? Exception
+                   (evals/verify-binding! c id (-> evaluator-identity
+                                                   (assoc :coordinate coordinate)
+                                                   (dissoc :runtime))))
+          "a caller without a runtime coordinate fails closed")
+      (is (thrown? Exception
+                   (evals/verify-binding! c id (assoc evaluator-identity
+                                                      :coordinate "js0:WRONG")))
+          "an authority-coordinate mismatch still fails closed"))))
+
+(deftest history-returns-the-bindings-total-order-with-statuses
+  (with-db [c]
+    (let [a (begin-eval! c {:coordinate coordinate :source "a"})
+          b (begin-eval! c {:coordinate coordinate :source "b"})]
+      (evals/record-intent! c a {:op :project/read :args ["f"]})
+      (evals/record-outcome! c a 0 {:result {:content "x"}})
+      (evals/complete! c a {:status :completed :result {:value 1}})
+      ;; b stays pending; an unrelated binding never appears in this history.
+      (evals/begin! c (assoc evaluator-identity
+                             :binding-id "bind:main:other"
+                             :coordinate coordinate :source "z"))
+      (let [h (evals/history c (:binding-id evaluator-identity))]
+        (is (= [a b] (mapv :id h)))
+        (is (= [0 1] (mapv :binding_seq h)))
+        (is (= [:completed :pending] (mapv :status h))
+            "pending rows are visible for what they are")
+        (is (= [runtime runtime] (mapv :runtime h)))
+        (let [r (first (:receipts (first h)))]
+          (is (= :project/read (:op r)))
+          (is (= :done (:phase r)))
+          (is (= {:content "x"} (:result r))
+              "receipts come back as data within the history projection")))
+      (is (= [] (evals/history c "bind:main:never-seen"))
+          "a binding with no record has an empty history"))))
 
 (deftest receipts-round-trip-as-structured-data-in-strict-order
   (with-db [c]

--- a/test/samizdat/evals_test.clj
+++ b/test/samizdat/evals_test.clj
@@ -1,0 +1,209 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.evals-test
+  "Durable evaluator receipt storage: intent before effect, completion
+  afterward, strict-sequence reads, structured EDN round-trips, and the
+  fail-closed treatment of whatever was left pending."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [samizdat.store.db :as db]
+            [samizdat.store.evals :as evals]))
+
+(defmacro with-db [[binding] & body]
+  `(let [~binding (db/open! ":memory:")]
+     (try ~@body (finally (db/close ~binding)))))
+
+(def ^:private coordinate
+  "An evaluator/context coordinate of the shape jolt.sandbox emits. Opaque
+  to the store."
+  "js0:[:map [[:jolt.sandbox/profile \":agent/project-read\"]]]")
+
+(def ^:private evaluator-identity
+  {:spec-id "project/develop"
+   :instance-id "inst:main"
+   :binding-id "bind:main:test"})
+
+(defn- begin-eval! [conn opts]
+  (evals/begin! conn (merge evaluator-identity opts)))
+
+(deftest migration-creates-the-eval-tables
+  (with-db [c]
+    (is (every? (set (db/table-names c))
+                ["evals" "eval_completions" "eval_receipts"]))))
+
+(deftest begin-records-intent-and-the-record-starts-pending
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "(+ 1 2)"})]
+      (is (pos? id))
+      (is (= [id] (mapv :id (evals/pending c)))
+          "pending from the moment intent is recorded")
+      (let [r (evals/load-eval c id)]
+        (is (= :pending (:status r)))
+        (is (= coordinate (:coordinate r)))
+        (is (= "(+ 1 2)" (:source r)))
+        (is (= [] (:receipts r)))
+        (is (nil? (:result r)))
+        (is (nil? (:completed_at r)))))))
+
+(deftest intent-needs-a-coordinate-and-source
+  (with-db [c]
+    (is (thrown? Exception (begin-eval! c {:coordinate "" :source "(+ 1 2)"})))
+    (is (thrown? Exception (begin-eval! c {:coordinate coordinate :source "  "})))
+    (is (empty? (evals/pending c)) "a refused intent records nothing")))
+
+(deftest receipts-round-trip-as-structured-data-in-strict-order
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate
+                              :source "(project/read \"a\") (project/edit \"b\" 2)"})
+          s0 (evals/record-intent! c id {:op :project/read
+                                         :args ["a" {:nested [1 2 {:k :v :s 'sym}]}]})
+          s1 (evals/record-intent! c id {:op :project/edit :args ["b" 2]})]
+      (is (= [0 1] [s0 s1]) "seqs are assigned in intent order")
+      (evals/record-outcome! c id s0 {:result {:bytes [1 2 3] :tag :ok}})
+      (evals/record-outcome! c id s1 {:error "disk full"})
+      (let [rs (:receipts (evals/load-eval c id))]
+        (is (= [0 1] (mapv :seq rs)) "receipts load in strict seq order")
+        (is (= [:project/read :project/edit] (mapv :op rs)))
+        (is (= ["a" {:nested [1 2 {:k :v :s 'sym}]}] (:args (first rs)))
+            "args come back as data, not transcript text")
+        (is (= {:bytes [1 2 3] :tag :ok} (:result (first rs)))
+            "and so does the result")
+        (is (= :done (:phase (first rs))))
+        (is (= :error (:phase (second rs))))
+        (is (= "disk full" (:error (second rs))))))))
+
+(deftest the-stored-form-is-canonical-edn-not-a-transcript
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "x"})
+          _ (evals/record-intent! c id {:op :project/stat :args [{:b 1 :a 2}]})
+          raw (:args (db/fetch-one c ["SELECT args FROM eval_receipts
+                                       WHERE eval_id = ? AND phase = 'intent'" id]))]
+      (is (string? raw) "the column holds text...")
+      (is (= [{:a 2 :b 1}] (edn/read-string raw)) "...that parses as EDN data")
+      (is (< (str/index-of raw ":a") (str/index-of raw ":b"))
+          "with map entries in canonical key order, not caller order"))))
+
+(deftest non-canonical-values-are-refused-not-stringified
+  ;; A receipt that cannot round-trip as data is not a receipt. Floats,
+  ;; live objects and functions are rejected at the boundary rather than
+  ;; pr-str'd into something that reads back as a different thing.
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "x"})]
+      (is (thrown? Exception (evals/record-intent! c id {:op :project/read :args [(atom 0)]})))
+      (is (thrown? Exception (evals/record-intent! c id {:op :project/read :args [1.5]})))
+      (is (empty? (evals/unsettled-effects c id))
+          "a refused intent records nothing")
+      (is (thrown? Exception (evals/complete! c id {:status :completed
+                                                    :result {:value (fn [x] x)}})))
+      (is (= [id] (mapv :id (evals/pending c))) "and the refused completion did not land"))))
+
+(deftest completion-records-terminal-status-and-structured-result
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "(+ 1 2)"})]
+      (is (true? (evals/complete! c id {:status :completed
+                                        :result {:value 3 :out "" :receipts-used 0}})))
+      (is (empty? (evals/pending c)))
+      (let [r (evals/load-eval c id)]
+        (is (= :completed (:status r)))
+        (is (= {:value 3 :out "" :receipts-used 0} (:result r))
+            "terminal result metadata round-trips as data")
+        (is (some? (:completed_at r)))))))
+
+(deftest completed-records-list-in-strict-sequence
+  ;; Insertion order, not completion order: the sequence is the order the
+  ;; evaluations were registered, which is the order their receipts replay.
+  (with-db [c]
+    (let [a (begin-eval! c {:coordinate coordinate :source "a"})
+          b (begin-eval! c {:coordinate coordinate :source "b"})
+          d (begin-eval! c {:coordinate coordinate :source "d"})]
+      (evals/complete! c b {:status :failed :result {:error "boom"}})
+      (evals/complete! c a {:status :completed})
+      (let [rows (evals/completed c)]
+        (is (= [a b] (mapv :id rows)))
+        (is (= [:completed :failed] (mapv :status rows)))
+        (is (= {:error "boom"} (:result (second rows)))))
+      (is (= [d] (mapv :id (evals/pending c)))))))
+
+(deftest lists-are-bounded
+  (with-db [c]
+    (dotimes [_ 5]
+       (evals/complete! c (begin-eval! c {:coordinate coordinate :source "x"})
+                       {:status :completed}))
+    (begin-eval! c {:coordinate coordinate :source "p1"})
+    (begin-eval! c {:coordinate coordinate :source "p2"})
+    (is (= 3 (count (evals/completed c 3))))
+    (is (= 5 (count (evals/completed c))) "the default bound covers a small history")
+    (is (= 1 (count (evals/pending c 1))))
+    (is (= 2 (count (evals/pending c))))))
+
+(deftest an-unsettled-effect-blocks-completion-so-the-caller-fails-closed
+  ;; The window that makes durability worth having: the process recorded the
+  ;; intent to actuate and died (or is still) between the actuation and its
+  ;; outcome. Completing now would claim a whole record when one actuation's
+  ;; effect on the world is unknown — so completion refuses, and the record
+  ;; stays pending where `pending` reports it.
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "(project/edit \"f\" 1)"})
+          n (evals/record-intent! c id {:op :project/edit :args ["f" 1]})]
+      (is (thrown? Exception (evals/complete! c id {:status :completed})))
+      (is (= [{:seq n :op :project/edit :args ["f" 1]}]
+             (evals/unsettled-effects c id))
+          "the effect whose actuation state is unknown, named exactly")
+      (is (= :intent (:phase (first (:receipts (evals/load-eval c id)))))
+          "and the loaded receipt says intent, not a guessed outcome")
+      (is (= [id] (mapv :id (evals/pending c)))
+          "the record stays pending: the actuation may have happened"))))
+
+(deftest a-settled-record-is-final
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "x"})
+          n (evals/record-intent! c id {:op :project/read :args ["a"]})]
+      (evals/record-outcome! c id n {:result nil})
+      (testing "a nil result is a real outcome, not an unsettled intent"
+        (let [r (first (:receipts (evals/load-eval c id)))]
+          (is (= :done (:phase r)))
+          (is (contains? r :result))
+          (is (nil? (:result r))))
+        (is (empty? (evals/unsettled-effects c id))))
+      (evals/complete! c id {:status :completed})
+      (is (thrown? Exception (evals/complete! c id {:status :completed}))
+          "no second terminal record")
+      (is (thrown? Exception (evals/record-intent! c id {:op :project/read :args []}))
+          "no receipts after completion")
+      (is (thrown? Exception (evals/record-outcome! c id n {:result 1}))
+          "and no late outcomes either"))))
+
+(deftest outcomes-require-an-intent-and-are-not-rewritten
+  (with-db [c]
+    (let [id (begin-eval! c {:coordinate coordinate :source "x"})]
+      (is (thrown? Exception (evals/record-outcome! c id 0 {:result 1}))
+          "an outcome with no intent is an effect nobody recorded running")
+      (let [n (evals/record-intent! c id {:op :project/read :args ["a"]})]
+        (evals/record-outcome! c id n {:result 1})
+        (is (thrown? Exception (evals/record-outcome! c id n {:result 2}))
+            "a receipt is not rewritten")
+        (is (thrown? Exception (evals/record-outcome! c id n {:result 1 :error "x"}))
+            "an outcome is a result or an error, not both")))))
+
+(deftest unknown-evaluations-are-refused-on-write-and-nil-on-read
+  (with-db [c]
+    (is (nil? (evals/load-eval c 999)))
+    (is (thrown? Exception (evals/record-intent! c 999 {:op :project/read :args []})))
+    (is (thrown? Exception (evals/complete! c 999 {:status :failed})))))

--- a/test/samizdat/gitdiff_test.clj
+++ b/test/samizdat/gitdiff_test.clj
@@ -2,8 +2,10 @@
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
 (ns samizdat.gitdiff-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing run-tests]]
             [samizdat.agent.gitdiff :as gd]
+            [samizdat.agent.verify :as verify]
             [samizdat.engine.proc :as proc]))
 
 (deftest diff-fails-soft
@@ -14,26 +16,118 @@
   (is (= "" (gd/diff "/tmp" nil)))
   (is (nil? (gd/baseline nil))))
 
-(defn- sh [dir cmd]
-  (proc/run {:timeout-ms 15000} "sh" "-c" (str "cd " dir " && " cmd)))
+;; Fixture setup runs through the same scoped structured seam the production
+;; code under test uses — direct argv with the repo as cwd and the scrubbed
+;; allowlist environment — so the tests never lean on shell composition the
+;; source discipline forbids.
+(defn- sh
+  [dir & cmd]
+  (proc/scope-run {:cmd (vec cmd) :dir dir
+                   :env (proc/scrubbed-allowlist-env)
+                   :timeout-ms 15000 :term-grace-ms 2000
+                   :out-bytes 65536 :err-bytes 65536}))
+
+(defn- temp-dir [tag]
+  (str (System/getProperty "java.io.tmpdir") "/samizdat-gd-" tag "-"
+       (System/currentTimeMillis) "-" (rand-int 100000)))
+
+(defn- init-repo! [dir]
+  (.mkdirs (java.io.File. dir))
+  (sh dir "git" "init" "-q")
+  (sh dir "git" "config" "user.email" "t@t.co")
+  (sh dir "git" "config" "user.name" "t"))
 
 (deftest changed-files-sees-new-untracked-files
   ;; The bug this pins: `git diff` is blind to untracked files, so a run that
   ;; CREATES a namespace + its test read as 'changed nothing' and every done
   ;; was refused as hollow. changed-files must union in `git ls-files --others`.
   (when (proc/available? "git")
-    (let [dir (str (System/getProperty "java.io.tmpdir") "/gd-untracked-"
-                   (System/currentTimeMillis))]
+    (let [dir (temp-dir "untracked")]
       (try
-        (proc/run {:timeout-ms 15000} "sh" "-c" (str "mkdir -p " dir))
-        (sh dir "git init -q && git config user.email t@t.co && git config user.name t")
-        (sh dir "echo seed > seed.txt && git add -A && git commit -qm init")
+        (init-repo! dir)
+        (spit (str dir "/seed.txt") "seed\n")
+        (sh dir "git" "add" "-A")
+        (sh dir "git" "commit" "-qm" "init")
         (let [base (gd/baseline dir)]
           (testing "a clean tree has changed nothing"
             (is (= [] (gd/changed-files dir base))))
           ;; a NEW untracked file (the create-a-namespace case) and a tracked edit
-          (sh dir "echo new > src_new.clj && echo more >> seed.txt")
+          (spit (str dir "/src_new.clj") "new\n")
+          (spit (str dir "/seed.txt") "seed\nmore\n" :append true)
           (let [changed (set (gd/changed-files dir base))]
             (is (contains? changed "src_new.clj") "the newly-created file is seen")
             (is (contains? changed "seed.txt") "and a tracked edit is still seen")))
-        (finally (sh dir (str "rm -rf " dir)))))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest adversarial-names-survive-git-and-refuse-focused-verification
+  ;; End-to-end for the critical verify-path finding: the model writes test
+  ;; files whose NAMES are the attack. git (which quotes exotic paths, so
+  ;; they stay visibly exotic) reports them through the scoped structured
+  ;; gitdiff; focused verification then REFUSES them — or, with a trusted
+  ;; fallback configured, runs the operator's command untouched. Nothing
+  ;; composes a shell anywhere on the way, so the names are data end to end.
+  (when (proc/available? "git")
+    (let [dir (temp-dir "adversarial")]
+      (try
+        (init-repo! dir)
+        (spit (str dir "/seed.txt") "seed\n")
+        (sh dir "git" "add" "-A")
+        (sh dir "git" "commit" "-qm" "init")
+        (let [base (gd/baseline dir)]
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          ;; the review's quote breakout, verbatim, as a real file name
+          (spit (str dir "/evil';touch pwned_test.clj") "(ns evil)\n")
+          ;; non-ASCII — git reports it C-quoted with octal escapes
+          (spit (str dir "/ünïcode_test.clj") "(ns uni)\n")
+          (let [changed (gd/changed-files dir base)
+                listed (some->> (.list (java.io.File. dir)) seq)]
+            (testing "the attack name really exists on disk"
+              (is (some #(str/includes? % "evil';touch pwned") listed)))
+            (testing "git reports the adversarial names back"
+              (is (some #(str/includes? % "good_test") changed))
+              (is (some #(str/includes? % "touch pwned") changed)
+                  "the printable-ASCII attack name arrives raw")
+              (is (some #(re-find #"\\3" %) changed)
+                  "the Unicode name arrives octal-escaped (git quoting)"))
+            (testing "focused verification refuses the whole derivation"
+              (let [req (verify/verify-request {:changed changed :focused? true})]
+                (is (= :refused (:kind req)))
+                (is (some #(str/includes? % "evil") (:refused req))
+                    "the adversarial name is named in the refusal")))
+            (testing "a trusted configured fallback absorbs it untouched"
+              (let [req (verify/verify-request {:changed changed :focused? true
+                                                :fallback-cmd "jolt -M:test"})]
+                (is (= :fallback (:kind req)))
+                (is (= ["sh" "-c" "jolt -M:test"] (:argv req))
+                    "the operator command runs verbatim; no changed path
+                     entered it")))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest gitdiff-fails-soft-when-the-scoped-primitive-is-missing
+  ;; The boundary half of the fail-closed contract: on a runtime without
+  ;; the scoped primitive every git call here fails, so this namespace's
+  ;; answers degrade to its fail-soft shapes (nil baseline, cannot-tell,
+  ;; empty diff) WITHOUT throwing — and the SHIP gate, which is where
+  ;; cannot-tell becomes a trust decision, probes the same boundary and
+  ;; blocks instead (see ship-test). Failing soft here can never fail
+  ;; open there.
+  (with-redefs [proc/scope-supported? (constantly false)]
+    (binding [proc/*scope-run*
+              (fn [_]
+                (throw (UnsupportedOperationException.
+                         "process-scope: requires Linux with posix_spawn process-group and poll(2) support")))]
+      (is (nil? (gd/baseline "/tmp")))
+      (is (nil? (gd/changed-files "/tmp" "HEAD")))
+      (is (= "" (gd/diff "/tmp" "HEAD"))))))
+
+;; --- self-run for the focused lane ---------------------------------------------
+;; On the recorded JS1 classpath (repo root; jolt located as bin/js1 locates
+;; it — $JOLT_HOME, else the sibling ../jolt checkout):
+;;   SAMIZDAT_GITDIFF_TEST_RUN=1 ../jolt/bin/jolt -Srepro -Scp "$(bin/js1 path)" run test/samizdat/gitdiff_test.clj
+
+(when (= "1" (jolt.host/getenv "SAMIZDAT_GITDIFF_TEST_RUN"))
+  (let [{:keys [fail error] :as summary} (run-tests 'samizdat.gitdiff-test)]
+    (println summary)
+    (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0))))

--- a/test/samizdat/js1_boundary_test.clj
+++ b/test/samizdat/js1_boundary_test.clj
@@ -1,0 +1,626 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.js1-boundary-test
+  "The JS1 durable-restart evidence, across REAL OS-process boundaries.
+
+  This one file is both halves of the harness:
+
+  SUITE MODE (default): a clojure.test entry that spawns child jolt
+  processes and asserts on their exit codes and the on-disk state they
+  leave.  A run needs the jolt binary, a Chez 10 scheme, the vendored SCI
+  source root, and the four extracted Maven jars the sandbox needs — the
+  same prerequisites samizdat.sandbox-test's direct invocation lists —
+  plus SAMIZDAT_JS1_BOUNDARY_TEST=1 so the ordinary suite stays fast.
+  Without them the test skips with a reason, exactly like the sandbox ns
+  skips without SCI.
+
+  CHILD MODE (SAMIZDAT_JS1_BOUNDARY_PHASE=<phase>): this same file is run
+  by `jolt -Scp <full project classpath + SCI roots> run <this file>` in a
+  FRESH process, executing one phase:
+
+    record          mint a JS1 binding, evaluate a helper def, an edit
+                    (actuation), and an observation into it through the
+                    durable *eval-store* seam backed by a FILE, plus one
+                    deliberately failing evaluation; write the exact
+                    journal information (workflow/js1-binding-journal-data,
+                    the same map production journals) and exit.  The
+                    process then dies — that is the point.
+
+    resume          a NEW process: install the file-backed store, tamper
+                    the project files, reconstruct the binding through
+                    samizdat.agent.resume/reconstruct-js1-binding! (whole
+                    committed history replayed into ONE fresh SCI context)
+                    and verify the model's definitions survived the crash.
+
+    mismatch-spec   a NEW process: reconstruct against journal info whose
+                    spec coordinate was tampered — must fail CLOSED.
+    mismatch-runtime  the same with a tampered runtime coordinate — must
+                    fail CLOSED before anything is allocated.
+    unsettled       a NEW process: the durable history's last record made
+                    pending with an unsettled effect intent, and separately
+                    a gap in the binding's total order — both must fail
+                    CLOSED, performing zero project operations.
+
+  The no-repeated-invocation evidence: `record` edits made.txt into
+  existence and reads it back; before every later phase the harness (or
+  the phase itself) tampers it on disk.  Replay serves the edit and the
+  read from receipts — a re-invoked edit would conflict (:absent on an
+  existing file), a re-invoked read would return the tampered content and
+  fail the recorded-result comparison, and a re-invoked edit would
+  overwrite the tampered bytes.  A successful reconstruction that leaves
+  the tampered file untouched is therefore direct evidence that ZERO real
+  project operations executed during replay."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [jolt.fs :as fs]
+            [samizdat.engine.proc :as proc]))
+
+;; ─── shared layout ──────────────────────────────────────────────────────────
+
+(def ^:private work-id "boundary-work")
+
+(defn- dir-env [] (jolt.host/getenv "SAMIZDAT_JS1_BOUNDARY_DIR"))
+(defn- phase-env [] (jolt.host/getenv "SAMIZDAT_JS1_BOUNDARY_PHASE"))
+
+(defn- root-dir [dir] (str dir "/root"))
+(defn- store-path [dir] (str dir "/store.edn"))
+(defn- journal-path [dir] (str dir "/journal.edn"))
+(defn- outcomes-path [dir] (str dir "/outcomes.edn"))
+(defn- made-path [dir] (str (root-dir dir) "/made.txt"))
+
+(defn- slurp-edn [path] (edn/read-string (slurp path)))
+
+(defn- deny? [f]
+  (try (f) false (catch Throwable _ true)))
+
+;; ─── child: the file-backed durable eval store ──────────────────────────────
+;;
+;; The samizdat.store.evals contract over one EDN file, so the durable
+;; record survives process death the way the sqlite tables do in
+;; production.  Row shape mirrors the real store's read projection exactly
+;; (underscore identity columns, :binding_seq, :runtime) because
+;; rebuild-binding!'s validation reads those keys.  `conn` is the state
+;; directory; every write persists the whole small state file.
+
+(defn- store-read!
+  "The whole durable state from `dir`, or a fresh empty state."
+  [dir]
+  (if (fs/exists? (store-path dir))
+    (slurp-edn (store-path dir))
+    {:next-id 1 :records {}}))
+
+(defn- store-write! [dir state]
+  (spit (store-path dir) (pr-str state)))
+
+(defn- file-begin! [dir {:keys [spec-id instance-id binding-id coordinate
+                                runtime source]}]
+  (let [state (store-read! dir)
+        id (:next-id state)
+        binding-seq (count (filter #(= (str binding-id) (:binding_id %))
+                                   (vals (:records state))))
+        record {:id id
+                :spec_id (str spec-id)
+                :instance_id (str instance-id)
+                :binding_id (str binding-id)
+                :binding_seq binding-seq
+                :coordinate (str coordinate)
+                :runtime (str runtime)
+                :source (str source)
+                :status :pending
+                :result nil
+                :receipts []}
+        state' (-> state
+                   (assoc :next-id (inc id))
+                   (assoc-in [:records id] record))]
+    (store-write! dir state')
+    id))
+
+(defn- file-record-intent! [dir eval-id {:keys [op args]}]
+  (let [state (store-read! dir)
+        record (get-in state [:records eval-id])
+        n (count (:receipts record))
+        receipt {:seq n :op op :args (vec (or args [])) :phase :intent}
+        state' (assoc-in state [:records eval-id :receipts]
+                         (conj (vec (:receipts record)) receipt))]
+    (store-write! dir state')
+    n))
+
+(defn- file-record-outcome! [dir eval-id seq-n {:keys [result error]}]
+  (let [state (store-read! dir)
+        receipts (vec (get-in state [:records eval-id :receipts]))
+        receipt (nth receipts seq-n)
+        ;; exactly one of :result / :error, like the real store
+        settled (if (some? error)
+                  (assoc receipt :phase :error :error (str error))
+                  (assoc receipt :phase :done :result result))
+        state' (assoc-in state [:records eval-id :receipts seq-n] settled)]
+    (store-write! dir state')
+    seq-n))
+
+(defn- file-complete! [dir eval-id {:keys [status result]}]
+  (let [state (store-read! dir)
+        state' (-> state
+                   (assoc-in [:records eval-id :status] status)
+                   (assoc-in [:records eval-id :result] result))]
+    (store-write! dir state')
+    true))
+
+(defn- file-load-eval [dir eval-id]
+  (get-in (store-read! dir) [:records eval-id]))
+
+(defn- file-verify-binding! [dir eval-id {:keys [spec-id instance-id
+                                                 binding-id coordinate runtime]}]
+  (let [record (file-load-eval dir eval-id)
+        expected {:spec_id (str spec-id)
+                  :instance_id (str instance-id)
+                  :binding_id (str binding-id)
+                  :coordinate (str coordinate)
+                  :runtime (str runtime)}]
+    (when-not (and record
+                   (= expected (select-keys record (keys expected))))
+      (throw (ex-info "evaluator binding does not match durable evaluation"
+                      {:eval-id eval-id})))
+    record))
+
+(defn- file-history [dir binding-id]
+  (->> (vals (:records (store-read! dir)))
+       (filter #(= (str binding-id) (:binding_id %)))
+       (sort-by :binding_seq)
+       vec))
+
+(defn- install-file-store!
+  "Point the sandbox's durable-eval seam at the file adapter for `dir`,
+  exactly the way a controller or test binds it in production (the seam
+  production leaves nil and dynamically resolves to samizdat.store.evals)."
+  [dir]
+  (let [v (resolve 'samizdat.agent.sandbox/*eval-store*)]
+    (alter-var-root
+     v (constantly
+        {:begin! (fn [conn intent] (file-begin! conn intent))
+         :record-intent! (fn [conn id m] (file-record-intent! conn id m))
+         :record-outcome! (fn [conn id n m] (file-record-outcome! conn id n m))
+         :complete! (fn [conn id m] (file-complete! conn id m))
+         :load-eval (fn [conn id] (file-load-eval conn id))
+         :verify-binding! (fn [conn id m] (file-verify-binding! conn id m))
+         :history (fn [conn b] (file-history conn b))}))))
+
+;; ─── child phases ───────────────────────────────────────────────────────────
+
+(defn- require-sandbox! []
+  (require 'samizdat.agent.sandbox))
+
+(defn- phase-record! [dir]
+  (require-sandbox!)
+  (require 'samizdat.workflow)
+  (fs/create-dirs (root-dir dir))
+  (install-file-store! dir)
+  (let [provider-fn (resolve 'samizdat.agent.sandbox/provider)
+        bind-fn (resolve 'samizdat.agent.sandbox/bind!)
+        rt-fn (resolve 'samizdat.agent.sandbox/runtime-coordinate)
+        journal-data-fn (resolve 'samizdat.workflow/js1-binding-journal-data)
+        evaluate! (resolve 'samizdat.agent.sandbox/evaluate-recorded!)
+        provider (provider-fn {:root (root-dir dir)})
+        binding (bind-fn provider work-id
+                         {:preset :project/develop
+                          :root (root-dir dir)
+                          :instance/key :main})]
+    ;; helper definition (pure state)
+    (evaluate! dir binding "(defn helper [x] (* 2 x))")
+    ;; actuation: the edit that must NEVER be re-invoked at replay
+    (evaluate! dir binding
+               "(project/edit \"made.txt\" :absent \"made-by-record\")")
+    ;; cross-eval state + observation: answer needs `helper` from the
+    ;; FIRST eval; the read's recorded result pins made.txt's content
+    (evaluate! dir binding
+               "(def answer (helper 21)) (project/read \"made.txt\")")
+    ;; a deliberately failing evaluation: durably :failed, rolled back,
+    ;; never replayed — `ghost` must not exist after the restart
+    (try
+      (evaluate! dir binding "(def ghost 1) (no-such-fn)")
+      (catch Throwable _ nil))
+    ;; the exact journal event data, from the same function production
+    ;; journals with
+    (spit (journal-path dir)
+          (pr-str (journal-data-fn "single-player" binding (rt-fn))))
+    (println "RECORD-OK")))
+
+(defn- expect-js1-error!
+  "Run `f`, require that it fails closed with {:js1/error code} (and
+  optionally a specific :sandbox-error), print OK, or throw so the child
+  exits non-zero."
+  ([f code] (expect-js1-error! f code nil))
+  ([f code sandbox-code]
+   (let [outcome (try
+                   {:returned (f)}
+                   (catch Throwable e
+                     {:thrown (ex-data e)}))]
+     (when (:returned outcome)
+       (throw (ex-info (str "expected a closed :js1/error " code
+                            " failure, but reconstruction returned")
+                       {:got (:returned outcome)})))
+     (let [d (:thrown outcome)]
+       (when (not= code (:js1/error d))
+         (throw (ex-info (str "expected :js1/error " code ", got "
+                              (:js1/error d))
+                       {:ex-data d})))
+       (when (and sandbox-code (not= sandbox-code (:sandbox-error d)))
+         (throw (ex-info (str "expected :sandbox-error " sandbox-code
+                              ", got " (:sandbox-error d))
+                         {:ex-data d})))
+        (println "CLOSED-OK" code
+                 (str "sandbox-error " (or (:sandbox-error d) "-")))))))
+
+(defn- reconstruct! [dir info]
+  (require 'samizdat.agent.resume)
+  (let [reconstruct (resolve 'samizdat.agent.resume/reconstruct-js1-binding!)]
+    (reconstruct dir info (root-dir dir))))
+
+(defn- phase-tool-refresh! [dir]
+  "The held-binding refresh contract, at the EVAL TOOL level, against the
+  real sandbox and the real durable store:
+
+  - a failed recorded evaluation rolls the instance back and supersedes
+    the ctx's held binding; the tool must transparently re-acquire the
+    registry's current binding so the NEXT eval works (and the committed
+    state survives while the failed eval's defs do not);
+  - an out-of-band rebuild-binding! between two tool evals supersedes the
+    held binding; the next eval must observe :stale-binding, re-acquire,
+    and retry ONCE — the model asked for an evaluation, not a wiring
+    error it cannot see."
+  (require-sandbox!)
+  (install-file-store! dir)
+  (require 'samizdat.agent.tools)
+  (require 'samizdat.agent.state)
+  (let [provider-fn (resolve 'samizdat.agent.sandbox/provider)
+        bind-fn (resolve 'samizdat.agent.sandbox/bind!)
+        rebuild-fn (resolve 'samizdat.agent.sandbox/rebuild-binding!)
+        provider (provider-fn {:root (root-dir dir)})
+        binding (bind-fn provider work-id
+                         {:preset :project/develop
+                          :root (root-dir dir)
+                          :instance/key :main})
+        holder (atom binding)
+        tools (resolve 'samizdat.agent.tools/run-tool)
+        new-branch (resolve 'samizdat.agent.state/new-branch)
+        branch (new-branch {:id "B1" :problem "boundary"})
+        eval-tool (fn [code]
+                    (let [r (tools {:branch branch
+                                    :conn dir
+                                    :tool-name "eval"
+                                    :args {:code code}
+                                    :js1/profile "single-player"
+                                    :js1/binding holder
+                                    :js1/provider provider})
+                          result (str (:result r))]
+                      {:ok? (str/starts-with? result "=>")
+                       :result result
+                       :branch (:branch r)}))
+        outcomes (atom [])]
+    ;; a committed def, then a failing eval whose partial def must roll
+    ;; back — the tool re-acquires the fresh binding after the failure
+    (let [r1 (eval-tool "(def x 1) x")]
+      (swap! outcomes conj [:commit-1 (:ok? r1) (:result r1)]))
+    (let [r2 (eval-tool "(def y 2) (no-such-fn)")]
+      (swap! outcomes conj [:fail (:ok? r2)]))
+    ;; THE assertion: the next eval works on the refreshed binding, sees
+    ;; the committed def, and does not see the rolled-back one
+    (let [r3 (eval-tool "(inc x)")]
+      (swap! outcomes conj [:after-rollback (:ok? r3) (:result r3)]))
+    (let [r4 (eval-tool "y")]
+      (swap! outcomes conj [:rolled-back-denied (not (:ok? r4))]))
+    ;; an out-of-band whole-history rebuild supersedes the held binding;
+    ;; the next tool eval must absorb it (:stale-binding retry-once)
+    (rebuild-fn dir @holder)
+    (let [r5 (eval-tool "(inc (inc x))")]
+      (swap! outcomes conj [:after-stale (:ok? r5) (:result r5)]))
+    (let [pad (fn [rows] (mapv (fn [row] (if (= 3 (count row)) row (conj row nil)))
+                               rows))
+          expected [[:commit-1 true "=> 1"]
+                    [:fail false]
+                    [:after-rollback true "=> 2"]
+                    [:rolled-back-denied true]
+                    [:after-stale true "=> 3"]]
+          got (pad @outcomes)]
+      (when (not= (pad expected) got)
+        (throw (ex-info "tool-refresh contract violated"
+                        {:expected (pad expected) :got got})))
+      (spit (str dir "/tool-refresh.edn") (pr-str got))
+      (println "TOOL-REFRESH-OK"))))
+
+(defn- phase-resume! [dir]
+  (require-sandbox!)
+  (install-file-store! dir)
+  (let [info (slurp-edn (journal-path dir))]
+    ;; The crash gap: between the record process dying and this one
+    ;; starting, the world moved. made.txt is tampered on disk; replay
+    ;; must serve BOTH the edit and the read from receipts, so a
+    ;; successful reconstruction leaving these bytes untouched is the
+    ;; no-repeated-invocation evidence.
+    (spit (made-path dir) "tampered-after-crash")
+    (let [{:keys [binding]} (reconstruct! dir info)
+          evaluate! (resolve 'samizdat.agent.sandbox/evaluate!)
+          outcomes {:helper (evaluate! binding "(helper 5)")
+                    :answer (evaluate! binding "answer")
+                    :ghost-denied? (deny? #(evaluate! binding "ghost"))
+                    :made-on-disk (slurp (made-path dir))
+                    :spec-coordinate (:spec/coordinate (:spec binding))
+                    :expected-spec-coordinate (:spec-coordinate info)}]
+      (spit (outcomes-path dir) (pr-str outcomes))
+      (println "RESUME-OK"))))
+
+(defn- phase-mismatch-spec! [dir]
+  (require-sandbox!)
+  (install-file-store! dir)
+  (let [info (assoc (slurp-edn (journal-path dir))
+                    :spec-coordinate "js1:tampered-coordinate")]
+    (expect-js1-error! #(reconstruct! dir info) :coordinate-mismatch)))
+
+(defn- phase-mismatch-runtime! [dir]
+  (require-sandbox!)
+  (install-file-store! dir)
+  (let [info (assoc (slurp-edn (journal-path dir))
+                    :runtime-coordinate "js1-rt/v1:tampered")]
+    (expect-js1-error! #(reconstruct! dir info) :runtime-mismatch)))
+
+(defn- last-completed-id [state]
+  (->> (vals (:records state))
+       (filter #(= :completed (:status %)))
+       (sort-by :binding_seq)
+       last
+       :id))
+
+(defn- phase-unsettled! [dir]
+  (require-sandbox!)
+  (install-file-store! dir)
+  (let [info (slurp-edn (journal-path dir))
+        state0 (store-read! dir)
+        target-id (last-completed-id state0)
+        original (get-in state0 [:records target-id])
+        first-id (->> (vals (:records state0))
+                      (sort-by :binding_seq)
+                      first
+                      :id)]
+    ;; Case 1: the target record is rewritten as the append-only crash
+    ;; shape — begin + edit intent landed, neither outcome nor completion
+    ;; did.  The actuation state of that edit is UNKNOWN, so the honest
+    ;; resume refuses.
+    (store-write!
+     dir
+     (assoc-in state0 [:records target-id]
+               (assoc original
+                      :status :pending :result nil
+                      :source "(project/edit \"unsettled.txt\" :absent \"maybe\")"
+                      :receipts [{:seq 0 :op :project/edit
+                                  :args ["unsettled.txt" :absent "maybe"]
+                                  :phase :intent}])))
+    (expect-js1-error! #(reconstruct! dir info)
+                       :history-invalid :pending-history)
+    (when (fs/exists? (str (root-dir dir) "/unsettled.txt"))
+      (throw (ex-info "the refused resume performed a project actuation" {})))
+    (println "UNSETTLED-OK")
+    ;; Case 2, from the clean state: a gap in the binding's durable total
+    ;; order is a torn record, refused as malformed history.
+    (store-write!
+     dir
+     (-> state0
+         (assoc-in [:records first-id :binding_seq] 5)
+         (assoc-in [:records target-id] original)))
+    (expect-js1-error! #(reconstruct! dir info)
+                       :history-invalid :malformed-history)
+    (when (fs/exists? (str (root-dir dir) "/unsettled.txt"))
+      (throw (ex-info "the refused resume performed a project actuation" {})))
+    (println "GAP-OK")))
+
+(defn- run-phase! []
+  (let [phase (phase-env)
+        dir (dir-env)]
+    (when (or (str/blank? phase) (str/blank? dir))
+      (throw (ex-info "child mode needs SAMIZDAT_JS1_BOUNDARY_PHASE and _DIR"
+                      {:phase phase})))
+    (case phase
+      "record" (phase-record! dir)
+      "resume" (phase-resume! dir)
+      "mismatch-spec" (phase-mismatch-spec! dir)
+      "mismatch-runtime" (phase-mismatch-runtime! dir)
+      "unsettled" (phase-unsettled! dir)
+      "tool-refresh" (phase-tool-refresh! dir)
+      (throw (ex-info "unknown phase" {:phase phase})))
+    (System/exit 0)))
+
+;; ─── suite mode: spawn the children, assert on their world ──────────────────
+
+(def ^:private m2-jars
+  ["borkdude/edamame/1.5.39/edamame-1.5.39.jar.jolt"
+   "org/babashka/sci.impl.types/0.0.3/sci.impl.types-0.0.3.jar.jolt"
+   "borkdude/graal.locking/0.0.2/graal.locking-0.0.2.jar.jolt"
+   "org/clojure/tools.reader/1.5.2/tools.reader-1.5.2.jar.jolt"])
+
+(defn- jolt-bin
+  "The jolt launcher: explicit override, then the sibling checkout of this
+  project (the dev layout this harness is written against)."
+  []
+  (let [candidates (remove str/blank?
+                           [(jolt.host/getenv "SAMIZDAT_JOLT_BIN")
+                            (let [wd (System/getProperty "user.dir")]
+                              (str wd "/../jolt/bin/jolt"))])]
+    (some #(when (fs/exists? %) %) candidates)))
+
+(defn- scheme-bin []
+  (or (let [e (jolt.host/getenv "JOLT_CHEZ")]
+        (when (and e (fs/exists? e)) e))
+      (let [e "/usr/local/bin/scheme"]
+        (when (fs/exists? e) e))))
+
+(defn- prerequisites []
+  (let [bin (jolt-bin)
+        scheme (scheme-bin)
+        sci-src (let [b (jolt-bin)]
+                  (when b (str (fs/parent (fs/parent b)) "/vendor/sci/src")))
+        home (jolt.host/getenv "HOME")
+        jars (when home
+               (mapv #(str home "/.m2/repository/" %) m2-jars))]
+    {:jolt bin
+     :scheme scheme
+     :sci-src sci-src
+     :jars jars
+     :ready? (and bin scheme
+                  sci-src (fs/exists? sci-src)
+                  (every? #(and % (fs/exists? %)) jars))}))
+
+(defn- project-dir []
+  (System/getProperty "user.dir"))
+
+(defn- child-classpath
+  "The full project classpath (resolved exactly as `jolt path` resolves
+  it, in a child of this project directory) plus the SCI roots the
+  sandbox needs — everything samizdat.agent.sandbox, samizdat.workflow
+  and samizdat.agent.resume load in child mode."
+  []
+  (let [{:keys [jolt scheme]} (prerequisites)
+        ;; jolt path resolves the deps.edn of its working directory
+        {:keys [exit out err]} (proc/run
+                                {:timeout-ms 120000
+                                 :env {"PATH" "/usr/local/bin:/usr/bin:/bin"
+                                       "HOME" (jolt.host/getenv "HOME")
+                                       "JOLT_CHEZ" scheme
+                                       "JOLT_QUIET" "1"
+                                       "JOLT_PWD" (project-dir)}}
+                                jolt "path")]
+    (when (not= 0 exit)
+      (throw (ex-info (str "jolt path failed: " err) {})))
+    (let [base (str/trim out)]
+      (when-not (str/includes? base "/src")
+        (throw (ex-info "jolt path returned no source roots" {:out out})))
+      base)))
+
+(defn- run-child!
+  "Spawn one phase in a fresh jolt process with the full classpath + SCI.
+  Returns {:exit :out :err :timeout}."
+  [cp phase dir]
+  (let [{:keys [jolt scheme]} (prerequisites)
+        this-file (str (project-dir) "/test/samizdat/js1_boundary_test.clj")]
+    (proc/run
+     {:timeout-ms 300000
+      :env {"PATH" "/usr/local/bin:/usr/bin:/bin"
+            "HOME" (jolt.host/getenv "HOME")
+            "JOLT_CHEZ" scheme
+            "JOLT_QUIET" "1"
+            "JOLT_PWD" (project-dir)
+            "SAMIZDAT_JS1_BOUNDARY_PHASE" phase
+            "SAMIZDAT_JS1_BOUNDARY_DIR" dir}}
+     jolt "-Scp" cp "run" this-file)))
+
+(defn- sci-classpath
+  "Project classpath plus the vendored SCI source and its four jars."
+  [cp]
+  (let [{:keys [sci-src jars]} (prerequisites)]
+    (str/join ":" (into [cp sci-src] jars))))
+
+(deftest js1-durable-restart-across-os-process-boundaries
+  (let [{:keys [ready? jolt scheme]} (prerequisites)]
+    (if (or (not ready?)
+            (not= "1" (jolt.host/getenv "SAMIZDAT_JS1_BOUNDARY_TEST")))
+      (is true (str "skipped: needs the jolt binary, Chez scheme, vendored"
+                    " SCI roots, the four SCI Maven jars, and"
+                    " SAMIZDAT_JS1_BOUNDARY_TEST=1"
+                    (when jolt (str " (jolt: " jolt ")"))
+                    (when scheme (str " (scheme: " scheme ")"))))
+      (let [base-cp (child-classpath)
+            cp (sci-classpath base-cp)
+            dir (str "/tmp/samizdat-js1-boundary-" (random-uuid))]
+        (fs/create-dirs dir)
+        (try
+          (testing "the record process mints the binding and durable history"
+            (let [{:keys [exit out err timeout]} (run-child! cp "record" dir)]
+              (is (not timeout) "record phase finished")
+              (is (= 0 exit) (str "record exit 0\nstdout: " out "\nstderr: " err))
+              (is (str/includes? out "RECORD-OK"))
+              (is (= "made-by-record" (slurp (made-path dir)))
+                  "the edit really actuated in the record process")
+              (is (fs/exists? (journal-path dir)))
+              (is (= 4 (count (file-history dir (str "bind:main:" work-id))))
+                  "helper, edit, observation, and the failed eval are all durable")))
+          (testing "a NEW process resumes: whole history, one SCI context, no re-invocation"
+            (let [{:keys [exit out err timeout]} (run-child! cp "resume" dir)]
+              (is (not timeout) "resume phase finished")
+              (is (= 0 exit) (str "resume exit 0\nstdout: " out "\nstderr: " err))
+              (is (str/includes? out "RESUME-OK"))
+              (let [o (slurp-edn (outcomes-path dir))]
+                (is (= 10 (:helper o))
+                    "the helper def from the first eval survived the crash")
+                (is (= 42 (:answer o))
+                    "cross-eval state (answer = helper 21) survived")
+                (is (true? (:ghost-denied? o))
+                    "the failed eval's def never committed and never replayed")
+                (is (= "tampered-after-crash" (:made-on-disk o))
+                    "replay invoked zero real project operations — the edit
+                     was served from its receipt, not re-run")
+                (is (= (:expected-spec-coordinate o) (:spec-coordinate o))
+                    "the reconstructed binding is spec-identical to the original"))))
+          (testing "a tampered spec coordinate fails closed in a fresh process"
+            (let [{:keys [exit out err timeout]} (run-child! cp "mismatch-spec" dir)]
+              (is (not timeout))
+              (is (= 0 exit) (str "mismatch-spec verified the closed failure"
+                                  "\nstdout: " out "\nstderr: " err))
+              (is (str/includes? out "CLOSED-OK :coordinate-mismatch"))))
+          (testing "a tampered runtime coordinate fails closed before allocation"
+            (let [{:keys [exit out err timeout]} (run-child! cp "mismatch-runtime" dir)]
+              (is (not timeout))
+              (is (= 0 exit) (str "mismatch-runtime verified the closed failure"
+                                  "\nstdout: " out "\nstderr: " err))
+              (is (str/includes? out "CLOSED-OK :runtime-mismatch"))))
+          (testing "an unsettled receipt history fails closed with no actuation"
+            (let [{:keys [exit out err timeout]} (run-child! cp "unsettled" dir)]
+              (is (not timeout))
+              (is (= 0 exit) (str "unsettled verified both closed failures"
+                                  "\nstdout: " out "\nstderr: " err))
+              (is (str/includes? out ":pending-history"))
+              (is (str/includes? out ":malformed-history"))
+              (is (not (fs/exists? (str dir "/root/unsettled.txt")))
+                  "neither refused resume performed a project actuation")
+              (is (= "tampered-after-crash" (slurp (made-path dir)))
+                  "made.txt untouched through every phase — no phase after
+                   record ever invoked a real project operation")))
+          (testing "the eval tool absorbs rollback and stale bindings so the next eval works"
+            (let [tdir (str dir "-tools")]
+              (fs/create-dirs tdir)
+              (let [{:keys [exit out err timeout]} (run-child! cp "tool-refresh" tdir)]
+                (is (not timeout))
+                (is (= 0 exit) (str "tool-refresh verified the refresh contract"
+                                    "\nstdout: " out "\nstderr: " err))
+                (is (str/includes? out "TOOL-REFRESH-OK"))
+                (is (= [[:commit-1 true "=> 1"]
+                        [:fail false nil]
+                        [:after-rollback true "=> 2"]
+                        [:rolled-back-denied true nil]
+                        [:after-stale true "=> 3"]]
+                       (slurp-edn (str tdir "/tool-refresh.edn")))
+                    "commit -> failure(rollback) -> next eval works with
+                     committed state -> rolled-back def denied -> out-of-band
+                     rebuild absorbed transparently"))))
+          (finally (fs/delete-tree dir) (fs/delete-tree (str dir "-tools"))))))))
+
+;; ─── child-mode entry ───────────────────────────────────────────────────────
+;;
+;; When the environment names a phase, this file IS the harness: run the
+;; phase and exit, so the suite process (which spawned us) asserts on our
+;; exit code, our stdout markers, and the world we left on disk.
+(when-let [phase (phase-env)]
+  (run-phase!))

--- a/test/samizdat/js1_dogfood_test.clj
+++ b/test/samizdat/js1_dogfood_test.clj
@@ -399,8 +399,99 @@
   (try (if (fs/exists? path) (edn/read-string (slurp path)) default)
        (catch Throwable _ default)))
 
-(defn- op-sequence [counter-path]
-  (mapv :op (:events (read-edn-file counter-path {:events [] :counts {}}))))
+(defn- phase-events [counter-path phase]
+  (->> (:events (read-edn-file counter-path {:events [] :counts {}}))
+       (filter #(= phase (:phase %)))
+       vec))
+
+(defn- event-matches-contract?
+  [event requirement]
+  (let [args (:args event)]
+    (and (= (:op requirement) (:op event))
+         (or (not (contains? requirement :args))
+             (= (:args requirement) args))
+         (or (not (contains? requirement :path))
+             (= (:path requirement) (nth args 0 nil)))
+         (or (not (contains? requirement :content))
+             (= (:content requirement) (nth args 2 nil)))
+         (or (not= :sha256 (:base requirement))
+             (boolean (re-matches #"sha256:[0-9a-f]{64}"
+                                  (str (nth args 1 nil))))))))
+
+(defn- required-subsequence?
+  [events requirements]
+  (loop [events (seq events), requirements (seq requirements)]
+    (cond
+      (nil? requirements) true
+      (nil? events) false
+      (event-matches-contract? (first events) (first requirements))
+      (recur (next events) (next requirements))
+      :else (recur (next events) requirements))))
+
+(defn- validate-pre-red-events!
+  "Order-aware start-phase contract. Extra discovery is allowed, but it must
+  be read-only and before the sole anchored RED edit. The required operations
+  remain an ordered subsequence, stat/edit counts remain exact, and the edit's
+  path, digest-shaped base, and complete content are checked."
+  [events]
+  (let [{:keys [required-subsequence minimum-counts exact-counts
+                additional-before-edit]}
+        (get-in contract [:semantic-operations :before-resume])
+        counts (frequencies (map :op events))
+        edit-indexes (keep-indexed (fn [i event]
+                                     (when (= :project/edit (:op event)) i))
+                                   events)
+        edit-index (first edit-indexes)
+        allowed-before (conj additional-before-edit :project/stat)
+        errors (cond-> []
+                 (not (required-subsequence? events required-subsequence))
+                 (conj :required-subsequence-missing)
+
+                 (some (fn [[op n]] (< (get counts op 0) n)) minimum-counts)
+                 (conj :minimum-count-missing)
+
+                 (some (fn [[op n]] (not= n (get counts op 0))) exact-counts)
+                 (conj :exact-count-violated)
+
+                 (not= 1 (count edit-indexes))
+                 (conj :first-edit-not-unique)
+
+                 (and edit-index (not= edit-index (dec (count events))))
+                 (conj :semantic-operation-after-edit)
+
+                 (and edit-index
+                      (some #(not (contains? allowed-before (:op %)))
+                            (subvec events 0 edit-index)))
+                 (conj :non-discovery-operation-before-edit))]
+    (when (seq errors)
+      (throw (ex-info
+              "RED checkpoint violates the ordered/minimum semantic-operation contract; refusing resume"
+              {:js1-dogfood/error :unexpected-red-operations
+               :errors errors
+               :counts counts
+               :events (mapv #(select-keys % [:phase :op :args]) events)})))
+    {:counts counts
+     :event-count (count events)
+     :extra-read-only-count
+     (- (count events) (count required-subsequence))
+     :required-subsequence true
+     :first-edit-index edit-index}))
+
+(defn- validate-resume-events!
+  "Exact resume-phase contract. Reconstruction itself contributes ZERO
+  events; the only permitted post-reconstruction operations are the new red
+  evidence read, one fresh stat, and one GREEN anchored edit. Thus historical
+  list/search/TASK/source/test observations and the RED edit cannot repeat."
+  [events]
+  (let [expected (get-in contract [:semantic-operations :resume-exact])]
+    (when-not (and (= (count expected) (count events))
+                   (every? true? (map event-matches-contract? events expected)))
+      (throw (ex-info
+              "resume/replay semantic operations were not exact"
+              {:js1-dogfood/error :unexpected-resume-operations
+               :expected expected
+               :actual (mapv #(select-keys % [:phase :op :args]) events)})))
+    {:exact true :event-count (count events)}))
 
 (defn- safe-spit! [path value]
   (spit path (if (string? value) value (pr-str value))))
@@ -744,6 +835,33 @@
 
 ;; ── parent test -------------------------------------------------------------
 
+(deftest pre-red-contract-allows-repeated-read-only-discovery
+  (let [event (fn [op args] {:phase "start" :op op :args args})
+        events [(event :project/list ["."])
+                ;; Exact independently observed live prefix: the first search
+                ;; attempt used the alternate argument order, then discovery
+                ;; retried with the documented order. Both are read-only.
+                (event :project/search [{:path "."} "DOGFOOD"])
+                (event :project/list ["."])
+                (event :project/search ["DOGFOOD" {:path "."}])
+                (event :project/read ["TASK.md"])
+                (event :project/read ["src/dogfood.clj"])
+                (event :project/read ["test/dogfood_test.clj"])
+                (event :project/stat ["src/dogfood.clj"])
+                (event :project/edit
+                       ["src/dogfood.clj"
+                        (str "sha256:" (apply str (repeat 64 "a")))
+                        "(ns fixture.dogfood)\n\n(def dogfood-state :red)\n"])]
+        witness (validate-pre-red-events! events)]
+    (is (:required-subsequence witness))
+    (is (= 2 (:extra-read-only-count witness)))
+    (is (= 1 (get-in witness [:counts :project/edit])))
+    (is (= :unexpected-red-operations
+           (try
+             (validate-pre-red-events! (conj events (event :project/read ["TASK.md"])))
+             nil
+             (catch ExceptionInfo e (:js1-dogfood/error (ex-data e))))))))
+
 (deftest durable-red-quiescence-classification
   ;; Offline discriminator for N1: a pending eval is unsafe even before it has
   ;; an effect, and an unsettled intent is reported explicitly. No SCI or model.
@@ -841,24 +959,19 @@
                   run-id (:run-id checkpoint)
                   _ (swap! run-data assoc :target target :run-id run-id
                            :checkpoint checkpoint :start-result start-result)
-                  before-resume-ops (op-sequence counter-path)]
+                  start-events (phase-events counter-path "start")
+                  pre-red-witness (validate-pre-red-events! start-events)]
               (println "JS1-DOGFOOD-RED-CHECKPOINT" run-id)
               ;; STOP made the first witness race-free; the post-reap witness
               ;; proves shutdown added no torn record before resume is allowed.
               (require-quiescent-db! db-path run-id "after bounded child reap")
-              (when-not (= (get-in contract [:semantic-operations :before-resume])
-                           before-resume-ops)
-                (throw (ex-info
-                        "RED checkpoint has unexpected semantic operations; refusing resume"
-                        {:js1-dogfood/error :unexpected-red-operations
-                         :expected (get-in contract [:semantic-operations :before-resume])
-                         :actual before-resume-ops})))
               (testing "the first process was intentionally killed at durable RED"
                 (is (not (.isAlive (:proc child))))
                 (is (= "(ns fixture.dogfood)\n\n(def dogfood-state :red)\n"
                        (slurp (str target "/src/dogfood.clj"))))
-                (is (= (get-in contract [:semantic-operations :before-resume])
-                       before-resume-ops)))
+                (is (:required-subsequence pre-red-witness))
+                (is (= 1 (get-in pre-red-witness [:counts :project/stat])))
+                (is (= 1 (get-in pre-red-witness [:counts :project/edit]))))
               (let [resume-result (run-child! runtime "resume"
                                               (assoc paths :run-id run-id
                                                      :timeout-ms
@@ -873,6 +986,12 @@
                                                        (min phase-timeout-ms
                                                             remaining))))]
                 (swap! run-data assoc :resume-result resume-result)
+                ;; Per-phase exactness is intentionally separate from the
+                ;; flexible discovery prefix. Replay emits no counter events;
+                ;; resume may only read NEW red evidence, stat, and edit GREEN.
+                (let [resume-witness
+                      (validate-resume-events!
+                       (phase-events counter-path "resume"))]
                 (testing "fresh-process resume reconstructed state and shipped GREEN"
                   (is (str/includes? (:out resume-result)
                                      "JS1-DOGFOOD-RESUME-HELPER-OK"))
@@ -880,10 +999,7 @@
                                      "JS1-DOGFOOD-GREEN-OK"))
                   (is (= "(ns fixture.dogfood)\n\n(def dogfood-state :green)\n"
                          (slurp (str target "/src/dogfood.clj"))))
-                  (is (= (vec (concat
-                               (get-in contract [:semantic-operations :before-resume])
-                               (get-in contract [:semantic-operations :after-resume])))
-                         (op-sequence counter-path))))
+                  (is (:exact resume-witness)))
                 (let [conn (db/connect db-path)]
                   (try
                     (let [run (runs/get-run conn run-id)
@@ -914,7 +1030,7 @@
                                     (map :tool_name turns))))
                       (testing "the same fixed operator verifier eventually recorded GREEN"
                         (is (= 1 (count green-events)))))
-                    (finally (db/close conn)))))))
+                    (finally (db/close conn))))))))
           (finally
             (when-let [target (:target @run-data)]
               (try

--- a/test/samizdat/js1_dogfood_test.clj
+++ b/test/samizdat/js1_dogfood_test.clj
@@ -14,14 +14,16 @@
     HARNESS_MODEL=<operator-selected model>
 
   The parent creates a disposable Git repository and a detached target
-  worktree under /tmp, outside this trusted checkout. It drives the real
+  worktree under a retained per-run user-data directory, outside this trusted
+  checkout. It drives the real
   workflow/run! in one pinned-JS1 process, kills that process only after a
   durable red ship-verify event, and drives agent.resume/resume! in a fresh
   pinned-JS1 process. No live REPL fallback exists in this harness.
 
-  Artifacts are retained in a printed /tmp directory: sanitized transcript,
-  run id, SQLite DB, process logs, semantic-operation dispatch counters,
-  journal, artifact rows, and target diff. No environment dump is captured."
+  Worktree, SQLite DB, and artifacts are co-located under one unique retained
+  run directory beneath ~/.local/share/samizdat/js1-dogfood (overridable with
+  SAMIZDAT_JS1_DOGFOOD_DIR). No temporary-directory fallback and no environment
+  dump is used."
   (:require [clojure.data.json :as json]
             [clojure.edn :as edn]
             [clojure.string :as str]
@@ -48,6 +50,51 @@
 
 (defn- env [name] (jolt.host/getenv name))
 (defn- internal-env [name] (env (str "SAMIZDAT_JS1_DOGFOOD_" name)))
+
+(defn- absolute-normal-path [path]
+  (str (.normalize (.toAbsolutePath (.toPath (java.io.File. (str path)))))))
+
+(defn- host-temporary-root?
+  "True for the two conventional host temporary trees.  An explicit override
+  is not permission to scatter a new run there; old artifacts may remain, but
+  every new harness layout is persistent user data."
+  [path]
+  (let [roots [(str "/" "tmp") (str "/" "var" "/" "tmp")]]
+    (some #(or (= path %) (str/starts-with? path (str % "/"))) roots)))
+
+(defn- dogfood-data-root
+  "Persistent root for every dogfood-owned path.  HOME/user.home is the only
+  default; importantly, the Java temporary-directory property is not a fallback."
+  []
+  (let [override (env "SAMIZDAT_JS1_DOGFOOD_DIR")
+        home (or (env "HOME") (System/getProperty "user.home"))
+        configured (if-not (str/blank? override)
+                     override
+                     (when-not (str/blank? home)
+                       (str home "/.local/share/samizdat/js1-dogfood")))]
+    (when (str/blank? configured)
+      (throw (ex-info
+              "JS1 dogfood needs HOME or SAMIZDAT_JS1_DOGFOOD_DIR; refusing a temporary-directory fallback"
+              {:js1-dogfood/error :data-root-unavailable})))
+    (let [root (absolute-normal-path configured)]
+      (when (host-temporary-root? root)
+        (throw (ex-info
+                "JS1 dogfood data root must be persistent and outside host temporary trees"
+                {:js1-dogfood/error :temporary-data-root :root root})))
+      root)))
+
+(defn- new-run-layout
+  "One unique retained directory containing the worktree/control repo, DB,
+  counters, logs, and captured artifacts for a preflight or live run."
+  [kind]
+  (let [run-dir (str (dogfood-data-root) "/" kind "-"
+                     (System/currentTimeMillis) "-" (random-uuid))
+        artifact-dir (str run-dir "/artifacts")]
+    {:run-dir run-dir
+     :workspace-root (str run-dir "/worktree")
+     :artifact-dir artifact-dir
+     :db-path (str run-dir "/run.sqlite3")
+     :counter-path (str artifact-dir "/semantic-operations.edn")}))
 
 (defn- live-requested? []
   (= "1" (env "SAMIZDAT_JS1_DOGFOOD_TEST")))
@@ -205,7 +252,7 @@
      :resolver-alias "-A:js1-dogfood-live"}))
 
 (defn- child-env
-  [{:keys [phase target db-path counter-path run-id]}]
+  [{:keys [phase target db-path counter-path verify-request-path run-id]}]
   (cond-> (assoc (safe-controller-env)
                  "HARNESS_PROVIDER" "local"
                  "HARNESS_BASE_URL" "http://localhost:13305/v1"
@@ -220,6 +267,8 @@
                  "SAMIZDAT_JS1_DOGFOOD_TARGET" target
                  "SAMIZDAT_JS1_DOGFOOD_DB" db-path
                  "SAMIZDAT_JS1_DOGFOOD_COUNTERS" counter-path)
+    verify-request-path
+    (assoc "SAMIZDAT_JS1_DOGFOOD_VERIFY_REQUEST" verify-request-path)
     (= phase "preflight")
     (assoc "SAMIZDAT_JS1_DOGFOOD_PREFLIGHT" "1")
     (not= phase "preflight")
@@ -620,6 +669,22 @@
        :verify-binding! evals/verify-binding!
        :history evals/history}))))
 
+(defn- install-verifier-request-capture!
+  "Capture the actual fresh-process fallback request immediately before the
+  trusted scope primitive receives it.  Persist only structure/cwd/bounds —
+  never the request's environment map."
+  [path]
+  (let [delegate proc/*scope-run*]
+    (alter-var-root
+     #'proc/*scope-run*
+     (constantly
+      (fn [request]
+        (when (= ["sh" "-c" "./verify-policy"] (:cmd request))
+          (safe-spit! path
+                      (select-keys request [:cmd :dir :timeout-ms :term-grace-ms
+                                            :out-bytes :err-bytes])))
+        (delegate request))))))
+
 (defn- dogfood-config [target db-path]
   (require 'samizdat.config)
   (let [load-config (resolve 'samizdat.config/load-config)]
@@ -774,6 +839,7 @@
   (let [target (internal-env "TARGET")
         db-path (internal-env "DB")
         counter-path (internal-env "COUNTERS")
+        verify-request-path (internal-env "VERIFY_REQUEST")
         run-id (internal-env "RUN_ID")
         config (dogfood-config target db-path)
         reconstruct (resolve 'samizdat.agent.resume/reconstruct-js1-binding!)
@@ -783,6 +849,7 @@
         conn (db/open! db-path)]
     (try
       (install-counting-eval-store! counter-path "resume")
+      (install-verifier-request-capture! verify-request-path)
       (let [before (counter-state counter-path)
             info (js1-event-info conn run-id)
             {:keys [binding]} (reconstruct conn info target)
@@ -884,21 +951,50 @@
           (is (:quiescent? (eval-quiescence conn)))))
       (finally (db/close conn)))))
 
+(deftest dogfood-storage-has-one-persistent-default-root
+  (testing "the default is the user's persistent data tree, never a temp fallback"
+    (with-redefs [env (fn [name] (when (= name "HOME") "/home/dogfood-user"))]
+      (is (= "/home/dogfood-user/.local/share/samizdat/js1-dogfood"
+             (dogfood-data-root)))))
+  (testing "the operator override owns the complete tree"
+    (with-redefs [env (fn [name]
+                        (case name
+                          "SAMIZDAT_JS1_DOGFOOD_DIR" "/srv/samizdat-dogfood"
+                          "HOME" "/home/ignored"
+                          nil))]
+      (let [a (new-run-layout "test")
+            b (new-run-layout "test")
+            owned (select-keys a [:workspace-root :artifact-dir
+                                  :db-path :counter-path])]
+        (is (str/starts-with? (:run-dir a) "/srv/samizdat-dogfood/test-"))
+        (is (not= (:run-dir a) (:run-dir b)) "every invocation is retained separately")
+        (is (every? #(str/starts-with? % (str (:run-dir a) "/")) (vals owned))
+            "worktree, DB, logs/counters, and artifacts share one run directory"))))
+  (testing "even an explicit override cannot put a new run in host temp"
+    (with-redefs [env (fn [name]
+                        (when (= name "SAMIZDAT_JS1_DOGFOOD_DIR")
+                          (str "/" "tmp" "/new-dogfood")))]
+      (is (= :temporary-data-root
+             (try (dogfood-data-root) nil
+                  (catch ExceptionInfo e (:js1-dogfood/error (ex-data e))))))))
+  (testing "static harness defaults contain no literal host-temp storage path"
+    (let [src (slurp (str source-dir "/test/samizdat/js1_dogfood_test.clj"))]
+      (is (not (str/includes? src (str "\"" "/" "tmp")))
+          "a new hard-coded host-temp path cannot bypass the layout helper")
+      (is (not (str/includes? src (str "java.io." "tmpdir")))
+          "the Java temporary directory is not a hidden fallback"))))
+
 (deftest no-provider-js1-dogfood-preflight
   (if-not (and (preflight-requested?) (not (live-requested?)))
     (is true "skipped: set SAMIZDAT_JS1_DOGFOOD_PREFLIGHT=1 for no-provider compile preflight")
     (do
       (require-preflight-contract!)
-      (let [id (str (random-uuid))
-            root (str "/tmp/samizdat-js1-dogfood-preflight-" id)
-            db-path (str root "/preflight.sqlite3")
-            counter-path (str root "/preflight-counters.edn")
-            before-source (source-witness)
-            layout (atom nil)]
-        (fs/create-dirs root)
+      (let [{:keys [run-dir workspace-root artifact-dir db-path counter-path]}
+            (new-run-layout "preflight")
+            before-source (source-witness)]
+        (fs/create-dirs artifact-dir)
         (try
-          (let [{:keys [target] :as made} (make-detached-target! root)
-                _ (reset! layout made)
+          (let [{:keys [target]} (make-detached-target! workspace-root)
                 runtime (live-runtime!)
                 result (run-child! runtime "preflight"
                                    {:target target :db-path db-path
@@ -910,35 +1006,29 @@
             (is (not (fs/exists? counter-path))
                 "preflight dispatched no model-facing semantic operation"))
           (finally
-            (when-let [{:keys [control target]} @layout]
-              (try (git! control "worktree" "remove" "--force" target)
-                   (catch Throwable _ nil)))
-            (try (fs/delete-tree root) (catch Throwable _ nil))
             (is (= before-source (source-witness))
-                "no-provider preflight modified the trusted source checkout")))))))
+                "no-provider preflight modified the trusted source checkout")
+            (println "JS1 dogfood preflight retained:" run-dir)))))))
 
 (deftest bounded-opt-in-live-js1-dogfood
   (if-not (live-requested?)
     (is true "skipped: set SAMIZDAT_JS1_DOGFOOD_TEST=1 plus the exact local-provider contract")
     (do
       (require-live-contract!)
-      (let [id (str (random-uuid))
-            root (str "/tmp/samizdat-js1-dogfood-" id)
-            artifact-dir (str "/tmp/samizdat-js1-dogfood-artifacts-" id)
-            db-path (str artifact-dir "/run.sqlite3")
-            counter-path (str artifact-dir "/semantic-operations-live.edn")
-             before-source (source-witness)
-            layout (atom nil)
+      (let [{:keys [run-dir workspace-root artifact-dir db-path counter-path]}
+            (new-run-layout "run")
+            verify-request-path (str artifact-dir "/resume-verifier-request.edn")
+            before-source (source-witness)
             run-data (atom {:artifact-dir artifact-dir :db-path db-path
                             :counter-path counter-path})]
-        (fs/create-dirs root)
         (fs/create-dirs artifact-dir)
         (try
-          (let [{:keys [control target] :as made} (make-detached-target! root)
-                _ (reset! layout made)
+          (let [{:keys [target]}
+                (make-detached-target! workspace-root)
                 _ (swap! run-data assoc :target target)
                 runtime (live-runtime!)
-                paths {:target target :db-path db-path :counter-path counter-path}
+                paths {:target target :db-path db-path :counter-path counter-path
+                       :verify-request-path verify-request-path}
                 preflight (run-child! runtime "preflight" paths)]
             (testing "current APIs form a real JS1 workflow path"
               (is (str/includes? (:out preflight) "JS1-DOGFOOD-PREFLIGHT-OK")))
@@ -999,7 +1089,15 @@
                                      "JS1-DOGFOOD-GREEN-OK"))
                   (is (= "(ns fixture.dogfood)\n\n(def dogfood-state :green)\n"
                          (slurp (str target "/src/dogfood.clj"))))
-                  (is (:exact resume-witness)))
+                  (is (:exact resume-witness))
+                  (let [request (read-edn-file verify-request-path nil)]
+                    (is (= ["sh" "-c" "./verify-policy"] (:cmd request))
+                        "done sent the fixed operator verifier as structured argv")
+                    (is (= target (:dir request))
+                        "the resumed verifier cwd is the detached target")
+                    (is (and (string? (:dir request))
+                             (.isAbsolute (java.io.File. (:dir request))))
+                        "the fresh process sent an absolute verifier cwd")))
                 (let [conn (db/connect db-path)]
                   (try
                     (let [run (runs/get-run conn run-id)
@@ -1038,12 +1136,9 @@
                 (catch Throwable e
                   (safe-spit! (str artifact-dir "/capture-error.txt")
                               (str (ex-message e) "\n")))))
-            (when-let [{:keys [control target]} @layout]
-              (try (git! control "worktree" "remove" "--force" target)
-                   (catch Throwable _ nil)))
-            (try (fs/delete-tree root) (catch Throwable _ nil))
             (is (= before-source (source-witness))
                 "the live dogfood modified the trusted running checkout")
+            (println "JS1 dogfood run retained:" run-dir)
             (println "JS1 dogfood artifacts:" artifact-dir)))))))
 
 (when-let [phase (internal-env "PHASE")]

--- a/test/samizdat/js1_dogfood_test.clj
+++ b/test/samizdat/js1_dogfood_test.clj
@@ -1,0 +1,934 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.js1-dogfood-test
+  "Bounded, explicitly opted-in, live JS1 dogfood over a LOCAL model only.
+
+  Ordinary test runs execute no process and no provider call. A live run needs
+  all three exact operator choices:
+
+    SAMIZDAT_JS1_DOGFOOD_TEST=1
+    HARNESS_PROVIDER=local
+    HARNESS_BASE_URL=http://localhost:13305/v1
+    HARNESS_MODEL=<operator-selected model>
+
+  The parent creates a disposable Git repository and a detached target
+  worktree under /tmp, outside this trusted checkout. It drives the real
+  workflow/run! in one pinned-JS1 process, kills that process only after a
+  durable red ship-verify event, and drives agent.resume/resume! in a fresh
+  pinned-JS1 process. No live REPL fallback exists in this harness.
+
+  Artifacts are retained in a printed /tmp directory: sanitized transcript,
+  run id, SQLite DB, process logs, semantic-operation dispatch counters,
+  journal, artifact rows, and target diff. No environment dump is captured."
+  (:require [clojure.data.json :as json]
+            [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [jolt.fs :as fs]
+            [jolt.process :as process]
+            [samizdat.engine.proc :as proc]
+            [samizdat.store.db :as db]
+            [samizdat.store.evals :as evals]
+            [samizdat.store.journal :as journal]
+            [samizdat.store.runs :as runs])
+  (:import [java.util.concurrent TimeUnit]))
+
+(def ^:private source-dir
+  (or (jolt.host/getenv "SAMIZDAT_JS1_DOGFOOD_SOURCE_DIR")
+      (jolt.host/getenv "JOLT_PWD")
+      (System/getProperty "user.dir")))
+
+(def ^:private fixture-dir (str source-dir "/test/fixtures/js1-dogfood"))
+(def ^:private contract (edn/read-string (slurp (str fixture-dir "/contract.edn"))))
+(def ^:private max-turns (get-in contract [:bounds :max-turns]))
+(def ^:private phase-timeout-ms (get-in contract [:bounds :phase-timeout-ms]))
+(def ^:private total-timeout-ms (get-in contract [:bounds :total-timeout-ms]))
+
+(defn- env [name] (jolt.host/getenv name))
+(defn- internal-env [name] (env (str "SAMIZDAT_JS1_DOGFOOD_" name)))
+
+(defn- live-requested? []
+  (= "1" (env "SAMIZDAT_JS1_DOGFOOD_TEST")))
+
+(defn- preflight-requested? []
+  (= "1" (env "SAMIZDAT_JS1_DOGFOOD_PREFLIGHT")))
+
+(defn- require-live-contract!
+  "Fail before runtime discovery or process creation when opt-in is malformed."
+  []
+  (doseq [[name expected] [["HARNESS_PROVIDER" "local"]
+                           ["HARNESS_BASE_URL" "http://localhost:13305/v1"]]]
+    (when-not (= expected (env name))
+      (throw (ex-info
+              (str "JS1 dogfood refused: " name " must be exactly " expected
+                   " when SAMIZDAT_JS1_DOGFOOD_TEST=1")
+              {:js1-dogfood/error :operator-contract :name name}))))
+  (when (str/blank? (env "HARNESS_MODEL"))
+    (throw (ex-info
+            "JS1 dogfood refused: HARNESS_MODEL must be explicitly set by the operator"
+            {:js1-dogfood/error :operator-contract :name "HARNESS_MODEL"})))
+  true)
+
+(defn- require-preflight-contract!
+  "The no-provider preflight still pins the local surface, but needs no real
+  model selection because it never calls the adapter."
+  []
+  (doseq [[name expected] [["HARNESS_PROVIDER" "local"]
+                           ["HARNESS_BASE_URL" "http://localhost:13305/v1"]]]
+    (when-not (= expected (env name))
+      (throw (ex-info
+              (str "JS1 dogfood preflight refused: " name " must be exactly " expected)
+              {:js1-dogfood/error :preflight-contract :name name}))))
+  true)
+
+(defn- safe-controller-env
+  "The complete environment for runtime/setup children. It intentionally has
+  no provider key and is never persisted as an environment dump."
+  []
+  (into {}
+        (keep (fn [name] (when-let [v (env name)] [name v])))
+        ["PATH" "HOME" "LANG" "LC_ALL" "LC_CTYPE" "TERM" "TMPDIR"
+         "JOLT_HOME" "JOLT_CHEZ" "JOLT_QUIET"]))
+
+(defn- run-command
+  [opts argv]
+  (apply proc/run opts argv))
+
+(defn- command!
+  [label opts argv]
+  (let [{:keys [exit timeout out err] :as result} (run-command opts argv)]
+    (when (or timeout (not= 0 exit))
+      (throw (ex-info (str label " failed"
+                           (when timeout " (timed out)")
+                           "\nstdout: " out "\nstderr: " err)
+                      {:js1-dogfood/error :command-failed
+                       :label label :argv argv :result result})))
+    result))
+
+(defn- git!
+  [dir & args]
+  (command! (str "git " (str/join " " args))
+            {:timeout-ms 30000 :env (safe-controller-env)}
+            (into ["git" "-C" dir] args)))
+
+(defn- copy-fixtures!
+  [control]
+  (doseq [rel (:fixture-files contract)]
+    (let [dst (str control "/" rel)]
+      (fs/create-dirs (fs/parent dst))
+      (spit dst (slurp (str fixture-dir "/" rel))))))
+
+(defn- make-detached-target!
+  [root]
+  (let [control (str root "/fixture-control")
+        target (str root "/detached-target")]
+    (fs/create-dirs control)
+    (git! control "init" "-q" ".")
+    (copy-fixtures! control)
+    (git! control "add" "--" ".")
+    ;; The source fixtures need not carry executable mode in the trusted
+    ;; checkout. The disposable fixture repository owns executable policy.
+    (git! control "add" "--chmod=+x" "--" "verify-policy" "test/focused_test.sh")
+    (git! control "-c" "user.name=JS1 Dogfood"
+          "-c" "user.email=js1-dogfood@invalid"
+          "commit" "-q" "-m" "fixture seed")
+    (git! control "worktree" "add" "--detach" target "HEAD")
+    (when (zero? (:exit (run-command {:timeout-ms 5000 :env (safe-controller-env)}
+                                     ["git" "-C" target "symbolic-ref" "-q" "HEAD"])))
+      (throw (ex-info "JS1 dogfood target unexpectedly has an attached branch"
+                      {:js1-dogfood/error :not-detached :target target})))
+    (let [target* (str (fs/canonicalize target))
+          source* (str (fs/canonicalize source-dir))]
+      (when (or (= target* source*)
+                (str/starts-with? target* (str source* "/")))
+      (throw (ex-info "JS1 dogfood target must be outside the trusted source checkout"
+                        {:js1-dogfood/error :unsafe-target :target target*}))))
+    {:control control :target (str (fs/canonicalize target))}))
+
+(defn- jolt-home []
+  (let [explicit (env "JOLT_HOME")]
+    (if (str/blank? explicit) (str source-dir "/../jolt") explicit)))
+
+(defn- distinct-classpath [paths]
+  (->> paths
+       (mapcat #(str/split (str/trim %) #":"))
+       (remove str/blank?)
+       distinct
+       (str/join ":")))
+
+(defn- live-runtime!
+  "Use bin/js1 as the pin-checking/SCI authority, then ask the pinned Jolt
+  resolver for ONE launch plan that retains the project's normal dependencies
+  and native descriptors while adding the validated SCI local root. A bare
+  -Scp union is not sufficient: it names db source but bypasses dependency
+  processing that loads sqlite3_open."
+  []
+  (let [wrapper (str source-dir "/bin/js1")
+        jolt (str (jolt-home) "/bin/jolt")
+        env (assoc (safe-controller-env) "JOLT_PWD" source-dir)
+        js1 (:out (command! "bin/js1 path" {:timeout-ms 180000 :env env}
+                            [wrapper "path"]))
+        production (:out (command! "pinned jolt production path"
+                                   {:timeout-ms 180000 :env env}
+                                   [jolt "-Srepro" "-Spath"]))
+        sci-root (str (jolt-home) "/vendor/sci")
+        resolver-sdeps
+        (pr-str {:aliases
+                 {:js1-dogfood-live
+                  {:extra-paths ["test"]
+                   :extra-deps
+                   {(symbol "borkdude/sci") {:local/root sci-root}}}}})
+        combined (:out
+                  (command! "normal Samizdat plus pinned JS1 path"
+                            {:timeout-ms 180000 :env env}
+                            [jolt "-Srepro" "-Sdeps" resolver-sdeps
+                             "-A:js1-dogfood-live" "-Spath"]))
+        cp (distinct-classpath [combined])]
+    (when (or (str/blank? cp) (not (fs/exists? jolt))
+              (not (str/includes? cp "/vendor/sci/src"))
+              (not (str/includes? cp "/samizdat/src")))
+      (throw (ex-info
+              "live JS1 dogfood unavailable: normal dependencies and bin/js1 SCI roots did not compose; refusing live REPL fallback"
+              {:js1-dogfood/error :runtime-unavailable
+               :has-sci? (str/includes? cp "/vendor/sci/src")
+               :has-samizdat? (str/includes? cp "/samizdat/src")})))
+    {:jolt jolt
+     ;; B0: neither component is sufficient by itself. Production contributes
+     ;; data.json, jdbc/db, HTTP, logging, Mycelium and resources; bin/js1
+     ;; contributes the pin-checked SCI roots and its Maven implementation jars.
+     :production-classpath (str/trim production)
+     :js1-classpath (str/trim js1)
+     :classpath cp
+     :resolver-sdeps resolver-sdeps
+     :resolver-alias "-A:js1-dogfood-live"}))
+
+(defn- child-env
+  [{:keys [phase target db-path counter-path run-id]}]
+  (cond-> (assoc (safe-controller-env)
+                 "HARNESS_PROVIDER" "local"
+                 "HARNESS_BASE_URL" "http://localhost:13305/v1"
+                 "HARNESS_MODEL" (or (env "HARNESS_MODEL")
+                                      "js1-preflight-no-provider")
+                 ;; B1: workflow manifests/cells/resources resolve from the
+                 ;; trusted checkout. The absolute :run :root below remains the
+                 ;; disposable target, which is the only root JS1 receives.
+                 "JOLT_PWD" (str (fs/canonicalize source-dir))
+                 "SAMIZDAT_JS1_DOGFOOD_SOURCE_DIR" source-dir
+                 "SAMIZDAT_JS1_DOGFOOD_PHASE" phase
+                 "SAMIZDAT_JS1_DOGFOOD_TARGET" target
+                 "SAMIZDAT_JS1_DOGFOOD_DB" db-path
+                 "SAMIZDAT_JS1_DOGFOOD_COUNTERS" counter-path)
+    (= phase "preflight")
+    (assoc "SAMIZDAT_JS1_DOGFOOD_PREFLIGHT" "1")
+    (not= phase "preflight")
+    (assoc "SAMIZDAT_JS1_DOGFOOD_TEST" "1")
+    run-id (assoc "SAMIZDAT_JS1_DOGFOOD_RUN_ID" run-id)))
+
+(defn- child-command [{:keys [jolt resolver-sdeps resolver-alias]}]
+  [jolt "-Srepro" "-Sdeps" resolver-sdeps resolver-alias "run"
+   (str source-dir "/test/samizdat/js1_dogfood_test.clj")])
+
+(defn- run-child!
+  [runtime phase paths]
+  (let [result (run-command {:timeout-ms (or (:timeout-ms paths)
+                                             phase-timeout-ms)
+                             :env (child-env (assoc paths :phase phase))}
+                            (child-command runtime))]
+    (when (or (:timeout result) (not= 0 (:exit result)))
+      (throw (ex-info
+              (str "live JS1 dogfood " phase " process failed. "
+                   "Current workflow APIs did not complete the requested JS1 phase; "
+                   "refusing any live REPL fallback.\nstdout: " (:out result)
+                   "\nstderr: " (:err result))
+              {:js1-dogfood/error :phase-failed :phase phase :result result})))
+    result))
+
+(defn- spawn-start!
+  [runtime paths]
+  (let [log-dir (fs/parent (:counter-path paths))
+        out-path (str log-dir "/start-live.stdout")
+        err-path (str log-dir "/start-live.stderr")]
+    ;; File redirection prevents an escaped descendant holding a capture pipe
+    ;; open from making result collection unbounded after the root exits.
+    (assoc (process/process (child-command runtime)
+                            {:dir source-dir
+                             :env (child-env (assoc paths :phase "start"))
+                             :out out-path :err err-path})
+           :dogfood/out-path out-path
+           :dogfood/err-path err-path)))
+
+(defn- reap-child!
+  "Own the child to a bounded terminal state. TERM-tree gets a short grace,
+  then the root is forcibly killed and re-waited. Output was redirected to
+  files, so collection performs no process deref and cannot wait on a pipe."
+  [child]
+  (let [p (:proc child)
+        started (System/currentTimeMillis)]
+    (try (process/destroy-tree child) (catch Throwable _ nil))
+    (let [term-exited? (try (.waitFor p 2000 TimeUnit/MILLISECONDS)
+                            (catch Throwable _ false))
+          _ (when-not term-exited? (try (.destroyForcibly p)
+                                        (catch Throwable _ nil)))
+          exited? (or term-exited?
+                      (try (.waitFor p 3000 TimeUnit/MILLISECONDS)
+                           (catch Throwable _ false)))
+          elapsed (- (System/currentTimeMillis) started)]
+      (if-not exited?
+        {:exit nil :out "" :err "child did not terminate after TERM/KILL"
+         :reap-timeout true :reap-ms elapsed}
+        {:exit (try (.exitValue p) (catch Throwable _ nil))
+         :out (if (fs/exists? (:dogfood/out-path child))
+                (slurp (:dogfood/out-path child)) "")
+         :err (if (fs/exists? (:dogfood/err-path child))
+                (slurp (:dogfood/err-path child)) "")
+         :reap-timeout false :reap-ms elapsed}))))
+
+(defn- require-reaped!
+  [result]
+  (when (:reap-timeout result)
+    (throw (ex-info
+            (str "JS1 dogfood could not boundedly reap/collect the start child: "
+                 (:err result))
+            {:js1-dogfood/error :child-reap-failed :result result})))
+  result)
+
+(defn- signal-child!
+  "Synchronously deliver SIGNAL to the owned root process. SIGSTOP is the
+  quiescence fence: after kill(2) returns, that process cannot begin another
+  model eval while the parent validates durable history."
+  [child signal]
+  (let [pid (.pid (:proc child))]
+    (command! (str "signal child " signal)
+              {:timeout-ms 5000 :env (safe-controller-env)}
+              ["kill" (str "-" signal) (str pid)])))
+
+(defn- parsed-event-data [event]
+  (try (json/read-str (:data event) :key-fn keyword)
+       (catch Throwable _ {})))
+
+(defn- red-ship-event [conn run-id]
+  (some (fn [event]
+          (let [data (parsed-event-data event)]
+            (when (and (= "ship-verify" (:kind event))
+                       (= false (:green data))
+                       (= true (:blocked data))
+                       (= 1 (:exit data))
+                       (str/ends-with? (str (:kind data)) "fallback"))
+              (assoc event :parsed-data data))))
+        (journal/events-since conn run-id 0 1000)))
+
+(defn- eval-quiescence
+  "The durable recovery-safety witness. Any pending eval is unsafe even when
+  pure; unsettled receipts additionally identify effects whose world state is
+  unknown. Called only while the producer process is SIGSTOPped."
+  [conn]
+  (let [pending (evals/pending conn 100)
+        unsettled (mapv (fn [row]
+                          {:eval-id (:id row)
+                           :binding-seq (:binding_seq row)
+                           :effects (evals/unsettled-effects conn (:id row))})
+                        pending)]
+    {:quiescent? (and (empty? pending)
+                      (every? (comp empty? :effects) unsettled))
+     :pending-eval-ids (mapv :id pending)
+     :unsettled unsettled}))
+
+(defn- wait-for-red-checkpoint!
+  [db-path target child timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)
+        held-conn (atom nil)]
+    (try
+      (loop []
+        (when (>= (System/currentTimeMillis) deadline)
+          (throw (ex-info
+                  "JS1 dogfood timed out before a durable quiescent RED ship-verify checkpoint"
+                  {:js1-dogfood/error :red-checkpoint-timeout})))
+        (when (and (nil? @held-conn) (fs/exists? db-path))
+          (try (reset! held-conn (db/connect db-path))
+               (catch Throwable _ nil)))
+        (let [conn @held-conn
+              run-id (when conn
+                       (try (:id (db/fetch-one conn
+                                               ["SELECT id FROM runs ORDER BY started_at DESC LIMIT 1"]))
+                            (catch Throwable _ nil)))
+              event (when run-id (try (red-ship-event conn run-id)
+                                      (catch Throwable _ nil)))]
+          (cond
+            event
+            (do
+              (when-not (and (fs/exists? (str target "/red-evidence.txt"))
+                             (str/includes? (slurp (str target "/red-evidence.txt"))
+                                            "JS1-DOGFOOD-FOCUSED-RED"))
+                (throw (ex-info "red ship event landed without fixture red evidence"
+                                {:js1-dogfood/error :missing-red-evidence})))
+              ;; N1 linearization: freeze the sole producer after the durable
+              ;; red event, then inspect the durable eval log while no new eval
+              ;; can begin. Only this state earns the checkpoint label.
+              (signal-child! child "STOP")
+              (let [quiescence (try (eval-quiescence conn)
+                                    (catch Throwable e
+                                      (throw (ex-info
+                                              (str "could not establish RED checkpoint quiescence: "
+                                                   (ex-message e))
+                                              {:js1-dogfood/error
+                                               :quiescence-check-failed}
+                                              e))))]
+                (when-not (:quiescent? quiescence)
+                  (throw (ex-info
+                          (str "unsafe RED checkpoint: pending evals or unsettled effects; "
+                               "refusing resume")
+                          {:js1-dogfood/error :unsafe-red-history
+                           :run-id run-id :quiescence quiescence})))
+                (println "JS1-DOGFOOD-RED-QUIESCENT" run-id)
+                {:run-id run-id :event event :quiescence quiescence
+                 :producer-stopped true}))
+
+            (not (.isAlive (:proc child)))
+            (throw (ex-info
+                    "JS1 dogfood start process exited before the RED checkpoint"
+                    {:js1-dogfood/error :early-exit}))
+
+            :else
+            (do (Thread/sleep 25) (recur)))))
+      (finally
+        (when-let [conn @held-conn] (db/close conn))))))
+
+(defn- read-edn-file [path default]
+  (try (if (fs/exists? path) (edn/read-string (slurp path)) default)
+       (catch Throwable _ default)))
+
+(defn- op-sequence [counter-path]
+  (mapv :op (:events (read-edn-file counter-path {:events [] :counts {}}))))
+
+(defn- safe-spit! [path value]
+  (spit path (if (string? value) value (pr-str value))))
+
+(defn- capture-artifacts!
+  [{:keys [artifact-dir target db-path counter-path run-id start-result resume-result checkpoint]}]
+  (fs/create-dirs artifact-dir)
+  (safe-spit! (str artifact-dir "/run-id.txt") (str run-id "\n"))
+  (safe-spit! (str artifact-dir "/semantic-operations.edn")
+              (read-edn-file counter-path {:events [] :counts {}}))
+  (safe-spit! (str artifact-dir "/phase-results.edn")
+              {:checkpoint checkpoint
+               :start-exit (:exit start-result)
+               :resume-exit (:exit resume-result)})
+  (safe-spit! (str artifact-dir "/start.stdout") (:out start-result))
+  (safe-spit! (str artifact-dir "/start.stderr") (:err start-result))
+  (safe-spit! (str artifact-dir "/resume.stdout") (:out resume-result))
+  (safe-spit! (str artifact-dir "/resume.stderr") (:err resume-result))
+  (safe-spit! (str artifact-dir "/safe-config.edn")
+              {:provider :local :base-url "http://localhost:13305/v1"
+               :model (env "HARNESS_MODEL") :api-key nil
+               :max-turns max-turns :beam-width 1
+               :verify-cmd "./verify-policy"})
+  (when (and run-id (fs/exists? db-path))
+    (let [conn (db/connect db-path)]
+      (try
+        (safe-spit! (str artifact-dir "/transcript.edn") (journal/turns conn run-id))
+        (safe-spit! (str artifact-dir "/journal.edn")
+                    (journal/events-since conn run-id 0 5000))
+        (safe-spit! (str artifact-dir "/artifacts.edn")
+                    (journal/artifacts conn run-id))
+        (safe-spit! (str artifact-dir "/eval-history.edn")
+                    (evals/history conn (str "bind:main:" run-id)))
+        (finally (db/close conn)))))
+  (when (fs/exists? target)
+    (let [diff (run-command {:timeout-ms 30000 :env (safe-controller-env)}
+                            ["git" "-C" target "diff" "--no-ext-diff" "HEAD"])
+          status (run-command {:timeout-ms 30000 :env (safe-controller-env)}
+                              ["git" "-C" target "status" "--short"])]
+      (safe-spit! (str artifact-dir "/worktree.diff") (:out diff))
+      (safe-spit! (str artifact-dir "/worktree.status") (:out status))
+      (when (fs/exists? (str target "/src/dogfood.clj"))
+        (safe-spit! (str artifact-dir "/final-source.clj")
+                    (slurp (str target "/src/dogfood.clj"))))
+      (when (fs/exists? (str target "/red-evidence.txt"))
+        (safe-spit! (str artifact-dir "/red-evidence.txt")
+                    (slurp (str target "/red-evidence.txt"))))))
+  artifact-dir)
+
+(defn- source-git-output [label & args]
+  (:out (command! label {:timeout-ms 30000 :env (safe-controller-env)}
+                  (into ["git" "-C" source-dir] args))))
+
+(defn- source-witness
+  "Stronger than status alone: HEAD, staged and unstaged patches, the complete
+  untracked inventory, and the bytes of every file this fenced change may
+  touch. The byte snapshot closes status's blind spot for an already-untracked
+  fixture whose content is modified in place."
+  []
+  (let [fenced (concat ["test/samizdat/js1_dogfood_test.clj"
+                        "test/samizdat/js1_harness_test.clj"
+                        "test/samizdat/test_runner.clj"]
+                       (map #(str "test/fixtures/js1-dogfood/" %)
+                            (:fixture-files contract))
+                       ["test/fixtures/js1-dogfood/contract.edn"])]
+    {:root (str (fs/canonicalize source-dir))
+     :head (str/trim (source-git-output "trusted source HEAD" "rev-parse" "HEAD"))
+     :status (source-git-output "trusted source status" "status" "--porcelain=v1"
+                                "--untracked-files=all")
+     :unstaged (source-git-output "trusted source unstaged diff"
+                                  "diff" "--no-ext-diff" "--binary")
+     :staged (source-git-output "trusted source staged diff"
+                                "diff" "--cached" "--no-ext-diff" "--binary")
+     :fenced-bytes (into {}
+                         (map (fn [rel] [rel (slurp (str source-dir "/" rel))]))
+                         fenced)}))
+
+(defn- require-quiescent-db!
+  [db-path run-id stage]
+  (let [conn (db/connect db-path)]
+    (try
+      (let [q (eval-quiescence conn)]
+        (when-not (:quiescent? q)
+          (throw (ex-info
+                  (str "unsafe JS1 history " stage
+                       ": pending evals or unsettled effects; refusing resume")
+                  {:js1-dogfood/error :unsafe-red-history
+                   :stage stage :run-id run-id :quiescence q})))
+        q)
+      (finally (db/close conn)))))
+
+;; ── child phases ------------------------------------------------------------
+
+(defn- counter-state [path]
+  (read-edn-file path {:events [] :counts {}}))
+
+(defn- count-semantic-op!
+  [path phase op args]
+  (let [state (counter-state path)
+        event {:phase phase :op op :args args}
+        next (-> state
+                 (update :events (fnil conj []) event)
+                 (update-in [:counts op] (fnil inc 0)))]
+    (spit path (pr-str next))))
+
+(defn- install-counting-eval-store!
+  "Instrument the trusted durable-store seam. record-intent! is called by
+  run-recorded-effect! immediately before the real semantic operation. Replay
+  consumes receipts through :history and never calls record-intent!, so an
+  unchanged counter is direct evidence that reconstruction re-actuated no
+  observation or edit."
+  [counter-path phase]
+  (require 'samizdat.agent.sandbox)
+  (let [store-var (resolve 'samizdat.agent.sandbox/*eval-store*)]
+    (alter-var-root
+     store-var
+     (constantly
+      {:begin! evals/begin!
+       :record-intent! (fn [conn id {:keys [op args] :as intent}]
+                         (let [seq-n (evals/record-intent! conn id intent)]
+                           (count-semantic-op! counter-path phase op args)
+                           seq-n))
+       :record-outcome! evals/record-outcome!
+       :complete! evals/complete!
+       :load-eval evals/load-eval
+       :verify-binding! evals/verify-binding!
+       :history evals/history}))))
+
+(defn- dogfood-config [target db-path]
+  (require 'samizdat.config)
+  (let [load-config (resolve 'samizdat.config/load-config)]
+    (load-config
+     {:db {:path db-path}
+      :llm {:provider :local
+            :base-url "http://localhost:13305/v1"
+            :api-key nil
+            :model (env "HARNESS_MODEL")
+            :max-tokens 4096
+            :temperature 0.0
+            :timeout-ms 120000
+            :conn-timeout-ms 5000
+            :max-response-ms 180000}
+      :run {:root target
+            :max-turns max-turns
+            :beam-width 1
+            :js1/profile "single-player"
+            :verify-focused? false
+            :require-test? false
+            :verify-cmd "./verify-policy"
+            :verify-timeout-ms 30000
+             :stop-on-first-done? true}})))
+
+(def ^:private preflight-api-symbols
+  "Every dynamically reached API in start, resume, and the reconstruction
+  witness. Preflight resolves the closed list before compiling the workflow."
+  '[samizdat.config/load-config
+    samizdat.workflow/load-loop!
+    samizdat.workflow/run!
+    samizdat.agent.resume/resume!
+    samizdat.agent.resume/reconstruct-js1-binding!
+    samizdat.agent.sandbox/provider
+    samizdat.agent.sandbox/bind!
+    samizdat.agent.sandbox/runtime-coordinate
+    samizdat.agent.sandbox/evaluate!
+    samizdat.agent.sandbox/evaluate-recorded!
+    samizdat.agent.sandbox/*eval-store*
+    samizdat.llm.registry/adapter-for
+    samizdat.store.db/open!
+    samizdat.store.db/close
+    samizdat.store.evals/begin!
+    samizdat.store.evals/record-intent!
+    samizdat.store.evals/record-outcome!
+    samizdat.store.evals/complete!
+    samizdat.store.evals/load-eval
+    samizdat.store.evals/verify-binding!
+    samizdat.store.evals/history
+    samizdat.store.evals/pending
+    samizdat.store.evals/unsettled-effects])
+
+(defn- resolve-preflight-apis! []
+  (let [missing (vec (remove resolve preflight-api-symbols))]
+    (when (seq missing)
+      (throw (ex-info "required dogfood APIs are unresolved"
+                      {:missing missing})))
+    true))
+
+(defn- phase-preflight! []
+  (try
+    (require 'samizdat.config)
+    (require 'samizdat.workflow)
+    (require 'samizdat.agent.resume)
+    (require 'samizdat.agent.sandbox)
+    (require 'samizdat.llm.registry)
+    (require 'samizdat.store.db)
+    (resolve-preflight-apis!)
+    (when-not (proc/scope-supported?)
+      (throw (ex-info "hardened verifier process scope is absent" {})))
+    (let [target (str (fs/canonicalize (internal-env "TARGET")))
+          db-path (internal-env "DB")
+          trusted-source (str (fs/canonicalize source-dir))
+          jolt-pwd (str (fs/canonicalize (env "JOLT_PWD")))
+          config (dogfood-config target db-path)
+          conn (db/open! db-path)]
+      (try
+        (when-not (= trusted-source jolt-pwd)
+          (throw (ex-info "child JOLT_PWD is not the trusted source checkout"
+                          {:expected trusted-source :actual jolt-pwd})))
+        (when-not (= target (get-in config [:run :root]))
+          (throw (ex-info "preflight config did not preserve the absolute target root"
+                          {:expected target :actual (get-in config [:run :root])})))
+        ;; This is a real resource/cell load and Mycelium compile, not a mere
+        ;; namespace require. It catches a child cwd/JOLT_PWD that resolves the
+        ;; disposable fixture instead of trusted workflow resources.
+        (let [loaded ((resolve 'samizdat.workflow/load-loop!) conn)
+              provider ((resolve 'samizdat.agent.sandbox/provider) {:root target})
+              binding ((resolve 'samizdat.agent.sandbox/bind!)
+                       provider "preflight-no-run"
+                       {:preset :project/develop :root target :instance/key :main})
+              adapter ((resolve 'samizdat.llm.registry/adapter-for) :local)
+              json-roundtrip (json/read-str (json/write-str {:ok true})
+                                            :key-fn keyword)]
+          (when-not (and (:compiled loaded)
+                         (= target (get-in binding [:spec :root]))
+                         adapter
+                         (= {:ok true} json-roundtrip))
+            (throw (ex-info "preflight compile/dependency/root witness failed"
+                            {:workflow-loaded? (boolean (:compiled loaded))
+                             :binding-root (get-in binding [:spec :root])
+                             :target target
+                             :adapter-loaded? (boolean adapter)
+                             :json json-roundtrip}))))
+        (println "JS1-DOGFOOD-PREFLIGHT-OK"
+                 "workflow=compiled" "jolt-pwd=source" "sandbox-root=target")
+        (finally (db/close conn))))
+    (catch Throwable e
+      (throw (ex-info
+              (str "live JS1 dogfood unavailable: the classpath built from "
+                   "bin/js1 plus production dependencies cannot load workflow/run!, "
+                   "agent.resume/resume!, SCI, SQLite, the local adapter, and the "
+                   "hardened verifier scope together: " (ex-message e)
+                   ". Refusing live REPL fallback.")
+              {:js1-dogfood/error :workflow-api-unavailable}
+              e)))))
+
+(defn- phase-start! []
+  (require 'samizdat.workflow)
+  (require 'samizdat.llm.registry)
+  (let [target (internal-env "TARGET")
+        db-path (internal-env "DB")
+        counter-path (internal-env "COUNTERS")
+        config (dogfood-config target db-path)
+        adapter-for (resolve 'samizdat.llm.registry/adapter-for)
+        run! (resolve 'samizdat.workflow/run!)
+        conn (db/open! db-path)]
+    (try
+      (install-counting-eval-store! counter-path "start")
+      ;; The parent deliberately kills this process at RED; returning here is a
+      ;; harness failure (the model either skipped RED or completed too early).
+      (let [result (run! {:conn conn :config config
+                          :llm-adapter (adapter-for :local)
+                          :llm-config (:llm config)
+                          :problem (slurp (str target "/TASK.md"))
+                          :max-turns max-turns})]
+        (throw (ex-info "start phase returned before the intentional RED kill"
+                        {:js1-dogfood/error :missed-red-kill :result result})))
+      (finally (db/close conn)))))
+
+(defn- js1-event-info [conn run-id]
+  (let [event (some #(when (= "js1-binding-created" (:kind %)) %)
+                    (journal/events-since conn run-id 0 1000))]
+    (when-not event
+      (throw (ex-info "resume has no durable JS1 binding event"
+                      {:js1-dogfood/error :missing-js1-event})))
+    (json/read-str (:data event) :key-fn keyword)))
+
+(defn- phase-resume! []
+  (require 'samizdat.agent.resume)
+  (require 'samizdat.agent.sandbox)
+  (require 'samizdat.llm.registry)
+  (let [target (internal-env "TARGET")
+        db-path (internal-env "DB")
+        counter-path (internal-env "COUNTERS")
+        run-id (internal-env "RUN_ID")
+        config (dogfood-config target db-path)
+        reconstruct (resolve 'samizdat.agent.resume/reconstruct-js1-binding!)
+        resume! (resolve 'samizdat.agent.resume/resume!)
+        evaluate! (resolve 'samizdat.agent.sandbox/evaluate!)
+        adapter-for (resolve 'samizdat.llm.registry/adapter-for)
+        conn (db/open! db-path)]
+    (try
+      (install-counting-eval-store! counter-path "resume")
+      (let [before (counter-state counter-path)
+            info (js1-event-info conn run-id)
+            {:keys [binding]} (reconstruct conn info target)
+            helper-value (evaluate! binding "(dogfood-helper \"controller-resume-check\")")
+            after (counter-state counter-path)]
+        (when-not (= "DOGFOOD-HELPER:controller-resume-check" helper-value)
+          (throw (ex-info "persistent SCI helper was not reconstructed"
+                          {:js1-dogfood/error :helper-missing
+                           :actual (pr-str helper-value)})))
+        (when-not (= before after)
+          (throw (ex-info
+                  "JS1 reconstruction repeated a semantic project operation"
+                  {:js1-dogfood/error :replay-actuated
+                   :before before :after after})))
+        (println "JS1-DOGFOOD-RESUME-HELPER-OK"))
+      (let [result (resume! {:conn conn :run-id run-id :config config
+                             :llm-adapter (adapter-for :local)
+                             :llm-config (:llm config)})]
+        (when-not (= :completed (:status result))
+          (throw (ex-info "resumed JS1 dogfood did not complete GREEN"
+                          {:js1-dogfood/error :not-green :result result})))
+        (spit (str (fs/parent counter-path) "/resume-result.edn")
+              (pr-str (select-keys result [:status :answer :run-id])))
+        (println "JS1-DOGFOOD-GREEN-OK"))
+      (finally (db/close conn)))))
+
+(defn- run-child-phase! [phase]
+  ;; An internal phase name is not an alternate live opt-in. Preflight has its
+  ;; own explicit no-provider gate; start/resume still require the live gate.
+  (if (= phase "preflight")
+    (do
+      (when-not (or (preflight-requested?) (live-requested?))
+        (throw (ex-info
+                "JS1 dogfood preflight refused without its explicit preflight flag"
+                {:js1-dogfood/error :not-opted-in})))
+      (require-preflight-contract!))
+    (do
+      (when-not (live-requested?)
+        (throw (ex-info "JS1 dogfood child refused without SAMIZDAT_JS1_DOGFOOD_TEST=1"
+                        {:js1-dogfood/error :not-opted-in})))
+      (require-live-contract!)))
+  (case phase
+    "preflight" (phase-preflight!)
+    "start" (phase-start!)
+    "resume" (phase-resume!)
+    (throw (ex-info "unknown JS1 dogfood phase"
+                    {:js1-dogfood/error :unknown-phase :phase phase})))
+  (flush)
+  (System/exit 0))
+
+;; ── parent test -------------------------------------------------------------
+
+(deftest durable-red-quiescence-classification
+  ;; Offline discriminator for N1: a pending eval is unsafe even before it has
+  ;; an effect, and an unsettled intent is reported explicitly. No SCI or model.
+  (let [conn (db/open! ":memory:")]
+    (try
+      (is (:quiescent? (eval-quiescence conn)))
+      (let [id (evals/begin! conn {:spec-id "spec" :instance-id "instance"
+                                   :binding-id "binding" :coordinate "coord"
+                                   :runtime "runtime" :source "(+ 1 2)"})]
+        (is (= [id] (:pending-eval-ids (eval-quiescence conn))))
+        (let [seq-n (evals/record-intent! conn id
+                                         {:op :project/edit
+                                          :args ["x" :absent "y"]})
+              unsafe (eval-quiescence conn)]
+          (is (false? (:quiescent? unsafe)))
+          (is (= :project/edit
+                 (get-in unsafe [:unsettled 0 :effects 0 :op])))
+          (evals/record-outcome! conn id seq-n {:result {:path "x"}})
+          (evals/complete! conn id {:status :completed :result {:value true}})
+          (is (:quiescent? (eval-quiescence conn)))))
+      (finally (db/close conn)))))
+
+(deftest no-provider-js1-dogfood-preflight
+  (if-not (and (preflight-requested?) (not (live-requested?)))
+    (is true "skipped: set SAMIZDAT_JS1_DOGFOOD_PREFLIGHT=1 for no-provider compile preflight")
+    (do
+      (require-preflight-contract!)
+      (let [id (str (random-uuid))
+            root (str "/tmp/samizdat-js1-dogfood-preflight-" id)
+            db-path (str root "/preflight.sqlite3")
+            counter-path (str root "/preflight-counters.edn")
+            before-source (source-witness)
+            layout (atom nil)]
+        (fs/create-dirs root)
+        (try
+          (let [{:keys [target] :as made} (make-detached-target! root)
+                _ (reset! layout made)
+                runtime (live-runtime!)
+                result (run-child! runtime "preflight"
+                                   {:target target :db-path db-path
+                                    :counter-path counter-path})]
+            (is (str/includes? (:out result) "JS1-DOGFOOD-PREFLIGHT-OK"))
+            (is (str/includes? (:out result) "workflow=compiled"))
+            (is (str/includes? (:out result) "jolt-pwd=source"))
+            (is (str/includes? (:out result) "sandbox-root=target"))
+            (is (not (fs/exists? counter-path))
+                "preflight dispatched no model-facing semantic operation"))
+          (finally
+            (when-let [{:keys [control target]} @layout]
+              (try (git! control "worktree" "remove" "--force" target)
+                   (catch Throwable _ nil)))
+            (try (fs/delete-tree root) (catch Throwable _ nil))
+            (is (= before-source (source-witness))
+                "no-provider preflight modified the trusted source checkout")))))))
+
+(deftest bounded-opt-in-live-js1-dogfood
+  (if-not (live-requested?)
+    (is true "skipped: set SAMIZDAT_JS1_DOGFOOD_TEST=1 plus the exact local-provider contract")
+    (do
+      (require-live-contract!)
+      (let [id (str (random-uuid))
+            root (str "/tmp/samizdat-js1-dogfood-" id)
+            artifact-dir (str "/tmp/samizdat-js1-dogfood-artifacts-" id)
+            db-path (str artifact-dir "/run.sqlite3")
+            counter-path (str artifact-dir "/semantic-operations-live.edn")
+             before-source (source-witness)
+            layout (atom nil)
+            run-data (atom {:artifact-dir artifact-dir :db-path db-path
+                            :counter-path counter-path})]
+        (fs/create-dirs root)
+        (fs/create-dirs artifact-dir)
+        (try
+          (let [{:keys [control target] :as made} (make-detached-target! root)
+                _ (reset! layout made)
+                _ (swap! run-data assoc :target target)
+                runtime (live-runtime!)
+                paths {:target target :db-path db-path :counter-path counter-path}
+                preflight (run-child! runtime "preflight" paths)]
+            (testing "current APIs form a real JS1 workflow path"
+              (is (str/includes? (:out preflight) "JS1-DOGFOOD-PREFLIGHT-OK")))
+            (let [child (spawn-start! runtime paths)
+                  ;; One wall-clock budget is shared by BOTH model-facing
+                  ;; processes. Resume receives only what start did not spend.
+                  model-deadline (+ (System/currentTimeMillis) total-timeout-ms)
+                  start-budget (min phase-timeout-ms
+                                    (- model-deadline (System/currentTimeMillis)))
+                  checkpoint (try (wait-for-red-checkpoint! db-path target child
+                                                            start-budget)
+                                   (catch Throwable e
+                                     (let [start-result (reap-child! child)]
+                                       (swap! run-data assoc :start-result start-result)
+                                       (require-reaped! start-result)
+                                       (throw e))))
+                  start-result (require-reaped! (reap-child! child))
+                  run-id (:run-id checkpoint)
+                  _ (swap! run-data assoc :target target :run-id run-id
+                           :checkpoint checkpoint :start-result start-result)
+                  before-resume-ops (op-sequence counter-path)]
+              (println "JS1-DOGFOOD-RED-CHECKPOINT" run-id)
+              ;; STOP made the first witness race-free; the post-reap witness
+              ;; proves shutdown added no torn record before resume is allowed.
+              (require-quiescent-db! db-path run-id "after bounded child reap")
+              (when-not (= (get-in contract [:semantic-operations :before-resume])
+                           before-resume-ops)
+                (throw (ex-info
+                        "RED checkpoint has unexpected semantic operations; refusing resume"
+                        {:js1-dogfood/error :unexpected-red-operations
+                         :expected (get-in contract [:semantic-operations :before-resume])
+                         :actual before-resume-ops})))
+              (testing "the first process was intentionally killed at durable RED"
+                (is (not (.isAlive (:proc child))))
+                (is (= "(ns fixture.dogfood)\n\n(def dogfood-state :red)\n"
+                       (slurp (str target "/src/dogfood.clj"))))
+                (is (= (get-in contract [:semantic-operations :before-resume])
+                       before-resume-ops)))
+              (let [resume-result (run-child! runtime "resume"
+                                              (assoc paths :run-id run-id
+                                                     :timeout-ms
+                                                     (let [remaining
+                                                           (- model-deadline
+                                                              (System/currentTimeMillis))]
+                                                       (when-not (pos? remaining)
+                                                         (throw (ex-info
+                                                                 "JS1 dogfood exhausted its total live-run deadline before resume"
+                                                                 {:js1-dogfood/error
+                                                                  :total-timeout})))
+                                                       (min phase-timeout-ms
+                                                            remaining))))]
+                (swap! run-data assoc :resume-result resume-result)
+                (testing "fresh-process resume reconstructed state and shipped GREEN"
+                  (is (str/includes? (:out resume-result)
+                                     "JS1-DOGFOOD-RESUME-HELPER-OK"))
+                  (is (str/includes? (:out resume-result)
+                                     "JS1-DOGFOOD-GREEN-OK"))
+                  (is (= "(ns fixture.dogfood)\n\n(def dogfood-state :green)\n"
+                         (slurp (str target "/src/dogfood.clj"))))
+                  (is (= (vec (concat
+                               (get-in contract [:semantic-operations :before-resume])
+                               (get-in contract [:semantic-operations :after-resume])))
+                         (op-sequence counter-path))))
+                (let [conn (db/connect db-path)]
+                  (try
+                    (let [run (runs/get-run conn run-id)
+                          turns (journal/turns conn run-id)
+                          events (journal/events-since conn run-id 0 5000)
+                          history (evals/history conn (str "bind:main:" run-id))
+                          sources (mapv :source history)
+                          green-events (filter
+                                        (fn [event]
+                                          (let [d (parsed-event-data event)]
+                                            (and (= "ship-verify" (:kind event))
+                                                 (= true (:green d))
+                                                 (= false (:blocked d))
+                                                 (= 0 (:exit d)))))
+                                        events)]
+                      (testing "single-player and total turn bounds are durable"
+                        (is (= 1 (:beam_width run)))
+                        (is (= max-turns (:max_turns run)))
+                        (is (= "completed" (:status run)))
+                        (is (<= (count turns) max-turns)))
+                      (testing "helper was defined once and used after resume"
+                        (is (= 1 (count (filter #(str/includes? % "(defn dogfood-helper")
+                                               sources))))
+                        (is (some #{"(dogfood-helper \"resumed\")"} sources)))
+                      (testing "the resumed model read red evidence and did not repeat observations"
+                        (is (some #{"(project/read \"red-evidence.txt\")"} sources))
+                        (is (every? #{"eval" "doc" "complete" "done"}
+                                    (map :tool_name turns))))
+                      (testing "the same fixed operator verifier eventually recorded GREEN"
+                        (is (= 1 (count green-events)))))
+                    (finally (db/close conn)))))))
+          (finally
+            (when-let [target (:target @run-data)]
+              (try
+                (capture-artifacts! (assoc @run-data :target target))
+                (catch Throwable e
+                  (safe-spit! (str artifact-dir "/capture-error.txt")
+                              (str (ex-message e) "\n")))))
+            (when-let [{:keys [control target]} @layout]
+              (try (git! control "worktree" "remove" "--force" target)
+                   (catch Throwable _ nil)))
+            (try (fs/delete-tree root) (catch Throwable _ nil))
+            (is (= before-source (source-witness))
+                "the live dogfood modified the trusted running checkout")
+            (println "JS1 dogfood artifacts:" artifact-dir)))))))
+
+(when-let [phase (internal-env "PHASE")]
+  (run-child-phase! phase))

--- a/test/samizdat/js1_harness_test.clj
+++ b/test/samizdat/js1_harness_test.clj
@@ -83,15 +83,23 @@
 
 (deftest lock-matches-wrapper-pins
   (testing "the lock restates bin/js1's pins exactly (no drift, no second truth)"
-    (is (= "619ef19685460af847654e22cf6beda904d052fb" (:jolt/sha lock)))
+    (is (= "279bca18bbf50f37b8574a4e6998dee40313cd26" (:jolt/sha lock)))
     (is (= (:jolt/sha lock) (wrapper-var "JOLT_SHA")))
     (is (= (:jolt/branch lock) (wrapper-var "JOLT_BRANCH")))
     (is (= (:jolt/url lock) (wrapper-var "JOLT_URL")))
-    (is (= "js0-functional-sci-upstream" (:jolt/branch lock)))
+    (is (= "js1-runtime-current-upstream" (:jolt/branch lock)))
     (is (= "32d62a5136ad3dc148588752f5bcc4cc30b14752" (:sci/sha lock)))
     (is (= (:sci/sha lock) (wrapper-var "SCI_SHA")))
     (is (= "0.13.53" (:sci/version lock)))
     (is (= (:sci/version lock) (wrapper-var "SCI_VERSION")))))
+
+(deftest docs-name-the-wrapper-pins
+  (testing "docs/JS1_RUNTIME.md § Pins names the pinned runtime (doc drift guard)"
+    (let [doc (slurp-rel "docs/JS1_RUNTIME.md")]
+      (is (str/includes? doc (wrapper-var "JOLT_SHA"))
+          "the docs no longer name bin/js1's JOLT_SHA")
+      (is (str/includes? doc (wrapper-var "JOLT_BRANCH"))
+          "the docs no longer name bin/js1's JOLT_BRANCH"))))
 
 (deftest lock-matches-deps-crypto-pin
   (testing "the lock's jolt-crypto pin equals deps.edn's :git/sha (its single home)"

--- a/test/samizdat/js1_harness_test.clj
+++ b/test/samizdat/js1_harness_test.clj
@@ -44,6 +44,8 @@
 (def ^:private lock-rel "ci/js1-smolvm/runtime-lock.edn")
 (def ^:private recipe-rel "ci/js1-smolvm/guest-recipe.edn")
 (def ^:private fixtures-rel "test/fixtures/js1/fixtures.edn")
+(def ^:private dogfood-contract-rel
+  "test/fixtures/js1-dogfood/contract.edn")
 
 (def ^:private harness-scripts
   ["ci/js1-smolvm/lib-lock.sh" "ci/js1-smolvm/preflight.sh"
@@ -62,6 +64,8 @@
 (def ^:private lock (edn/read-string (slurp-rel lock-rel)))
 (def ^:private recipe (edn/read-string (slurp-rel recipe-rel)))
 (def ^:private fixtures (edn/read-string (slurp-rel fixtures-rel)))
+(def ^:private dogfood-contract
+  (edn/read-string (slurp-rel dogfood-contract-rel)))
 (def ^:private wrapper-src (slurp-rel "bin/js1"))
 (def ^:private deps-src (slurp-rel "deps.edn"))
 
@@ -218,6 +222,143 @@
       (doseq [[_ marker] (:guest-markers fixtures)]
         (is (str/includes? gs marker)
             (str "guest-setup.sh never prints " marker))))))
+
+;; ── bounded live dogfood fixture (static only; NEVER calls a provider) ─────
+
+(deftest dogfood-contract-is-explicitly-opted-in-and-bounded
+  (let [suite (slurp-rel "test/samizdat/js1_dogfood_test.clj")
+        task (slurp-rel "test/fixtures/js1-dogfood/TASK.md")]
+    (testing "all three operator choices are exact and the model is explicit"
+      (is (= "SAMIZDAT_JS1_DOGFOOD_TEST"
+             (get-in dogfood-contract [:opt-in :flag])))
+      (is (= "SAMIZDAT_JS1_DOGFOOD_PREFLIGHT"
+             (get-in dogfood-contract [:opt-in :preflight-flag])))
+      (is (= {"HARNESS_PROVIDER" "local"
+              "HARNESS_BASE_URL" "http://localhost:13305/v1"}
+             (get-in dogfood-contract [:opt-in :required])))
+      (is (= "HARNESS_MODEL"
+             (get-in dogfood-contract [:opt-in :operator-model-env])))
+      (doseq [literal ["SAMIZDAT_JS1_DOGFOOD_TEST=1"
+                       "HARNESS_PROVIDER=local"
+                       "HARNESS_BASE_URL=http://localhost:13305/v1"
+                       "HARNESS_MODEL=<operator-selected model>"]]
+        (is (str/includes? suite literal) (str "suite lacks " literal))))
+    (testing "turn, player, phase, and shared live-run wall-clock bounds are data"
+      (is (= 14 (get-in dogfood-contract [:bounds :max-turns])))
+      (is (= 1 (get-in dogfood-contract [:bounds :beam-width])))
+      (is (<= (get-in dogfood-contract [:bounds :phase-timeout-ms]) 900000))
+      (is (<= (get-in dogfood-contract [:bounds :total-timeout-ms]) 1800000))
+      (is (= ["preflight" "start" "resume"] (:phases dogfood-contract)))
+      (is (str/includes? suite ":max-turns max-turns"))
+      (is (str/includes? suite ":beam-width 1")))
+    (testing "the task itself names the required discovery and phase boundary"
+      (doseq [marker ["complete" "project/" "doc" "project/edit"
+                      "symbol `map`"
+                      "project/list" "project/search" "project/read"
+                      "dogfood-helper" "project/stat" "first anchored edit"
+                      "ship-verify" "fresh-process resume"
+                      "red-evidence.txt" "second anchored edit"]]
+        (is (str/includes? task marker) (str "task lacks " marker))))))
+
+(deftest dogfood-fixture-markers-and-verifier-are-coherent
+  (let [suite (slurp-rel "test/samizdat/js1_dogfood_test.clj")
+        policy (slurp-rel "test/fixtures/js1-dogfood/verify-policy")
+        focused (slurp-rel "test/fixtures/js1-dogfood/test/focused_test.sh")]
+    (testing "every declared file exists"
+      (doseq [rel (:fixture-files dogfood-contract)]
+        (is (fs/exists? (p (str "test/fixtures/js1-dogfood/" rel)))
+            (str "dogfood fixture missing " rel))))
+    (testing "phase and red/green markers are source facts"
+      (doseq [marker (:phase-markers dogfood-contract)]
+        (is (str/includes? suite marker) (str "suite lacks marker " marker)))
+      (doseq [marker [(get-in dogfood-contract [:verify :red-marker])
+                      (get-in dogfood-contract [:verify :green-marker])]]
+        (is (str/includes? focused marker) (str "focused test lacks " marker))))
+    (testing "trusted policy is fixed fixture argv, never model-derived"
+      (is (= "./verify-policy"
+             (get-in dogfood-contract [:verify :operator-command])))
+      (is (= ["sh" "-c" "./verify-policy"]
+             (get-in dogfood-contract [:verify :hardened-argv])))
+      (is (str/includes? policy "exec ./test/focused_test.sh"))
+      (is (str/includes? suite ":verify-cmd \"./verify-policy\""))
+      (is (str/includes? suite ":verify-focused? false")))
+    (testing "the deterministic policy owns both RED evidence and GREEN"
+      (is (str/includes? focused "cat > red-evidence.txt"))
+      (is (str/includes? focused "exit 1"))
+      (is (str/includes? focused "exit 0")))))
+
+(deftest dogfood-live-suite-stays-outside-the-trusted-checkout
+  (let [suite (slurp-rel "test/samizdat/js1_dogfood_test.clj")]
+    (testing "target is a disposable detached worktree and source status is pinned"
+      (is (str/includes? suite "worktree\" \"add\" \"--detach"))
+      (is (str/includes? suite "target must be outside the trusted source checkout"))
+      (is (str/includes? suite "before-source"))
+      (is (str/includes? suite "the live dogfood modified the trusted running checkout"))
+      (is (str/includes? suite ":unstaged"))
+      (is (str/includes? suite ":staged"))
+      (is (str/includes? suite ":fenced-bytes")))
+    (testing "actual public workflow and resume APIs run in fresh pinned processes"
+      (is (str/includes? suite "samizdat.workflow/run!"))
+      (is (str/includes? suite "samizdat.agent.resume/resume!"))
+      (is (str/includes? suite "bin/js1 path"))
+      (is (str/includes? suite "\"-Sdeps\""))
+      (is (str/includes? suite "-A:js1-dogfood-live"))
+      (is (str/includes? suite "refusing live REPL fallback"))
+      (is (not (str/includes? suite "samizdat.repl"))))
+    (testing "B0 composes normal dependencies with pin-checked SCI roots"
+      (is (str/includes? suite ":production-classpath"))
+      (is (str/includes? suite ":js1-classpath"))
+      (is (str/includes? suite "distinct-classpath [combined]"))
+      (is (str/includes? suite ":local/root sci-root"))
+      (is (str/includes? suite "A bare\n  -Scp union is not sufficient"))
+      (is (str/includes? suite "data.json, jdbc/db, HTTP"))
+      (is (str/includes? suite "bin/js1 path")))
+    (testing "B1 separates trusted workflow resolution from target authority"
+      (is (str/includes? suite "\"JOLT_PWD\" (str (fs/canonicalize source-dir))"))
+      (is (str/includes? suite ":root target"))
+      (is (str/includes? suite "child JOLT_PWD is not the trusted source checkout"))
+      (is (str/includes? suite "sandbox-root=target")))
+    (testing "preflight really compiles and resolves the used API set"
+      (is (str/includes? suite "preflight-api-symbols"))
+      (doseq [api ["samizdat.workflow/load-loop!"
+                   "samizdat.workflow/run!"
+                   "samizdat.agent.resume/resume!"
+                   "samizdat.agent.resume/reconstruct-js1-binding!"
+                   "samizdat.agent.sandbox/evaluate!"
+                   "samizdat.agent.sandbox/evaluate-recorded!"
+                   "samizdat.store.evals/unsettled-effects"]]
+        (is (str/includes? suite api) (str "preflight/harness lacks " api)))
+      (is (str/includes? suite "workflow=compiled"))
+      (is (str/includes? suite "SAMIZDAT_JS1_DOGFOOD_PREFLIGHT")))
+    (testing "N1 freezes at RED and refuses any unsafe durable history"
+      (is (str/includes? suite "signal-child! child \"STOP\""))
+      (is (str/includes? suite "evals/pending"))
+      (is (str/includes? suite "evals/unsettled-effects"))
+      (is (str/includes? suite ":unsafe-red-history"))
+      (is (str/includes? suite "require-quiescent-db!"))
+      (is (str/includes? suite "JS1-DOGFOOD-RED-QUIESCENT")))
+    (testing "N2/N3 cleanup and reaping are bounded"
+      (is (str/includes? suite "finally (db/close conn)"))
+      (is (str/includes? suite ".waitFor p 2000"))
+      (is (str/includes? suite ".waitFor p 3000"))
+      (is (str/includes? suite ":reap-timeout true"))
+      (is (str/includes? suite ":out out-path :err err-path"))
+      (is (not (str/includes? suite "assoc @child")))
+      (is (str/includes? suite "require-reaped!")))
+    (testing "no push, remote provider, source write, or environment dump"
+      (is (not (re-find #"git[^\n]*push" suite)))
+      (is (not (re-find #"https://(api|open)\." suite)))
+      (is (not (str/includes? suite "System/getenv)")))
+      (is (not (str/includes? suite "spit source-dir"))))
+    (testing "direct semantic counters bracket replay and enforce no repeats"
+      (is (= [:project/list :project/search
+              :project/read :project/read :project/read
+              :project/stat :project/edit]
+             (get-in dogfood-contract [:semantic-operations :before-resume])))
+      (is (= [:project/read :project/stat :project/edit]
+             (get-in dogfood-contract [:semantic-operations :after-resume])))
+      (is (str/includes? suite "record-intent! is called"))
+      (is (str/includes? suite "when-not (= before after)")))))
 
 ;; ── shell harness discipline ─────────────────────────────────────────────
 

--- a/test/samizdat/js1_harness_test.clj
+++ b/test/samizdat/js1_harness_test.clj
@@ -354,9 +354,33 @@
       (is (= [:project/list :project/search
               :project/read :project/read :project/read
               :project/stat :project/edit]
-             (get-in dogfood-contract [:semantic-operations :before-resume])))
+             (mapv :op (get-in dogfood-contract
+                                [:semantic-operations :before-resume
+                                 :required-subsequence]))))
+      (is (= {:project/list 1 :project/search 1 :project/read 3}
+             (get-in dogfood-contract
+                     [:semantic-operations :before-resume :minimum-counts])))
+      (is (= {:project/stat 1 :project/edit 1}
+             (get-in dogfood-contract
+                     [:semantic-operations :before-resume :exact-counts])))
+      (is (= {:op :project/edit
+              :path "src/dogfood.clj"
+              :base :sha256
+              :content "(ns fixture.dogfood)\n\n(def dogfood-state :red)\n"}
+             (last (get-in dogfood-contract
+                           [:semantic-operations :before-resume
+                            :required-subsequence]))))
+      (is (= #{:project/list :project/search :project/read}
+             (get-in dogfood-contract
+                     [:semantic-operations :before-resume
+                      :additional-before-edit])))
       (is (= [:project/read :project/stat :project/edit]
-             (get-in dogfood-contract [:semantic-operations :after-resume])))
+             (mapv :op (get-in dogfood-contract
+                                [:semantic-operations :resume-exact]))))
+      (is (str/includes? suite "required-subsequence?"))
+      (is (str/includes? suite "validate-pre-red-events!"))
+      (is (str/includes? suite "validate-resume-events!"))
+      (is (str/includes? suite "phase-events counter-path \"resume\""))
       (is (str/includes? suite "record-intent! is called"))
       (is (str/includes? suite "when-not (= before after)")))))
 

--- a/test/samizdat/js1_harness_test.clj
+++ b/test/samizdat/js1_harness_test.clj
@@ -1,0 +1,294 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.js1-harness-test
+  "Static contract tests for the JS1×SmolVM CI harness (ci/js1-smolvm).
+
+  These tests validate DATA and TEXT ONLY: the runtime lock parses as EDN
+  and agrees with the repo's own pin authorities (bin/js1, deps.edn), the
+  guest recipe is coherent with the lock, the fixtures match the real
+  suite's markers, the shell scripts stay inside their discipline (no
+  host /tmp, fail-closed), and the workflow is manual-only on self-hosted
+  KVM labels. They run offline under plain `jolt -M:test` — no SCI, no
+  smolvm, no KVM, no guest — and they NEVER fabricate a guest run. When
+  the lock records the pack as :unbuilt they assert exactly that the
+  fail-closed refusal is the wired behavior.
+
+  Self-run for quick iteration:
+    SAMIZDAT_JS1_HARNESS_TEST_RUN=1 jolt -Srepro run test/samizdat/js1_harness_test.clj"
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest testing is] :as t]
+            [jolt.fs :as fs]))
+
+(def ^:private project-dir
+  (or (jolt.host/getenv "JOLT_PWD") (System/getProperty "user.dir")))
+
+(defn- p [rel] (str project-dir "/" rel))
+
+(def ^:private lock-rel "ci/js1-smolvm/runtime-lock.edn")
+(def ^:private recipe-rel "ci/js1-smolvm/guest-recipe.edn")
+(def ^:private fixtures-rel "test/fixtures/js1/fixtures.edn")
+
+(def ^:private harness-scripts
+  ["ci/js1-smolvm/lib-lock.sh" "ci/js1-smolvm/preflight.sh"
+   "ci/js1-smolvm/producer-gate.sh" "ci/js1-smolvm/consumer-run.sh"
+   "ci/js1-smolvm/guest-setup.sh" "ci/js1-smolvm/build-guest-pack.sh"])
+
+(defn- slurp-rel
+  "Slurp a repo file, throwing ex-info when absent (a missing harness file
+  must error the suite loudly, not skip)."
+  [rel]
+  (let [f (p rel)]
+    (when-not (fs/exists? f)
+      (throw (ex-info (str "missing harness file: " rel) {:path f})))
+    (slurp f)))
+
+(def ^:private lock (edn/read-string (slurp-rel lock-rel)))
+(def ^:private recipe (edn/read-string (slurp-rel recipe-rel)))
+(def ^:private fixtures (edn/read-string (slurp-rel fixtures-rel)))
+(def ^:private wrapper-src (slurp-rel "bin/js1"))
+(def ^:private deps-src (slurp-rel "deps.edn"))
+
+(defn- wrapper-var
+  "The shell assignment value of VAR in bin/js1."
+  [v]
+  (second (re-find (re-pattern (str "(?m)^" v "=(\\S+)$")) wrapper-src)))
+
+(defn- lock-line
+  "The raw lock line for KEY — the shell gates grep exactly these lines,
+  so the test asserts the one-scalar-per-line discipline holds (both
+  readers must always see the same bytes). Lock keys contain only
+  [a-z0-9/-], so the key itself is regex-safe."
+  [k]
+  (second (re-find (re-pattern (str "(?m)^ " k " (\\S.*)$"))
+                   (slurp-rel lock-rel))))
+
+;; ── lock ↔ repo pin authorities ──────────────────────────────────────────
+
+(deftest lock-matches-wrapper-pins
+  (testing "the lock restates bin/js1's pins exactly (no drift, no second truth)"
+    (is (= "619ef19685460af847654e22cf6beda904d052fb" (:jolt/sha lock)))
+    (is (= (:jolt/sha lock) (wrapper-var "JOLT_SHA")))
+    (is (= (:jolt/branch lock) (wrapper-var "JOLT_BRANCH")))
+    (is (= (:jolt/url lock) (wrapper-var "JOLT_URL")))
+    (is (= "js0-functional-sci-upstream" (:jolt/branch lock)))
+    (is (= "32d62a5136ad3dc148588752f5bcc4cc30b14752" (:sci/sha lock)))
+    (is (= (:sci/sha lock) (wrapper-var "SCI_SHA")))
+    (is (= "0.13.53" (:sci/version lock)))
+    (is (= (:sci/version lock) (wrapper-var "SCI_VERSION")))))
+
+(deftest lock-matches-deps-crypto-pin
+  (testing "the lock's jolt-crypto pin equals deps.edn's :git/sha (its single home)"
+    (let [m (re-find #"(?s)jolt-lang/jolt-crypto.*?\"([0-9a-f]{40})\"" deps-src)]
+      (is (some? m) "deps.edn carries a jolt-crypto :git/sha")
+      (is (= "1ab72aa5f73be7ec41f01086953ffb43ecd3d84e" (second m)))
+      (is (= (second m) (:jolt-crypto/sha lock))))))
+
+(deftest lock-is-shell-greppable
+  (testing "every pin the shell gates read sits alone on its line"
+    (doseq [k [:lock/version :platform/os :platform/arch :jolt/sha :sci/sha
+               :sci/version :jolt-crypto/sha :smolvm/version
+               :smolvm/bin-sha256 :guest-pack/status :guest-pack/sha256
+               :machine/cpus :machine/mem-mib :deadline/total-seconds
+               :log/max-step-bytes]]
+      (is (some? (lock-line k)) (str "lock line missing for " k))))
+  (testing "platform is exactly linux/x86_64 + /dev/kvm — never silently retargeted"
+    (is (= "linux" (:platform/os lock)))
+    (is (= "x86_64" (:platform/arch lock)))
+    (is (= "/dev/kvm" (:platform/kvm-device lock))))
+  (testing "smolvm is pinned by version AND binary digest"
+    (is (= "1.7.5" (:smolvm/version lock)))
+    (is (re-matches #"[0-9a-f]{64}" (str (:smolvm/bin-sha256 lock))))))
+
+(deftest lock-pack-gate-is-fail-closed
+  (testing "the pack status is a known keyword and the sha256 shape agrees"
+    (is (contains? #{:unbuilt :built} (:guest-pack/status lock)))
+    (if (= :unbuilt (:guest-pack/status lock))
+      (is (nil? (:guest-pack/sha256 lock))
+          ":unbuilt means NO digest is asserted — a run may not be fabricated")
+      (is (re-matches #"[0-9a-f]{64}" (str (:guest-pack/sha256 lock)))
+          ":built requires a real sha256 pin")))
+  (testing "the producer gate refuses an unbuilt/absent pack with the remedy"
+    (let [src (slurp-rel "ci/js1-smolvm/producer-gate.sh")]
+      (is (str/includes? src "the JS1 guest pack is not provisioned"))
+      (is (str/includes? src "build-guest-pack.sh"))
+      (is (str/includes? src "never fabricates one"))
+      ;; the build-lane exemption is explicit and scoped to the build only
+      (is (str/includes? src "JS1_SMOLVM_BUILD_LANE")))))
+
+(deftest lock-bounds-are-bounded
+  (testing "every deadline is a positive int and the total caps the lane"
+    (doseq [k [:deadline/preflight-seconds :deadline/producer-seconds
+               :deadline/setup-seconds :deadline/check-seconds
+               :deadline/smoke-seconds :deadline/boundary-seconds
+               :deadline/teardown-seconds :deadline/total-seconds]]
+      (is (and (integer? (get lock k)) (pos? (get lock k)))
+          (str "deadline missing or non-positive: " k)))
+    (is (<= (:deadline/total-seconds lock) 2700)
+        "the lane's total deadline fits the workflow's timeout-minutes 45"))
+  (testing "machine + log bounds are explicit and modest"
+    (is (<= 1 (:machine/cpus lock) 8))
+    (is (<= 512 (:machine/mem-mib lock) 16384))
+    (is (<= 65536 (:log/max-step-bytes lock) (* 64 1024 1024)))))
+
+;; ── recipe coherence ─────────────────────────────────────────────────────
+
+(deftest recipe-agrees-with-lock
+  (testing "the recipe restates the same runtime pins"
+    (is (= (:jolt/sha lock) (get-in recipe [:jolt-runtime :sha])))
+    (is (= (:sci/sha lock) (get-in recipe [:jolt-runtime :submodule :sha])))
+    (is (= (:sci/version lock) (get-in recipe [:jolt-runtime :submodule :version])))
+    (is (= (get-in recipe [:jolt-runtime :guest-path]) (:guest/jolt-home lock))))
+  (testing "chez payload is digest-pinned and threaded"
+    (is (re-matches #"[0-9a-f]{64}" (get-in recipe [:chez :payload-sha256])))
+    (is (true? (get-in recipe [:chez :threaded])))
+    (is (= "10.4.1" (get-in recipe [:chez :version]))))
+  (testing "the four SCI jars on the sandbox classpath are sha256-pinned"
+    (is (= 4 (count (get-in recipe [:warm-caches :sci-jar-sha256]))))
+    (doseq [[artifact sha] (get-in recipe [:warm-caches :sci-jar-sha256])]
+      (is (str/ends-with? artifact ".jar"))
+      (is (re-matches #"[0-9a-f]{64}" sha) (str "jar pin malformed: " artifact))))
+  (testing "the warm git-dep set covers deps.edn's git deps (full-resolve warm)"
+    (doseq [lib ["jolt-lang/http-client" "jolt-lang/db" "jolt-lang/nrepl"
+                 "jolt-lang/jolt-crypto" "org.clojure/data.json"
+                 "jolt-lang/logging" "jolt-lang/time"]]
+      (is (re-matches #"[0-9a-f]{40}"
+                      (str (get-in recipe [:warm-caches :git-deps lib] "")))
+          (str "warm-caches missing git dep " lib))))
+  (testing "the guest env contract names the baked runtime"
+    (is (= (:guest/jolt-home lock) (get-in recipe [:guest-env "JOLT_HOME"])))
+    (is (= (:guest/chez lock) (get-in recipe [:guest-env "JOLT_CHEZ"])))
+    (is (= (:guest/home lock) (get-in recipe [:guest-env "HOME"])))))
+
+;; ── fixtures match the real suite ────────────────────────────────────────
+
+(deftest fixtures-match-boundary-suite
+  (let [suite (slurp-rel "test/samizdat/js1_boundary_test.clj")]
+    (testing "every declared phase is a phase the suite's run-phase! dispatches"
+      (doseq [phase (get-in fixtures [:boundary :phases])]
+        (is (str/includes? suite (str "\"" phase "\""))
+            (str "suite has no phase " phase))))
+    (testing "every declared marker string appears in the suite source"
+      (doseq [[phase markers] (get-in fixtures [:boundary :phase-markers])
+              marker markers]
+        (is (str/includes? suite marker)
+            (str "suite never prints/asserts marker " marker " for phase " phase))))
+    (testing "the non-actuation witness string is the suite's"
+      (is (str/includes? suite (get-in fixtures [:boundary :non-actuation-witness]))))
+    (testing "the env vars are the suite's"
+      (doseq [k [:suite-env :phase-env :dir-env :jolt-bin-env]]
+        (is (str/includes? suite (get-in fixtures [:boundary k]))
+            (str "suite does not read " (get-in fixtures [:boundary k])))))))
+
+(deftest fixtures-match-smoke-and-wrapper
+  (testing "the smoke marker is the suite's own success line"
+    (is (str/includes? (slurp-rel "test/samizdat/sandbox_test.clj")
+                       (get-in fixtures [:wrapper :smoke-marker]))))
+  (testing "the runner fixture drives the boundary suite and propagates exit"
+    (let [runner (slurp-rel (get-in fixtures [:boundary :runner]))]
+      (is (str/includes? runner "(require 'samizdat.js1-boundary-test)"))
+      (is (str/includes? runner "t/run-tests 'samizdat.js1-boundary-test"))
+      (is (str/includes? runner "System/exit"))))
+  (testing "guest step markers in fixtures are what guest-setup.sh prints"
+    (let [gs (slurp-rel "ci/js1-smolvm/guest-setup.sh")]
+      (doseq [[_ marker] (:guest-markers fixtures)]
+        (is (str/includes? gs marker)
+            (str "guest-setup.sh never prints " marker))))))
+
+;; ── shell harness discipline ─────────────────────────────────────────────
+
+(deftest harness-never-uses-host-tmp
+  (testing "no ci/js1-smolvm script calls mktemp or writes literal /tmp paths"
+    (doseq [rel harness-scripts]
+      (let [src (slurp-rel rel)]
+        (is (not (str/includes? src "mktemp")) (str rel " uses mktemp"))
+        ;; /tmp may appear only in refusal text, the guard pattern itself,
+        ;; or guest-side VM-local paths — never as a host write target.
+        (doseq [line (str/split-lines src)]
+          (when (str/includes? line "/tmp")
+            (is (or (str/includes? line "never") (str/includes? line "not ")
+                    (str/includes? line "refuses") (str/includes? line "guest")
+                    (str/includes? line "VM-local") (str/includes? line "warm")
+                    (str/includes? line "/var/tmp"))
+                (str rel " mentions /tmp outside an allowed context: " line)))))))
+  (testing "the CI dir is required, absolute, and refused under /tmp"
+    (let [src (slurp-rel "ci/js1-smolvm/lib-lock.sh")]
+      (is (str/includes? src "JS1_SMOLVM_CI_DIR is unset"))
+      (is (str/includes? src "must be absolute"))
+      (is (str/includes? src "/tmp|/tmp/*|/var/tmp|/var/tmp/*")))))
+
+(deftest consumer-is-bounded-and-clean
+  (let [src (slurp-rel "ci/js1-smolvm/consumer-run.sh")
+        lib (slurp-rel "ci/js1-smolvm/lib-lock.sh")
+        gs (slurp-rel "ci/js1-smolvm/guest-setup.sh")]
+    (testing "guest is network-disabled, source read-only, scratch VM-local"
+      (is (str/includes? src ":network :disabled"))
+      (is (str/includes? src ":ro\" --cpus"))
+      (is (str/includes? src "'\"network\":false'"))
+      (is (str/includes? src "'\"mounts\":1'")))
+    (testing "teardown is trapped and forced, with its own budget"
+      (is (str/includes? src "trap teardown EXIT INT TERM"))
+      (is (str/includes? src "machine delete --name \"$MACHINE_NAME\" --force")))
+    (testing "every exec is host-timeout wrapped and guest-timeout bounded"
+      (is (str/includes? lib "timeout -s TERM -k 30"))
+      (is (str/includes? src "--timeout \"${_to}s\"")))
+    (testing "invokes exactly the required evidence: check, smoke, boundary=1"
+      (is (str/includes? gs "bin/js1 check"))
+      (is (str/includes? gs "bin/js1 smoke"))
+      (is (str/includes? gs "SAMIZDAT_JS1_BOUNDARY_TEST=1")))
+    (testing "no producer shortcut: the consumer re-runs both gates"
+      (is (str/includes? src "preflight.sh"))
+      (is (str/includes? src "producer-gate.sh")))))
+
+;; ── workflow: manual, self-hosted KVM, non-blocking ──────────────────────
+
+(deftest workflow-is-manual-and-non-blocking
+  (let [wf (slurp-rel ".github/workflows/js1-smolvm.yml")]
+    (testing "dispatch-only: no push/PR triggers, so it can never gate a merge"
+      (is (str/includes? wf "workflow_dispatch"))
+      (is (not (re-find #"(?m)^  push:" wf)))
+      (is (not (re-find #"(?m)^  pull_request:" wf))))
+    (testing "self-hosted linux/x64/kvm labels"
+      (is (str/includes? wf "runs-on: [self-hosted, linux, x64, kvm]")))
+    (testing "bounded job, runner-owned CI dir, artifacts always uploaded"
+      (is (str/includes? wf "timeout-minutes: 45"))
+      (is (str/includes? wf "runner.temp"))
+      (is (str/includes? wf "if: always()")))
+    (testing "no reusable-workflow or trigger fan-in from other workflows"
+      (is (not (str/includes? wf "workflow_call")))
+      (is (not (str/includes? wf "workflow_run")))))
+  (testing "the ordinary tests workflow is untouched by this lane"
+    (let [tests (slurp-rel ".github/workflows/tests.yml")]
+      (is (not (str/includes? tests "js1-smolvm")))
+      (is (not (str/includes? tests "smolvm"))))))
+
+;; ── inventory agreement ──────────────────────────────────────────────────
+
+(deftest inventory-files-exist
+  (doseq [[k v] lock]
+    (when (= "inventory" (namespace k))
+      (is (fs/exists? (p v)) (str "inventory missing: " v " (" k ")")))))
+
+;; ── self-run ─────────────────────────────────────────────────────────────
+
+(when (= "1" (jolt.host/getenv "SAMIZDAT_JS1_HARNESS_TEST_RUN"))
+  (let [{:keys [fail error] :as summary}
+        (t/run-tests 'samizdat.js1-harness-test)]
+    (println summary)
+    (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0))))

--- a/test/samizdat/js1_wrapper_test.clj
+++ b/test/samizdat/js1_wrapper_test.clj
@@ -1,0 +1,129 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.js1-wrapper-test
+  "bin/js1 wrapper contract tests (deterministic, offline, no SCI needed).
+
+  The smoke's evidence value rests on the wrapper's fail-closed gates, so
+  those gates are what this file pins: every wrong-runtime shape must be
+  refused with the remedy on stderr.  Only sh (jolt.host/sh) and git are
+  required; the positive pin-check runs only when a genuinely pinned Jolt
+  checkout is discoverable (JOLT_HOME, else the sibling ../jolt) and skips
+  otherwise.  The smoke itself is deliberately NOT run here — it is the
+  samizdat.sandbox-test self-run plus this plumbing, and docs/
+  JS1_RUNTIME.md records its evidence."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [jolt.fs :as fs]))
+
+(def ^:private project-dir
+  (or (jolt.host/getenv "JOLT_PWD") (System/getProperty "user.dir")))
+
+(def ^:private wrapper (str project-dir "/bin/js1"))
+
+;; The same pins bin/js1 enforces (docs/JS1_RUNTIME.md § Pins).
+(def ^:private expected-jolt-sha "619ef19685460af847654e22cf6beda904d052fb")
+(def ^:private jolt-url "https://github.com/casselc/jolt")
+(def ^:private jolt-branch "js0-functional-sci-upstream")
+
+(defn- git-available? []
+  (zero? (jolt.host/sh "command -v git >/dev/null 2>&1")))
+
+(defn- sh-capture
+  "Run CMD through sh with stdout/stderr captured to files under a fresh
+  /tmp dir.  Returns {:exit :out :err}."
+  [cmd]
+  (let [dir (str "/tmp/samizdat-js1-wrapper-" (random-uuid))
+        out (str dir "/out")
+        err (str dir "/err")]
+    (fs/create-dirs dir)
+    (try
+      (let [exit (jolt.host/sh (str cmd " >" out " 2>" err))]
+        {:exit exit
+         :out (when (fs/exists? out) (slurp out))
+         :err (when (fs/exists? err) (slurp err))})
+      (finally (fs/delete-tree dir)))))
+
+(defn- git
+  "git -C dir <args>; returns the exit code.  pr-str quotes the dir for
+  the shell (EDN string escapes are sh double-quote escapes)."
+  [dir args]
+  (jolt.host/sh (str "git -C " (pr-str dir) " " args " >/dev/null 2>&1")))
+
+(defn- make-fake-jolt
+  "A tmp dir that looks like a Jolt checkout (executable bin/jolt stub, a
+  git repo with one empty commit) — enough to reach the pin check, at a
+  commit that is necessarily not the pin.  Returns the dir."
+  []
+  (let [dir (str "/tmp/samizdat-js1-fake-jolt-" (random-uuid))]
+    (fs/create-dirs (str dir "/bin"))
+    (spit (str dir "/bin/jolt") "#!/bin/sh\n")
+    (jolt.host/sh (str "chmod +x " dir "/bin/jolt"))
+    (git dir "init -q .")
+    (git dir "-c user.email=js1@test -c user.name=js1 commit -q --allow-empty -m x")
+    dir))
+
+(deftest wrapper-refuses-missing-checkout
+  (if-not (git-available?)
+    (is true "skipped: git not on PATH")
+    (testing "JOLT_HOME set to a nonexistent directory"
+      (let [{:keys [exit err]} (sh-capture
+                                (str "env JOLT_HOME=/nonexistent-js1-" (random-uuid)
+                                     " sh " (pr-str wrapper) " check"))]
+        (is (not= 0 exit))
+        (is (str/includes? err "is not a directory"))
+        (is (str/includes? err jolt-url))
+        (is (str/includes? err expected-jolt-sha))))
+    (testing "no JOLT_HOME and no sibling checkout"
+      ;; A copy of the wrapper in a bare tmp tree has no sibling ../jolt,
+      ;; so the fallback probe misses regardless of this workspace.
+      (let [dir (str "/tmp/samizdat-js1-nosib-" (random-uuid))]
+        (fs/create-dirs (str dir "/bin"))
+        (spit (str dir "/bin/js1") (slurp wrapper))
+        (try
+          (let [{:keys [exit err]} (sh-capture
+                                    (str "env JOLT_HOME= sh " dir "/bin/js1 check"))]
+            (is (not= 0 exit))
+            (is (str/includes? err "no Jolt checkout found"))
+            (is (str/includes? err jolt-url))
+            (is (str/includes? err jolt-branch)))
+          (finally (fs/delete-tree dir)))))))
+
+(deftest wrapper-refuses-wrong-commit
+  (if-not (git-available?)
+    (is true "skipped: git not on PATH")
+    (let [fake (make-fake-jolt)]
+      (try
+        (let [{:keys [exit err]} (sh-capture
+                                  (str "env JOLT_HOME=" fake " sh " (pr-str wrapper) " check"))]
+          (is (not= 0 exit))
+          (is (str/includes? err "not at the pinned JS1 runtime commit"))
+          (is (str/includes? err expected-jolt-sha))
+          (is (str/includes? err jolt-branch))
+          ;; the remedy, not just the refusal
+          (is (str/includes? err "submodule update --init vendor/sci")))
+        (finally (fs/delete-tree fake))))))
+
+(deftest wrapper-accepts-pinned-checkout-when-present
+  (if-not (git-available?)
+    (is true "skipped: git not on PATH")
+    ;; Discover a candidate exactly the way the wrapper does, then only
+    ;; demand a pass when it is genuinely at the pin.
+    (let [home (jolt.host/getenv "JOLT_HOME")
+          candidate (if (and home (not (str/blank? home)))
+                      home
+                      (str project-dir "/../jolt"))
+          at-pin? (and (fs/exists? (str candidate "/.git"))
+                       (= expected-jolt-sha
+                          (let [{:keys [exit out]} (sh-capture
+                                                    (str "git -C " (pr-str candidate) " rev-parse HEAD"))]
+                            (when (zero? exit) (str/trim out)))))]
+      (if-not at-pin?
+        (is true (str "skipped: no Jolt checkout at the pinned commit "
+                      "(looked at " candidate ")"))
+        (let [{:keys [exit out]} (sh-capture (str "sh " (pr-str wrapper) " check"))]
+          (is (zero? exit))
+          (is (str/includes? out "js1 runtime stack: OK"))
+          (is (str/includes? out expected-jolt-sha))
+          (is (str/includes? out "0.13.53")))))))

--- a/test/samizdat/js1_wrapper_test.clj
+++ b/test/samizdat/js1_wrapper_test.clj
@@ -23,9 +23,9 @@
 (def ^:private wrapper (str project-dir "/bin/js1"))
 
 ;; The same pins bin/js1 enforces (docs/JS1_RUNTIME.md § Pins).
-(def ^:private expected-jolt-sha "619ef19685460af847654e22cf6beda904d052fb")
+(def ^:private expected-jolt-sha "279bca18bbf50f37b8574a4e6998dee40313cd26")
 (def ^:private jolt-url "https://github.com/casselc/jolt")
-(def ^:private jolt-branch "js0-functional-sci-upstream")
+(def ^:private jolt-branch "js1-runtime-current-upstream")
 
 (defn- git-available? []
   (zero? (jolt.host/sh "command -v git >/dev/null 2>&1")))

--- a/test/samizdat/proc_test.clj
+++ b/test/samizdat/proc_test.clj
@@ -1,0 +1,251 @@
+;; samizdat - a self-hosting agentic harness
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.proc-test
+  "The scoped structured execution seam (proc/scope-run over
+  jolt.host/process-scope-run): the fail-closed request contract, the exact
+  request forwarded to the trusted primitive, the explicit scrubbed allowlist
+  environment (no controller inheritance), independent stdout/stderr byte
+  caps, and the process-tree timeout that leaves no TERM-resistant survivor.
+
+  Real-spawn sections gate on Linux — the primitive itself throws
+  UnsupportedOperationException elsewhere, so off Linux they skip (and the
+  pure contract tests still run). The no-survivor checks read /proc
+  independently of the primitive's own confirmation, so a regression is
+  caught by evidence it cannot fabricate.
+
+  Self-run on the recorded JS1 classpath (from the repo root; jolt is
+  located exactly as bin/js1 locates it — $JOLT_HOME, else the sibling
+  ../jolt checkout — and the classpath is the one bin/js1 path records):
+    SAMIZDAT_PROC_TEST_RUN=1 ../jolt/bin/jolt -Srepro -Scp \"$(bin/js1 path)\" run test/samizdat/proc_test.clj"
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing run-tests]]
+            [samizdat.engine.proc :as proc]))
+
+(def ^:private linux?
+  (str/includes? (str (System/getProperty "os.name")) "Linux"))
+
+;; The trusted primitive, captured at load (the root binding) so the
+;; dispatching stubs below can delegate git-style calls to reality while
+;; capturing the call under test.
+(def real-scope-run proc/*scope-run*)
+
+;; Alive in the same sense the primitive's confirm loop means it: a /proc
+;; entry whose state is not Z/X/x. A vanished entry is not live, never an
+;; exception.
+(defn- proc-live? [pid]
+  (when pid
+    (try
+      (let [s (slurp (str "/proc/" pid "/stat"))
+            rp (.lastIndexOf s ")")]
+        (and (>= rp 0)
+             (> (count s) (+ rp 2))
+             (not (contains? #{"Z" "X" "x"} (subs s (+ rp 2) (+ rp 3))))))
+      (catch Exception _ false))))
+
+(defn- nuke-group!
+  "Belt and braces AFTER a failed no-survivor assertion: destroy the leaked
+  group so a regression cannot outlive the test run. Runs only when the
+  assertion's evidence is already captured."
+  [pgid]
+  (try
+    (real-scope-run {:cmd ["/bin/sh" "-c" (str "kill -9 -" pgid)]
+                     :env {} :timeout-ms 5000})
+    (catch Throwable _ nil)))
+
+;; --- the explicit scrubbed allowlist environment (pure) ----------------------
+
+(deftest scrubbed-allowlist-env-is-explicit-and-scrubbed
+  (let [child (proc/scrubbed-allowlist-env
+                {"PATH" "/usr/bin:/bin"
+                 "HOME" "/home/w"
+                 "TERM" "xterm"
+                 "SAMIZDAT_API_KEY" "sk-abcdefghijklmnopqrstuv"
+                 "HARNESS_TOKEN" "opaque-token-value-0123456789"
+                 "DATABASE_URL" "postgres://u:secretpw@db.example.com/prod"
+                 "SOMETHING_ELSE" "1"})]
+    (testing "exactly the allowlisted names survive — nothing else crosses"
+      (is (= #{"PATH" "HOME" "TERM"} (set (keys child)))))
+    (testing "name-sensitive values are absent entirely"
+      (is (not (str/includes? (str (vals child)) "sk-abcdefghijklmnopqrstuv")))
+      (is (not (str/includes? (str (vals child)) "opaque-token-value"))))
+    (testing "unallowlisted names are dropped, not redacted-in-place"
+      (is (nil? (get child "DATABASE_URL")))
+      (is (nil? (get child "SOMETHING_ELSE"))))
+    (testing "allowed values pass through untouched"
+      (is (= "/usr/bin:/bin" (get child "PATH")))))
+  (testing "empty and nil sources yield an empty explicit environment"
+    (is (= {} (proc/scrubbed-allowlist-env {})))
+    (is (= {} (proc/scrubbed-allowlist-env nil))))
+  (testing "a credential-shaped value under an ALLOWED name is scrubbed"
+    (is (= "[REDACTED]"
+           (get (proc/scrubbed-allowlist-env {"PATH" "sk-abcdefghijklmnopqrstuv"})
+                "PATH")))))
+
+;; --- the request contract fails closed before anything spawns -----------------
+
+(deftest scope-run-fails-closed-on-malformed-requests
+  (binding [proc/*scope-run* (fn [req] (throw (ex-info "must not spawn" req)))]
+    (doseq [[label req]
+            ["empty argv"        {:cmd [] :env {} :timeout-ms 100}
+             "nil argv"          {:cmd nil :env {} :timeout-ms 100}
+             "blank element"     {:cmd [""] :env {} :timeout-ms 100}
+             "non-string elem"   {:cmd [:git] :env {} :timeout-ms 100}
+             "no env at all"     {:cmd ["git"] :timeout-ms 100}
+             "non-map env"       {:cmd ["git"] :env "PATH=/bin" :timeout-ms 100}
+             "= inside name"     {:cmd ["git"] :env {"A=B" "1"} :timeout-ms 100}
+             "non-string value"  {:cmd ["git"] :env {"A" 1} :timeout-ms 100}
+             "no timeout"        {:cmd ["git"] :env {}}
+             "zero timeout"      {:cmd ["git"] :env {} :timeout-ms 0}
+             "fractional time"   {:cmd ["git"] :env {} :timeout-ms 2.5}
+             "zero out cap"      {:cmd ["git"] :env {} :timeout-ms 100 :out-bytes 0}
+             "negative err cap"  {:cmd ["git"] :env {} :timeout-ms 100 :err-bytes -1}
+             "fractional cap"    {:cmd ["git"] :env {} :timeout-ms 100 :out-bytes 2.5}
+             "blank dir"         {:cmd ["git"] :env {} :timeout-ms 100 :dir ""}]]
+      (is (thrown? IllegalArgumentException (proc/scope-run req))
+          (str label ": must throw before anything spawns")))))
+
+(deftest scope-run-forwards-exactly-the-checked-request
+  (let [seen (atom ::none)
+        ok {:pid 1 :exit 0 :timed-out false}]
+    (binding [proc/*scope-run* (fn [req] (reset! seen req) ok)]
+      (proc/scope-run {:cmd ["git" "status"] :env {"A" "1"} :timeout-ms 5000
+                       :dir "/tmp" :term-grace-ms 250 :out-bytes 10 :err-bytes 20})
+      (is (= {:cmd ["git" "status"] :env {"A" "1"} :timeout-ms 5000
+              :dir "/tmp" :term-grace-ms 250 :out-bytes 10 :err-bytes 20}
+             @seen)
+          "every requested knob, verbatim")
+      (proc/scope-run {:cmd ["x"] :env {} :timeout-ms 1})
+      (is (= {:cmd ["x"] :env {} :timeout-ms 1} @seen)
+          "absent optionals are ABSENT keys — no nil-valued or invented knobs"))))
+
+;; --- the capability probe: off-Linux / missing primitive must be answerable ----
+
+(deftest scope-supported?-probes-the-primitive-without-spawning
+  (testing "on this runtime (Linux) the scoped capability is present"
+    (is (true? (proc/scope-supported?))))
+  (testing "a primitive that answers, or throws a request-shape complaint, counts as present"
+    (binding [proc/*scope-run* (fn [_req] {:exit 0})]
+      (is (true? (proc/scope-supported?))))
+    (binding [proc/*scope-run*
+              (fn [req]
+                (throw (IllegalArgumentException. (str "shape: " (pr-str (:cmd req))))))]
+      (is (true? (proc/scope-supported?)))))
+  (testing "UnsupportedOperationException is the absent answer — off Linux"
+    (binding [proc/*scope-run*
+              (fn [_req]
+                (throw (UnsupportedOperationException.
+                         "process-scope: requires Linux with posix_spawn process-group and poll(2) support")))]
+      (is (false? (proc/scope-supported?)))))
+  (testing "the probe request is the capability shape: a lone :cmd, no :timeout-ms"
+    (let [seen (atom nil)]
+      (binding [proc/*scope-run* (fn [req] (reset! seen req) {:exit 0})]
+        (is (true? (proc/scope-supported?)))
+        (is (= ["samizdat-scope-capability-probe"] (:cmd @seen)))
+        (is (nil? (:timeout-ms @seen))
+            "no timeout means no spawn path is ever reached on a present
+             primitive — and on an absent one the throw precedes everything")))))
+
+;; --- the allowlist is LOCKED, not merely filtered ------------------------------
+
+(def ^:private expected-allowlist
+  "The pinned set. Changing the allowlist is a trust decision; this test is
+  where that decision gets made visibly, in both directions — an addition
+  or removal anywhere else fails here."
+  #{"PATH" "HOME" "LANG" "LC_ALL" "LC_CTYPE" "TERM" "TMPDIR"})
+
+(def ^:private project-dir
+  (or (jolt.host/getenv "JOLT_PWD") (System/getProperty "user.dir")))
+
+(deftest scoped-env-allowlist-is-locked-exactly
+  (testing "the source literal in proc.clj IS the pinned set (no drift either way)"
+    (let [src (slurp (str project-dir "/src/samizdat/engine/proc.clj"))
+          m (re-find #"(?s)\(def \^:private scope-env-allowlist.*?\[([^\]]*)\]" src)]
+      (is (some? m) "the scope-env-allowlist vector was not found in proc.clj")
+      (is (= expected-allowlist
+             (set (map second (re-seq #"\"([^\"]+)\"" (second m)))))
+          "the allowlist changed without updating this lock — that is a
+           trust decision, make it here, deliberately")))
+  (testing "behavior: a source env holding every allowlisted name plus junk
+            yields EXACTLY the allowlist — equality, not subset"
+    (let [src-env (merge (into {} (map #(vector % (str "v-" %)) expected-allowlist))
+                         {"SAMIZDAT_API_KEY" "x" "SOMETHING_ELSE" "y"})
+          child (proc/scrubbed-allowlist-env src-env)]
+      (is (= expected-allowlist (set (keys child)))
+          "no name outside the pinned set may ever appear")
+      (is (every? #(= (str "v-" %) (get child %)) expected-allowlist)
+          "and every pinned name's plain value passes through"))))
+
+;; --- real scoped execution (Linux: the primitive's own platform bound) -------
+
+(deftest scope-run-executes-structured-argv-without-inheriting-the-controller-env
+  (when linux?
+    (let [r (proc/scope-run {:cmd ["/bin/sh" "-c"
+                                   "echo \"JP=$JP_ONLY HOME=${HOME:-unset}\"; pwd"]
+                             :dir "/tmp"
+                             :env {"JP_ONLY" "1"}
+                             :timeout-ms 10000
+                             :out-bytes 1000 :err-bytes 1000})]
+      (is (zero? (:exit r)))
+      (is (false? (:timed-out r)))
+      (is (= :complete (:out-status r)))
+      (is (str/includes? (:out r) "JP=1") "the explicit env reached the child")
+      (is (str/includes? (:out r) "HOME=unset")
+          "the controller environment is NOT inherited — :env replaces it")
+      (is (str/includes? (:out r) "/tmp") "the request :dir set the child cwd"))))
+
+(deftest scope-run-caps-stdout-and-stderr-independently
+  (when linux?
+    (let [r (proc/scope-run {:cmd ["/bin/sh" "-c"
+                                   (str "echo one-line; i=0; "
+                                        "while [ $i -lt 100000 ]; do echo E$i 1>&2; "
+                                        "i=$((i+1)); done; sleep 30")]
+                             :env {} :timeout-ms 20000
+                             :err-bytes 16 :out-bytes 4096})]
+      (is (= :truncated (:err-status r)) "the flooding stream hit its own cap")
+      (is (= 16 (count (:err r))) "the stderr bound is honored exactly")
+      (is (= :complete (:out-status r)) "the bounded stdout still completed")
+      (is (= "one-line\n" (:out r)) "stdout content is intact")
+      (is (false? (:timed-out r)) "an overflow abort is not a controller timeout")
+      (is (not (zero? (:exit r))) "the overflow abort killed the run"))))
+
+(deftest scope-run-timeout-leaves-no-term-resistant-survivors
+  (when linux?
+    (let [pidf (str "/tmp/samizdat-proc-test-"
+                    (System/currentTimeMillis) ".pid")]
+      (try
+        ;; A tree where EVERY member resists SIGTERM: the child traps TERM,
+        ;; and a shell that has trapped TERM leaves SIG_IGN in place for
+        ;; everything it spawns afterwards, so the grandchild's sleep
+        ;; survives the TERM wave too. Only the group KILL clears it.
+        (let [script (str "trap '' TERM; "
+                          "/bin/sh -c 'trap \"\" TERM; echo $$ > " pidf
+                          "; sleep 60' & wait")
+              r (proc/scope-run {:cmd ["/bin/sh" "-c" script]
+                                 :env {} :timeout-ms 800 :term-grace-ms 250
+                                 :out-bytes 1000})
+              leaked-grandchild? (when (.exists (java.io.File. pidf))
+                                   (proc-live? (str/trim (slurp pidf))))]
+          (is (true? (:timed-out r)))
+          (is (contains? #{137 143} (:exit r))
+              "the root died to the escalation ladder (KILL 137 / TERM 143)")
+          (is (not (proc-live? (:pid r))) "the root is gone from /proc")
+          (is (not leaked-grandchild?)
+              "the TERM-resistant grandchild is dead — no survivor")
+          (when leaked-grandchild? (nuke-group! (:pid r))))
+        (finally
+          (let [f (java.io.File. pidf)]
+            (when (.exists f) (.delete f))))))))
+
+(deftest scope-run-throws-when-the-program-cannot-run
+  (when linux?
+    (is (thrown? Exception
+                 (proc/scope-run {:cmd ["definitely-no-such-program-xyz"]
+                                  :env {} :timeout-ms 1000})))))
+
+;; --- self-run for the focused lane --------------------------------------------
+
+(when (= "1" (jolt.host/getenv "SAMIZDAT_PROC_TEST_RUN"))
+  (let [{:keys [fail error] :as summary} (run-tests 'samizdat.proc-test)]
+    (println summary)
+    (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0))))

--- a/test/samizdat/resume_test.clj
+++ b/test/samizdat/resume_test.clj
@@ -1,0 +1,210 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.resume-test
+  "JS1 resume: the fail-closed ladder, deterministically.
+
+  The whole-history reconstruction itself needs SCI, so its positive path
+  is exercised for real across an OS-process boundary by
+  samizdat.js1-boundary-test.  What CAN be asserted here, with no SCI on
+  the classpath (the `jolt -M:test` suite shape), is every rung of the
+  ladder that refuses:
+
+  - a run with no JS1 journal event resumes with no JS1 dependency at all;
+  - a JS1-profiled run whose sandbox cannot load fails CLOSED — never a
+    live-eval fallthrough (under the plain suite SCI is genuinely absent,
+    so :sandbox-unavailable is exercised directly);
+  - journal info that lacks any reconstruction field is refused as data,
+    before SCI is even required — corrupt data must not be laundered by an
+    environment difference;
+  - the journal round trip of the exact reconstruction information
+    (workflow/js1-binding-journal-data out, resume's normalization in)
+    preserves everything reconstruction needs;
+  - a JS1 event on a multi-branch run is refused before the run is marked
+    running again."
+  (:require [clojure.data.json :as json]
+            [clojure.test :refer [deftest testing is]]
+            [samizdat.agent.resume :as resume]
+            [samizdat.agent.tools.base :as base]
+            [samizdat.store.db :as db]
+            [samizdat.store.journal :as journal]
+            [samizdat.store.runs :as runs]
+            [samizdat.workflow :as wf]))
+
+(defn- with-db [f]
+  (let [c (db/open! ":memory:")]
+    (try (f c) (finally (db/close c)))))
+
+(def ^:private sci-present?
+  ;; The same quiet probe sandbox-test uses: under `jolt -M:test` the SCI
+  ;; roots are absent and this is false, which is the environment these
+  ;; assertions are written against.
+  (try (require 'samizdat.agent.sandbox) true
+       (catch Throwable _ false)))
+
+(def ^:private fake-binding
+  "A structurally faithful Binding map for the journal round-trip: the
+  fields js1-binding-journal-data reads, in the shapes a real binding
+  carries (spec coordinate keyword keys, sorted capability keywords,
+  bounds map, timeout)."
+  {:binding/id "bind:main:42"
+   :instance/id "inst:main"
+   :work-id "42"
+   :spec {:preset :project/develop
+          :spec/coordinate "js1:abcdef"
+          :capabilities [:project/edit :project/list :project/read
+                         :project/search :project/stat]
+          :bounds {:max-read-chars 60000 :max-list-entries 1000
+                   :max-search-results 500 :search-max-chars 500000}
+          :timeout-ms 30000}})
+
+(defn- journal-js1-event!
+  "Journal a :js1-binding-created event exactly the way workflow/run! does,
+  through the real journal, with real serialization."
+  ([c rid]
+   (journal-js1-event! c rid (wf/js1-binding-journal-data
+                              "single-player" fake-binding
+                              "js1-rt/v1:fake")))
+  ([c rid data]
+   (journal/note! c rid :js1-binding-created {:data data})
+   rid))
+
+(deftest a-non-js1-run-resumes-with-no-js1-dependency
+  ;; The absence path must not so much as require the sandbox namespace:
+  ;; an unprofiled run cannot start failing on a dependency it never used.
+  (with-db
+    (fn [c]
+      (let [rid (runs/start-run! c {:problem "p" :max-turns 5 :beam-width 1})]
+        (is (nil? (@#'resume/reconstruct-run-js1-binding! c rid "/tmp"))
+            "no journal event, no reconstruction, no SCI require")))))
+
+(deftest js1-resume-fails-closed-on-sci-unavailability
+  (with-db
+    (fn [c]
+      (let [rid (journal-js1-event!
+                 c (runs/start-run! c {:problem "p" :max-turns 5 :beam-width 1}))]
+        (try
+          (resume/resume! {:conn c :run-id rid :config {}
+                           :llm-adapter :a :llm-config {}})
+          (is false "resume! must not return for a JS1-profiled run")
+          (catch Throwable e
+            (let [code (:js1/error (ex-data e))]
+              (is (contains? #{:sandbox-unavailable :runtime-mismatch
+                               :history-invalid :binding-id-mismatch} code)
+                  (str "a JS1-profiled resume fails closed, got: " code))
+              (if sci-present?
+                ;; With SCI on the roots the fabricated runtime coordinate
+                ;; is the first thing that can be wrong — still closed.
+                (is (contains? #{:runtime-mismatch :binding-id-mismatch
+                                 :history-invalid} code)
+                    "with SCI present, the fabricated runtime coordinate is refused")
+                ;; The suite shape: the sandbox truly cannot load, and the
+                ;; refusal says so rather than guessing a mismatch.
+                (is (= :sandbox-unavailable code)
+                    "without SCI the refusal names the sandbox, not a guess")))))))))
+
+(deftest js1-resume-refuses-incomplete-journal-info-as-data
+  ;; Corrupt journal data is refused before SCI is even required, so no
+  ;; environment difference can launder it into a reconstructed binding.
+  (let [incomplete
+        {:spec-coordinate "js1:x" :runtime-coordinate "js1-rt/v1:y"
+         :binding-id "bind:main:1" :instance-id "inst:main"
+         :preset "project/develop" :capabilities ["project/read"]
+         ;; no :bounds, no :timeout-ms
+         }
+        thrown-code (fn [info]
+                      (try
+                        (resume/reconstruct-js1-binding! nil info "/tmp")
+                        nil
+                        (catch Throwable e (:js1/error (ex-data e)))))]
+    (is (= :reconstruction-info-missing (thrown-code incomplete))
+        "missing bounds/timeout are refused as data")
+    (is (= :reconstruction-info-missing
+           (thrown-code (assoc incomplete :bounds {:max-read-chars 60000}
+                               :timeout-ms 30000
+                               :spec-coordinate "")))
+        "a blank spec coordinate is refused, not defaulted")
+    (is (= :reconstruction-info-missing
+           (thrown-code (assoc incomplete :bounds {:max-read-chars 60000}
+                               :timeout-ms 0)))
+        "a non-positive timeout is refused")
+    (is (= :reconstruction-info-missing
+           (thrown-code (assoc incomplete :timeout-ms 30000
+                               :bounds {:max-read-chars "many"})))
+        "a non-integer bound is refused")
+    (is (= :reconstruction-info-missing (thrown-code "not a map"))
+        "non-map journal data is refused")))
+
+(deftest journal-round-trips-exact-js1-reconstruction-info
+  ;; The production writer (workflow) and the production reader (resume)
+  ;; agree through the REAL journal serialization, not just in memory.
+  (with-db
+    (fn [c]
+      (let [rid (journal-js1-event!
+                 c (runs/start-run! c {:problem "p" :max-turns 5 :beam-width 1}))]
+        (is (= 1 (count (filter #(= "js1-binding-created" (:kind %))
+                                (journal/events-since c rid 0))))
+            "the event landed")
+        (let [raw (some #(when (= "js1-binding-created" (:kind %)) %)
+                        (journal/events-since c rid 0))
+              ;; The exact parse resume performs on the JSON column.
+              parsed (try
+                       (json/read-str (:data raw) :key-fn keyword)
+                       (catch Throwable _ ::unparseable))]
+          (is (not= ::unparseable parsed) "the journaled data is JSON")
+          (let [norm (@#'resume/normalize-js1-info parsed)]
+            (is (= "bind:main:42" (:binding-id norm)))
+            (is (= "inst:main" (:instance-id norm)))
+            (is (= :project/develop (:preset norm))
+                "the preset keyword survives the JSON round trip")
+            (is (= "js1:abcdef" (:spec-coordinate norm)))
+            (is (= "js1-rt/v1:fake" (:runtime-coordinate norm)))
+            (is (= [:project/edit :project/list :project/read
+                    :project/search :project/stat]
+                   (:capabilities norm))
+                "capabilities read back as full-name keywords, sorted")
+            (is (= {:max-read-chars 60000 :max-list-entries 1000
+                    :max-search-results 500 :search-max-chars 500000}
+                   (:bounds norm))
+                "bounds keys re-keyword through the round trip")
+            (is (= 30000 (:timeout-ms norm)))))))))
+
+(deftest js1-resume-refuses-a-multi-branch-run-before-any-work
+  (with-db
+    (fn [c]
+      (let [rid (journal-js1-event!
+                 c (runs/start-run! c {:problem "p" :max-turns 5 :beam-width 3}))
+            _ (runs/finish-run! c rid :failed nil)]
+        (is (resume/resumable? c rid) "sanity: the fixture is resumable")
+        (try
+          (resume/resume! {:conn c :run-id rid :config {}
+                           :llm-adapter :a :llm-config {}})
+          (is false "a JS1 event on a width-3 run must not resume")
+          (catch Throwable e
+            (is (= :multi-branch-not-supported (:js1/error (ex-data e)))
+                "refused as the single-player shape violation it is")
+            (is (= "failed" (:status (runs/get-run c rid)))
+                "and refused BEFORE the run is marked running again")))))))
+
+(deftest the-single-branch-guard-admits-width-one
+  ;; The guard exists to refuse a SHAPE, not the profile: a plain
+  ;; single-branch JS1 run is exactly what the profile is for.
+  (is (nil? (base/js1-assert-single-branch! true 1)))
+  (is (nil? (base/js1-assert-single-branch! false 5))
+      "a non-JS1 beam at any width is untouched")
+  (is (thrown? ExceptionInfo (base/js1-assert-single-branch! true 2))))

--- a/test/samizdat/resume_test.clj
+++ b/test/samizdat/resume_test.clj
@@ -39,8 +39,12 @@
     running again."
   (:require [clojure.data.json :as json]
             [clojure.test :refer [deftest testing is]]
+            [samizdat.agent.beam :as beam]
+            [samizdat.agent.gitdiff :as gitdiff]
             [samizdat.agent.resume :as resume]
             [samizdat.agent.tools.base :as base]
+            [samizdat.agent.tools.ship]
+            [samizdat.engine.proc :as proc]
             [samizdat.store.db :as db]
             [samizdat.store.journal :as journal]
             [samizdat.store.runs :as runs]
@@ -92,6 +96,90 @@
       (let [rid (runs/start-run! c {:problem "p" :max-turns 5 :beam-width 1})]
         (is (nil? (@#'resume/reconstruct-run-js1-binding! c rid "/tmp"))
             "no journal event, no reconstruction, no SCI require")))))
+
+(deftest red-resume-rebuilt-context-done-verifies-in-the-absolute-target-root
+  ;; Regression for the first live dogfood: reconstruction and the GREEN edit
+  ;; succeeded, but resume dropped :root when it handed the rebuilt branch to
+  ;; beam/run-rounds. done therefore reached scope-run with :dir "".  Drive the
+  ;; real done/verify structured boundary from the resumed ctx and capture the
+  ;; primitive request; no provider or process is involved.
+  (with-db
+    (fn [c]
+      (let [target "/home/dogfood-user/.local/share/samizdat/js1-dogfood/run/target"
+            rid (runs/start-run! c {:problem "repair dogfood green"
+                                    :max-turns 5 :beam-width 1})
+            seen (atom nil)
+            green {:pid 1 :exit 0 :timed-out false
+                   :out "GREEN" :out-status :complete
+                   :err "" :err-status :complete}]
+        (runs/open-branch! c rid {:branch-id "B1"})
+        ;; Durable RED is what makes this a recovery path rather than merely a
+        ;; ctx-construction test. resume! below rebuilds the branch solely from
+        ;; the run store/journal; the live dogfood test supplies the OS-process
+        ;; boundary for the same assertion.
+        (journal/note! c rid :ship-verify
+                       {:branch-id "B1"
+                        :data {:green false :blocked true :exit 1
+                               :kind :fallback}})
+        (binding [proc/*scope-run*
+                  (fn [request]
+                    (if (= ["samizdat-scope-capability-probe"] (:cmd request))
+                      {}
+                      (do (reset! seen request) green)))]
+          (with-redefs [gitdiff/changed-files
+                        (fn [root _baseline]
+                          (is (= target root) "git diff receives the resumed target")
+                          ["src/dogfood.clj"])
+                        beam/run-rounds
+                        (fn [ctx branches start-turn]
+                          (let [done (base/run-tool
+                                      (assoc ctx
+                                             :branch (first branches)
+                                             :tool-name "done"
+                                             :turn start-turn
+                                             :args {:answer "repair dogfood green"}))]
+                            (is (:done? done) "the fake GREEN verifier permits done")
+                            {:status :completed :run-id rid}))]
+            (is (= :completed
+                   (:status
+                    (resume/resume!
+                     {:conn c :run-id rid
+                      :config {:run {:root target
+                                     :verify-cmd "./verify-policy"
+                                     :verify-timeout-ms 4321
+                                     :require-test? false}}
+                      :llm-adapter :unused :llm-config {}}))))))
+        (is (some? @seen) "done reached the structured process primitive")
+        (is (= ["sh" "-c" "./verify-policy"] (:cmd @seen)))
+        (is (= target (:dir @seen)))
+        (is (.isAbsolute (java.io.File. (:dir @seen)))
+            "the verifier cwd is the absolute target, not source/model data")))))
+
+(deftest resume-and-beam-roots-come-from-controller-config-with-cwd-default
+  (with-db
+    (fn [c]
+      (let [cwd (System/getProperty "user.dir")
+            configured "/home/operator/persistent-target"
+            roots (atom [])
+            rid (runs/start-run! c {:problem "p" :max-turns 1 :beam-width 1})]
+        (runs/open-branch! c rid {:branch-id "B1"})
+        (with-redefs [beam/run-rounds
+                      (fn [ctx _branches _start-turn]
+                        (swap! roots conj (:root ctx))
+                        {:status :exhausted :run-id (:run-id ctx)})]
+          (resume/resume! {:conn c :run-id rid :config {}
+                           :llm-adapter :unused :llm-config {}})
+          (beam/run! {:conn c :config {}
+                      :llm-adapter :unused :llm-config {}
+                      :problem "p" :max-turns 1 :beam-width 1})
+          (beam/run! {:conn c :config {:run {:root configured}}
+                      :llm-adapter :unused :llm-config {}
+                      ;; Deliberately unrelated model-facing text: it cannot
+                      ;; become the target root.
+                      :problem "model says work somewhere else"
+                      :max-turns 1 :beam-width 1}))
+        (is (= [cwd cwd configured] @roots)
+            "drivers default to controller cwd and honor only trusted run config")))))
 
 (deftest js1-resume-fails-closed-on-sci-unavailability
   (with-db

--- a/test/samizdat/sandbox_test.clj
+++ b/test/samizdat/sandbox_test.clj
@@ -7,14 +7,18 @@
 
    The sandbox needs jolt.sandbox, which needs the vendored SCI source and
    its Maven deps on the source roots — none of which are in samizdat's
-   deps.edn.  Direct invocation (from the samizdat project dir), with
-   explicit -Scp roots so no dependency is expanded or fetched (one
-   line; M2 is $HOME/.m2/repository):
+   deps.edn.  Digests additionally need jolt-crypto's source root (its
+   MessageDigest shim plus libcrypto, which samizdat.agent.files bootstraps
+   for -Scp runs that load no natives).  Direct invocation (from the
+   samizdat project dir), with explicit -Scp roots so no dependency is
+   expanded or fetched (one line; M2 is $HOME/.m2/repository):
 
-     SAMIZDAT_SANDBOX_TEST_RUN=1 JOLT_CHEZ=/usr/local/bin/scheme JOLT_QUIET=1 /home/chuck/opencode/src/jolt/bin/jolt -Scp "$PWD/src:$PWD/test:/home/chuck/opencode/src/jolt/vendor/sci/src:$M2/borkdude/edamame/1.5.39/edamame-1.5.39.jar.jolt:$M2/org/babashka/sci.impl.types/0.0.3/sci.impl.types-0.0.3.jar.jolt:$M2/borkdude/graal.locking/0.0.2/graal.locking-0.0.2.jar.jolt:$M2/org/clojure/tools.reader/1.5.2/tools.reader-1.5.2.jar.jolt" run "$PWD/test/samizdat/sandbox_test.clj"
+     SAMIZDAT_SANDBOX_TEST_RUN=1 JOLT_CHEZ=/usr/local/bin/scheme JOLT_QUIET=1 /home/chuck/opencode/src/jolt/bin/jolt -Scp \"$PWD/src:$PWD/test:$HOME/.gitlibs/libs/jolt-lang/jolt-crypto/1ab72aa5f73be7ec41f01086953ffb43ecd3d84e/src:/home/chuck/opencode/src/jolt/vendor/sci/src:$M2/borkdude/edamame/1.5.39/edamame-1.5.39.jar.jolt:$M2/org/babashka/sci.impl.types/0.0.3/sci.impl.types-0.0.3.jar.jolt:$M2/borkdude/graal.locking/0.0.2/graal.locking-0.0.2.jar.jolt:$M2/org/clojure/tools.reader/1.5.2/tools.reader-1.5.2.jar.jolt\" run \"$PWD/test/samizdat/sandbox_test.clj\"
 
    (The .jar.jolt directories are jolt's extracted-jar layout beside each
-   cached Maven artifact; -Scp takes source roots verbatim.)
+   cached Maven artifact; -Scp takes source roots verbatim.  Without the
+   jolt-crypto root every digest fails closed by contract, and the
+   digest-dependent assertions below fail.)
 
    Under plain `jolt -M:test` the SCI deps are absent, the sandbox ns
    fails to resolve, and every test here skips: this file defines its
@@ -22,7 +26,8 @@
    SAMIZDAT_SANDBOX_TEST_RUN=1, so the suite runner never double-runs it."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest testing is are] :as t]
-            [jolt.fs :as fs]))
+            [jolt.fs :as fs]
+            [samizdat.agent.files :as files]))
 
 (def ^:private sandbox-ns-resolved?
   ;; In self-run mode (the direct -Scp invocation) require loudly: a
@@ -37,6 +42,15 @@
 (when sandbox-ns-resolved?
   (require '[samizdat.agent.sandbox :as sb]))
 
+(def ^:private digest-available?
+  "Whether the digest machinery works in this process (it does when
+   jolt-crypto's root is on the -Scp roots, which the documented direct
+   invocation includes; samizdat.agent.files bootstraps libcrypto for it).
+   Every digest assertion runs under this gate so a crypto-less run fails
+   ONLY the fail-on-error assertions, never with a nil fake coordinate."
+  (try (do (files/bytes-digest (.getBytes "probe" "UTF-8")) true)
+       (catch Throwable _ false)))
+
 (defn- with-tmp [f]
   (let [root (str "/tmp/samizdat-sandbox-" (random-uuid))]
     (fs/create-dirs root)
@@ -45,11 +59,49 @@
 (defn- deny? [f]
   (try (f) false (catch Throwable _ true)))
 
+(defn- thrown-data
+  "The {:samizdat.sandbox/error …} ex-data of a failure, digging through
+   the SCI wrapper's cause chain to the host error the operation raised."
+  [f]
+  (try (f) nil
+       (catch Throwable e
+         (loop [e e]
+           (cond
+             (:samizdat.sandbox/error (ex-data e)) (ex-data e)
+             (ex-cause e) (recur (ex-cause e))
+             :else (ex-data e))))))
+
+(defn- thrown-code
+  "The {:samizdat.sandbox/error …} code of a failure, digging through the
+   SCI wrapper's cause chain to the host error the operation raised."
+  [f]
+  (try (f) nil
+       (catch Throwable e
+         (loop [e e]
+           (cond
+             (:samizdat.sandbox/error (ex-data e)) (:samizdat.sandbox/error (ex-data e))
+             (ex-cause e) (recur (ex-cause e))
+             :else nil)))))
+
+(defn- write-bytes!
+  "Raw bytes to a file — the only honest way to fixture invalid UTF-8."
+  [path ^bytes bs]
+  (let [out (java.io.FileOutputStream. path)]
+    (try (.write out bs)
+         (finally (try (.close out) (catch Throwable _ nil))))))
+
+(defn- known-sha256
+  "The expected sha256:… coordinate of `s`'s UTF-8 bytes."
+  [^String s]
+  (str "sha256:" (files/bytes-digest (.getBytes s "UTF-8"))))
+
 ;; Small append-only implementation of the samizdat.store.evals contract.
 ;; The direct Jolt+SCI invocation intentionally has no DB dependency on its
 ;; classpath; production resolves the real store dynamically.  Keeping this
 ;; adapter as data exercises that exact dynamic seam without weakening the
-;; bridge to transcript mocks.
+;; bridge to transcript mocks.  Rows mirror the real store's read shape:
+;; underscore identity columns, a per-binding :binding_seq total order, and
+;; the :runtime coordinate.
 (defn- memory-db []
   (atom {:next-id 1 :records {} :events []}))
 
@@ -58,7 +110,17 @@
 
 (defn- memory-begin! [conn intent]
   (let [id (:next-id @conn)
-        record (assoc intent :id id :status :pending :result nil :receipts [])]
+        binding-seq (count (filter #(= (:binding-id intent) (:binding_id %))
+                                   (vals (:records @conn))))
+        record {:id id
+                :spec_id (:spec-id intent)
+                :instance_id (:instance-id intent)
+                :binding_id (:binding-id intent)
+                :binding_seq binding-seq
+                :coordinate (:coordinate intent)
+                :runtime (:runtime intent)
+                :source (:source intent)
+                :status :pending :result nil :receipts []}]
     (reset! conn (-> @conn
                      (assoc :next-id (inc id))
                      (assoc-in [:records id] record)))
@@ -100,21 +162,34 @@
   (get-in @conn [:records eval-id]))
 
 (defn- memory-verify-binding!
-  "Mirrors samizdat.store.evals/verify-binding!: all four durable identity
-  fields — spec, instance, binding, AND the exact spec coordinate — must
-  match, so a caller that omits the coordinate (or holds stale authority)
-  is denied exactly as the real store denies it."
+  "Mirrors samizdat.store.evals/verify-binding!: all five durable identity
+   fields — spec, instance, binding, the exact authority coordinate, AND the
+   runtime coordinate — must match, so a caller that omits a field (or holds
+   stale authority or a stale runtime) is denied exactly as the real store
+   denies it."
   [conn eval-id identity]
   (memory-event! conn :verify)
-  (let [record (get-in @conn [:records eval-id])]
+  (let [record (get-in @conn [:records eval-id])
+        expected {:spec_id (:spec-id identity)
+                  :instance_id (:instance-id identity)
+                  :binding_id (:binding-id identity)
+                  :coordinate (:coordinate identity)
+                  :runtime (:runtime identity)}]
     (when-not (and record
-                   (= (:spec-id identity) (:spec-id record))
-                   (= (:instance-id identity) (:instance-id record))
-                   (= (:binding-id identity) (:binding-id record))
-                   (= (:coordinate identity) (:coordinate record)))
+                   (= expected (select-keys record (keys expected))))
       (throw (ex-info "durable evaluation binding mismatch"
                       {:eval-id eval-id})))
     true))
+
+(defn- memory-history
+  "Mirrors samizdat.store.evals/history: every record for the binding in the
+   binding's durable total order (binding_seq ascending), statuses included."
+  [conn binding-id]
+  (memory-event! conn :history)
+  (->> (vals (:records @conn))
+       (filter #(= binding-id (:binding_id %)))
+       (sort-by :binding_seq)
+       vec))
 
 (def ^:private memory-eval-store
   {:begin! memory-begin!
@@ -122,15 +197,16 @@
    :record-outcome! memory-record-outcome!
    :complete! memory-complete!
    :load-eval memory-load-eval
-   :verify-binding! memory-verify-binding!})
+   :verify-binding! memory-verify-binding!
+   :history memory-history})
 
 (defn- with-eval-store
   "Run `f` with the sandbox's durable-eval seam set to `store` (the memory
-  adapter, or a wrapper over it).  alter-var-root on a runtime-resolved
-  var, NOT `binding`: jolt analyzes binding's var at load time, but this
-  file must stay loadable — quietly skipped — where SCI, and with it the
-  `sb` alias, is absent (the `jolt -M:test` suite shape).  The root (nil
-  in production) is restored afterward."
+   adapter, or a wrapper over it).  alter-var-root on a runtime-resolved
+   var, NOT `binding`: jolt analyzes binding's var at load time, but this
+   file must stay loadable — quietly skipped — where SCI, and with it the
+   `sb` alias, is absent (the `jolt -M:test` suite shape).  The root (nil
+   in production) is restored afterward."
   [store f]
   (let [v (resolve 'samizdat.agent.sandbox/*eval-store*)
         original (deref v)]
@@ -157,8 +233,11 @@
               "preset capabilities are explicit and sorted")
           (is (= 30000 (:timeout-ms s1)))
           (is (= #{:max-read-chars :max-list-entries
-                   :max-search-results :search-max-chars}
-                 (set (keys (:bounds s1)))))
+                   :max-search-results :search-max-chars
+                   :search-max-files :max-write-bytes}
+                 (set (keys (:bounds s1))))
+              "six bounds: the four originals plus the frozen-contract
+               search file-count and edit write-byte limits")
           (is (= (:spec/coordinate s1) (:spec/coordinate s2))
               "same content, same coordinate")
           (is (not= (:spec/coordinate s1) (:spec/coordinate s3))
@@ -237,8 +316,8 @@
                                        :root root
                                        :instance/key :narrow
                                        :capabilities #{:project/read}})]
-          (is (= "hello" (:content (sb/evaluate! b "(project/read \"a.txt\")")))
-              "the granted op still works")
+          (is (= "hello" (sb/evaluate! b "(project/read \"a.txt\")"))
+              "the granted op still works, returning the decoded string")
           (is (deny? #(sb/evaluate! b "(project/edit \"a.txt\" :absent \"x\")"))
               "source cannot invoke a capability the controller did not grant")
           (is (deny? #(sb/evaluate! b "(jolt.host/getenv \"HOME\")"))
@@ -288,7 +367,8 @@
             (is (nil? (:samizdat.sandbox/instance-id dc)))
             (is (nil? (:samizdat.sandbox/binding-id dc))))))))
 
-  ;; ─── Safe discovery: host-derived over effective authority ───
+  ;; ─── Safe discovery: host-derived union of effective authority and the
+  ;; ─── reviewed language surface — never live introspection ───────────
 
   (deftest safe-discovery-is-host-derived-over-effective-authority
     (with-tmp
@@ -317,49 +397,419 @@
           ;; the full develop preset discovers its edit op, with arglists
           (let [d (sb/operation-doc dev "project/edit")]
             (is (= "project/edit" (:name d)))
-            (is (= '[rel-path base-digest new-content] (first (:arglists d))))
+            (is (= '[rel-path base new-content] (first (:arglists d))))
             (is (str/includes? (:doc d) "actuation")))
-          ;; completion: authorized projected names only, prefix-narrowed
-          (is (= ["project/read"] (sb/complete-capability ro "")))
-          (is (= ["project/read"] (sb/complete-capability ro "project/r")))
-          (is (= [] (sb/complete-capability ro "project/e")))
-          (is (= [] (sb/complete-capability ro "read")))
-          (is (= 5 (count (sb/complete-capability dev ""))))
-          (is (= ["project/read"] (sb/complete-capability dev "project/re")))
-          ;; a hostile prefix can only narrow; it never evaluates or errors
-          (is (= [] (sb/complete-capability dev "\" (do (evil))")))
-          ;; the sandbox vocabulary denies the forbidden introspection forms
-          ;; outright — host-derived discovery is the only door to them
-          (is (deny? #(sb/evaluate! ro "(resolve 'project/read)")))
-          (is (deny? #(sb/evaluate! ro "(find-ns 'project)")))
-          (is (deny? #(sb/evaluate! ro "(ns-publics 'project)")))
-          (is (deny? #(sb/evaluate! ro "(meta 'project/read)")))
           ;; discovery claims no evaluation ownership: eval still works
           (is (= 2 (sb/evaluate! ro "(inc 1)")))))))
 
-  ;; ─── Semantic ops still behave under the seam ───
+  (deftest safe-discovery-unions-reviewed-symbols-with-effective-operations
+    (with-tmp
+      (fn [root]
+        (let [p (sb/provider)
+              ro (sb/bind! p "union-ro" {:preset :project/develop :root root
+                                         :capabilities #{:project/read}})
+              dev (sb/bind! p "union-dev" {:preset :project/develop :root root
+                                           :instance/key :dev2})
+              surface-count (count (sb/complete-capability dev ""))
+              op-names (filter #(str/starts-with? % "project/")
+                               (sb/complete-capability dev ""))]
+          ;; doc answers for reviewed pure symbols from the trusted static
+          ;; language surface — curated entries carry arglists…
+          (let [d (sb/operation-doc ro "map")]
+            (is (map? d))
+            (is (= "map" (:name d)))
+            (is (= '[f coll] (first (:arglists d))))
+            (is (str/includes? (:doc d) "pure")))
+          ;; …and every other reviewed symbol gets the generic surface doc
+          (let [d (sb/operation-doc ro "zipmap")]
+            (is (= "zipmap" (:name d)))
+            (is (str/includes? (:doc d) "Reviewed pure language-surface")))
+          (is (= "map" (:name (sb/operation-doc ro ":map")))
+              "a leading colon is tolerated for pure symbols too")
+          ;; symbols outside the reviewed surface answer nothing
+          (is (nil? (sb/operation-doc ro "eval"))
+              "eval is not in the reviewed vocabulary")
+          (is (nil? (sb/operation-doc ro "jolt.host/getenv"))
+              "host namespaces are not discoverable")
+          (is (nil? (sb/operation-doc ro "resolve"))
+              "introspection is not part of the surface")
+          (is (nil? (sb/operation-doc ro "clojure.string/join")))
+          ;; completion is the UNION: operations plus pure symbols, sorted
+          (is (= ["map" "map?" "mapcat" "mapv" "max"]
+                 (sb/complete-capability dev "ma")))
+          (is (= ["project/edit" "project/list" "project/read"
+                  "project/search" "project/stat"]
+                 op-names)
+              "the five effective operations are all and only the project/ names")
+          (is (= 5 (count op-names)))
+          (is (< 150 surface-count)
+              "the union carries the reviewed surface (156 symbols at v1)")
+          (is (= 4 (- surface-count (count (sb/complete-capability ro ""))))
+              "the reviewed surface is unconditional; only the ops track grants
+               (dev has five, ro has one)")
+          ;; an ungranted operation never completes, pure symbols always do
+          (is (= [] (sb/complete-capability ro "project/e")))
+          (is (sb/complete-capability ro "proj")
+              "granted project/ names complete for the read-only binding")
+          ;; a hostile prefix can only narrow; it never evaluates or errors
+          (is (= [] (sb/complete-capability dev "\" (do (evil))")))
+          ;; the surface is stable within the process (trusted static data)
+          (is (= (sb/complete-capability dev "ma")
+                 (sb/complete-capability dev "ma")))))))
+
+  ;; ─── The five projected ops, normalized against the frozen A2/A3b
+  ;; ─── contract — positive shapes ────────────────────────────────────
 
   (deftest semantic-ops-bounded-anchored-and-confined
     (with-tmp
       (fn [root]
         (let [ctx (sb/new {:root root :profile :agent/project-develop})]
           (let [created (sb/evaluate! ctx "(project/edit \"doc.txt\" :absent \"hello world\")")]
-            (is (:created? created))
-            ;; Digests come from files/file-digest, which needs the
-            ;; jolt-crypto natives; under the offline -Scp roots those are
-            ;; absent and the digest is nil (fail-closed: updates then
-            ;; stale-conflict rather than blindly overwriting).
-            (is (or (nil? (:digest created))
-                    (str/starts-with? (:digest created) "sha256:"))))
+            (is (map? created))
+            (is (= "doc.txt" (:path created)))
+            (is (pos? (:bytes created)))
+            (when digest-available?
+              (is (= (known-sha256 "hello world") (:digest created))
+                  "the result digest is the new content's real coordinate")))
           (let [st (sb/evaluate! ctx "(project/stat \"doc.txt\")")]
-            (is (:exists st))
-            (is (= :file (:type st))))
+            (is (= :file (:kind st)))
+            (is (= 11 (:bytes st)))
+            (when digest-available?
+              (is (= (known-sha256 "hello world") (:digest st)))))
           (is (= "hello world"
-                 (:content (sb/evaluate! ctx "(project/read \"doc.txt\")"))))
+                 (sb/evaluate! ctx "(project/read \"doc.txt\")")))
           (is (deny? #(sb/evaluate! ctx "(project/read \"../escape\")"))
               "path escape is denied")
           (is (deny? #(sb/evaluate! ctx "(project/edit \"doc.txt\" :absent \"again\")"))
               "no blind overwrite of an existing file")))))
+
+  ;; ─── A2/A3b conformance: project/read ───
+
+  (deftest project-read-is-bounded-strict-utf8-and-symlink-refusing
+    (with-tmp
+      (fn [root]
+        (spit (str root "/a.txt") "hello")
+        (spit (str root "/multi.txt") "héllo — wörld")
+        (fs/create-dirs (str root "/sub"))
+        (fs/create-sym-link (str root "/link.txt") (str root "/a.txt"))
+        (fs/create-sym-link (str root "/linkdir") (str root "/sub"))
+        (write-bytes! (str root "/invalid.txt")
+                      (byte-array [(byte 0x68) (unchecked-byte 0xc3) (byte 0x28)]))
+        (let [ctx (sb/new {:root root :profile :agent/project-develop
+                           :max-read-chars 100})]
+          (is (= "hello" (sb/evaluate! ctx "(project/read \"a.txt\")"))
+              "returns the decoded string, nothing else")
+          (is (= "héllo — wörld" (sb/evaluate! ctx "(project/read \"multi.txt\")"))
+              "multibyte UTF-8 decodes exactly")
+          (is (= "hello" (sb/evaluate! ctx "(project/read \"./a.txt\")"))
+              "lexically normalized paths read the same file")
+          (is (= "hello" (sb/evaluate! ctx "(project/read \"sub/../a.txt\")")))
+          ;; strict UTF-8: malformed input is an error, never mojibake
+          (is (= :invalid-utf8
+                 (thrown-code #(sb/evaluate! ctx "(project/read \"invalid.txt\")"))))
+          ;; bounds fail rather than truncate — consumption stops at the bound
+          (spit (str root "/over-byte.txt") (apply str (repeat 500 "x")))
+          (is (= :too-large
+                 (thrown-code #(sb/evaluate! ctx "(project/read \"over-byte.txt\")")))
+              "the derived byte ceiling (4× the char bound) fails first")
+          (spit (str root "/over-char.txt") (apply str (repeat 350 "y")))
+          (is (= :too-large
+                 (thrown-code #(sb/evaluate! ctx "(project/read \"over-char.txt\")")))
+              "within the byte ceiling but over the char bound still fails")
+          ;; non-regular targets are refused
+          (are [code src] (= code (thrown-code #(sb/evaluate! ctx src)))
+            :not-file "(project/read \"missing.txt\")"
+            :not-file "(project/read \"sub\")"
+            :not-file "(project/read \".\")"
+            :not-file "(project/read \"link.txt\")"
+            :symlink "(project/read \"linkdir/a.txt\")"
+            :path-escape "(project/read \"../outside.txt\")"
+            :absolute-path (str "(project/read \"" root "/a.txt\")"))
+          (is (deny? #(sb/evaluate! ctx "(project/read)"))
+              "exactly one path argument")))))
+
+  ;; ─── A2/A3b conformance: project/list ───
+
+  (deftest project-list-is-exactly-one-level-structured-and-sorted
+    (with-tmp
+      (fn [root]
+        (spit (str root "/b.txt") "bb")
+        (spit (str root "/a.txt") "hello")
+        (fs/create-dirs (str root "/sub/deep"))
+        (spit (str root "/sub/inner.txt") "inner")
+        (fs/create-sym-link (str root "/z-link.txt") (str root "/a.txt")
+                            )
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})
+              entries (sb/evaluate! ctx "(project/list \".\")")]
+          (is (vector? entries))
+          (is (= ["a.txt" "b.txt" "sub" "z-link.txt"]
+                 (mapv :name entries))
+              "one level only, sorted by name — sub's children never appear")
+          (is (= [:file :file :directory :symlink] (mapv :kind entries)))
+          (is (= 5 (:bytes (first entries)))
+              "files carry their byte size")
+          (is (= 2 (:bytes (second entries))))
+          (is (nil? (:bytes (nth entries 2)))
+              "directories carry no :bytes")
+          (is (= [{:name "deep" :kind :directory}
+                  {:name "inner.txt" :kind :file :bytes 5}]
+                 (sb/evaluate! ctx "(project/list \"sub\")"))
+              "listing a subdirectory shows exactly its immediate entries"))
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})]
+          (are [code src] (= code (thrown-code #(sb/evaluate! ctx src)))
+            :not-found "(project/list \"nope\")"
+            :not-found "(project/list \"a.txt\")"
+            :symlink "(project/list \"z-link.txt\")")
+          (is (= [] (sb/evaluate! ctx "(project/list \"sub/deep\")"))
+              "an empty directory lists as an empty vector"))
+        ;; the entry bound fails rather than sampling the directory
+        (dotimes [i 3] (spit (str root "/many" i ".txt") "x"))
+        (let [ctx (sb/new {:root root :profile :agent/project-develop
+                           :max-list-entries 4})]
+          (is (= :too-many-entries
+                 (thrown-code #(sb/evaluate! ctx "(project/list \".\")")))))
+        ;; dot-entries are LISTED (only search hides them by default)
+        (spit (str root "/.dotted.txt") "x")
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})]
+          (is (some #{".dotted.txt"}
+                    (mapv :name (sb/evaluate! ctx "(project/list \".\")"))))))))
+
+  ;; ─── A2/A3b conformance: project/search ───
+
+  (deftest project-search-returns-path-line-text-under-frozen-bounds
+    (with-tmp
+      (fn [root]
+        (fs/create-dirs (str root "/alpha"))
+        (fs/create-dirs (str root "/beta"))
+        (spit (str root "/z.txt") "no match\nneedle last")
+        (spit (str root "/alpha/m.txt") "needle one\nplain")
+        (spit (str root "/beta/k.txt") "  needle padded  ")
+        (spit (str root "/.hidden.txt") "hidden needle")
+        (write-bytes! (str root "/binary.dat")
+                      (byte-array [(byte 0x6e) (unchecked-byte 0xff)]))
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})
+              ms (sb/evaluate! ctx "(project/search \"needle\")")]
+          (is (vector? ms))
+          (is (every? map? ms))
+          (is (= ["alpha/m.txt" "beta/k.txt" "z.txt"] (mapv :path ms))
+              "results are {:path :line :text} maps ordered by path")
+          (is (= [1 1 2] (mapv :line ms)))
+          (is (= "needle one" (:text (first ms))))
+          (is (= "needle padded" (:text (second ms)))
+              "matched text is trimmed")
+          (is (nil? (some #(= ".hidden.txt" (:path %)) ms))
+              "dot-entries are skipped by default")
+          (is (= [".hidden.txt" "alpha/m.txt" "beta/k.txt" "z.txt"]
+                 (mapv :path
+                       (sb/evaluate! ctx "(project/search \"needle\" {:include-hidden? true})")))
+              "dot-entries search with {:include-hidden? true}")
+          (is (= ["alpha/m.txt"]
+                 (mapv :path (sb/evaluate! ctx "(project/search \"needle\" {:path \"alpha\"})")))
+              "{:path …} searches one subtree")
+          ;; binary files are skipped by strict decode, not by name: the
+          ;; file's text prefix would match, but it never decodes
+          (write-bytes! (str root "/binary.dat")
+                        (byte-array (concat (map (fn [^long c] (byte c))
+                                                 (map int "needle"))
+                                            [(unchecked-byte 0xff)])))
+          (is (nil? (some #(= "binary.dat" (:path %))
+                          (sb/evaluate! ctx "(project/search \"needle\")")))
+              "the binary file contributes no match though its text prefix fits")
+          (is (= :not-found
+                 (thrown-code
+                  #(sb/evaluate! ctx "(project/search \"needle\" {:path \"binary.dat\"})")))
+              "a file :path is not a directory — the frozen contract refuses it")
+          ;; a huge file is skipped UNREAD: its bytes are never consumed
+          (spit (str root "/huge.txt") (apply str (repeat 100000 "needle")))
+          (is (= ["alpha/m.txt" "beta/k.txt" "z.txt"]
+                 (mapv :path (sb/evaluate! ctx "(project/search \"needle\")")))
+              "the oversize file is skipped before reading; matches survive"))
+        ;; pattern and argument bounds
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})]
+          (are [code src] (= code (thrown-code #(sb/evaluate! ctx src)))
+            :invalid-regex "(project/search \"[unclosed\")"
+            :invalid-arguments "(project/search \"needle\" \"alpha\")"
+            :invalid-arguments "(project/search)"
+            :invalid-arguments "(project/search \"\")"
+            :path-escape "(project/search \"x\" {:path \"../out\"})")
+          (is (= :invalid-arguments
+                 (thrown-code
+                   #(sb/evaluate! ctx (str "(project/search \""
+                                           (apply str (repeat 201 "a"))
+                                           "\")"))))
+              "patterns over 200 characters are refused"))
+        ;; result and file bounds
+        (let [ctx (sb/new {:root root :profile :agent/project-develop
+                           :max-search-results 2})]
+          (is (= 2 (count (sb/evaluate! ctx "(project/search \"needle\")")))
+              "collection stops at the result bound"))
+        (let [ctx (sb/new {:root root :profile :agent/project-develop
+                           :search-max-files 2})]
+          (is (= :too-many-files
+                 (thrown-code #(sb/evaluate! ctx "(project/search \"x\")")))
+              "more regular files than the file bound fails the search"))
+        ;; symlinked directories are never followed into
+        (fs/create-sym-link (str root "/alpha/slink") (str root "/beta"))
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})]
+          (is (= ["alpha/m.txt"]
+                 (mapv :path (sb/evaluate! ctx "(project/search \"needle\" {:path \"alpha\"})")))
+              "the symlinked subdirectory contributes no matches")))))
+
+  ;; ─── A2/A3b conformance: project/stat ───
+
+  (deftest project-stat-names-the-coordinate-or-fails
+    (with-tmp
+      (fn [root]
+        (spit (str root "/a.txt") "hello")
+        (fs/create-dirs (str root "/sub"))
+        (fs/create-sym-link (str root "/link.txt") (str root "/a.txt"))
+        (fs/create-sym-link (str root "/linkdir") (str root "/sub"))
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})]
+          (let [st (sb/evaluate! ctx "(project/stat \"a.txt\")")]
+            (is (= {:path "a.txt" :kind :file :bytes 5
+                    :digest (known-sha256 "hello")}
+                   st)
+                "a regular file's coordinate is exact — never a nil digest"))
+          (is (= {:path "nope.txt" :kind :absent}
+                 (sb/evaluate! ctx "(project/stat \"nope.txt\")")))
+          (is (= {:path "sub" :kind :directory}
+                 (sb/evaluate! ctx "(project/stat \"sub\")")))
+          (is (= {:path "link.txt" :kind :symlink}
+                 (sb/evaluate! ctx "(project/stat \"link.txt\")"))
+              "a symlink is reported as a link, never followed")
+          (is (= {:path "linkdir" :kind :symlink}
+                 (sb/evaluate! ctx "(project/stat \"linkdir\")"))
+              "a symlinked directory is reported as a link too")
+          (is (= :not-file
+                 (thrown-code #(sb/evaluate! ctx "(project/stat \".\")"))))
+          ;; oversize: the digest read fails closed rather than faking nil
+          (spit (str root "/huge.txt") (apply str (repeat 100000 "x")))
+          (let [narrow (sb/new {:root root :profile :agent/project-develop
+                                :max-read-chars 100})]
+            (is (= :digest-failed
+                   (thrown-code #(sb/evaluate! narrow "(project/stat \"huge.txt\")")))))
+          ;; unreadable: same refusal — a coordinate is computed or absent
+          (when digest-available?
+            (spit (str root "/secret.txt") "s")
+            (fs/set-posix-file-permissions (str root "/secret.txt") "---------")
+            (try
+              (when (deny? #(slurp (str root "/secret.txt")))
+                (is (= :digest-failed
+                       (thrown-code
+                         #(sb/evaluate! ctx "(project/stat \"secret.txt\")")))
+                    "a digest that cannot be read fails the stat — nil is a
+                     fake coordinate, not an absent one"))
+              (finally
+                (fs/set-posix-file-permissions (str root "/secret.txt")
+                                               "rw-------"))))))))
+
+  ;; ─── A2/A3b conformance: project/edit ───
+
+  (deftest project-edit-is-anchored-atomic-and-never-materializes-hierarchy
+    (with-tmp
+      (fn [root]
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})
+              temps (fn [] (filter #(str/includes? (str %) ".samizdat-edit-")
+                                   (map str (fs/list-dir root))))]
+          ;; creation: :absent, leaf only
+          (let [created (sb/evaluate!
+                         ctx "(project/edit \"made.txt\" :absent \"first\")")]
+            (is (= "made.txt" (:path created)))
+            (is (= 5 (:bytes created)))
+            (is (= (known-sha256 "first") (:digest created))))
+          (is (= [] (temps)) "a successful atomic write leaves no temporary")
+          ;; no blind overwrite
+          (let [d (thrown-data #(sb/evaluate!
+                                 ctx "(project/edit \"made.txt\" :absent \"second\")"))]
+            (is (= :already-exists (:samizdat.sandbox/error d)))
+            (is (:bbagent/conflict d) "marked as a conflict like the contract")
+            (is (= (known-sha256 "first") (:conflict/observed d))))
+          ;; anchored update through the stat coordinate
+          (let [digest (get-in (sb/evaluate! ctx "(project/stat \"made.txt\")")
+                               [:digest])]
+            (is (= {:path "made.txt" :bytes 6
+                    :digest (known-sha256 "second")}
+                   (sb/evaluate!
+                    ctx (str "(project/edit \"made.txt\" \"" digest
+                             "\" \"second\")"))))
+            ;; stale: the world moved since the read
+            (let [d (thrown-data
+                     #(sb/evaluate!
+                       ctx (str "(project/edit \"made.txt\" \"" digest
+                                "\" \"third\")")))]
+              (is (= :stale-conflict (:samizdat.sandbox/error d)))
+              (is (:bbagent/conflict d))
+              (is (= (known-sha256 "second") (:conflict/observed d)))
+              (is (= digest (:conflict/expected d)))))
+          ;; a digest base on a missing file is a conflict, not a creation
+          (let [d (thrown-data #(sb/evaluate!
+                                 ctx "(project/edit \"gone.txt\" \"sha256:x\" \"y\")"))]
+            (is (= :not-found (:samizdat.sandbox/error d)))
+            (is (:bbagent/conflict d)))
+          ;; :absent creates ONLY an absent leaf — never a parent hierarchy
+          (is (= :not-found
+                 (thrown-code #(sb/evaluate!
+                                ctx "(project/edit \"new/dir/f.txt\" :absent \"x\")"))))
+          (is (not (fs/exists? (str root "/new")))
+              "no directory was materialized")
+          (is (= [] (temps)) "the failed write left no temporary")
+          ;; write bound and content typing
+          (is (= :invalid-arguments
+                 (thrown-code #(sb/evaluate! ctx "(project/edit \"n.txt\" :absent 42)")))
+              "content must be a string")
+          (let [wide (sb/new {:root root :profile :agent/project-develop
+                              :max-write-bytes 10})]
+            (is (= :write-limit
+                   (thrown-code #(sb/evaluate!
+                                  wide "(project/edit \"w.txt\" :absent \"01234567890123456\")")))))
+          ;; non-regular targets and root confinement
+          (fs/create-dirs (str root "/sub"))
+          (fs/create-sym-link (str root "/made-link.txt") (str root "/made.txt"))
+          (fs/create-sym-link (str root "/sub-link") (str root "/sub"))
+          (are [code src] (= code (thrown-code #(sb/evaluate! ctx src)))
+            :not-file "(project/edit \"sub\" :absent \"x\")"
+            :not-file "(project/edit \"made-link.txt\" :absent \"x\")"
+            :not-file "(project/edit \".\" :absent \"x\")"
+            :path-escape "(project/edit \"../out.txt\" :absent \"x\")"
+            :absolute-path (str "(project/edit \"" root "/made.txt\" :absent \"x\")"))
+          (is (= :symlink
+                 (thrown-code #(sb/evaluate!
+                                ctx "(project/edit \"sub-link/new.txt\" :absent \"x\")")))
+              "a symlinked parent is refused by the descent")
+          (is (= [] (temps))
+              "no failure path left a temporary behind")))))
+
+  ;; ─── Root confinement and authority negatives across all five ops ───
+
+  (deftest root-confinement-and-authority-negatives-are-preserved
+    (with-tmp
+      (fn [root]
+        (spit (str root "/a.txt") "hello")
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})]
+          ;; lexical escapes are refused for every op
+          (are [code src] (= code (thrown-code #(sb/evaluate! ctx src)))
+            :path-escape "(project/read \"../a.txt\")"
+            :path-escape "(project/list \"..\")"
+            :path-escape "(project/search \"x\" {:path \"..\"})"
+            :path-escape "(project/stat \"../a.txt\")"
+            :path-escape "(project/edit \"../a.txt\" :absent \"x\")")
+          ;; absolute paths are refused outright, under-root or not
+          (are [code src] (= code (thrown-code #(sb/evaluate! ctx src)))
+            :absolute-path (str "(project/read \"" root "/a.txt\")")
+            :absolute-path (str "(project/list \"" root "\")")
+            :absolute-path (str "(project/stat \"" root "/a.txt\")")
+            :absolute-path (str "(project/edit \"" root "/a.txt\" :absent \"x\")"))
+          ;; a symlink pointing outside the root never widens a read
+          (fs/create-sym-link (str root "/out-link.txt") "/etc/hostname")
+          (is (= :not-file
+                 (thrown-code #(sb/evaluate! ctx "(project/read \"out-link.txt\")"))))
+          (is (= {:path "out-link.txt" :kind :symlink}
+                 (sb/evaluate! ctx "(project/stat \"out-link.txt\")"))
+              "an escaping link is reported as a link, never followed")
+          ;; the vocabulary's introspection negatives still hold
+          (is (deny? #(sb/evaluate! ctx "(resolve 'project/read)")))
+          (is (deny? #(sb/evaluate! ctx "(find-ns 'project)")))
+          (is (deny? #(sb/evaluate! ctx "(eval (read-string \"(+ 1 2)\"))")))))))
 
   ;; ─── rebuild!: fresh context, stable identity ───
 
@@ -408,7 +858,7 @@
               (is (= [:project/edit] (mapv :op (:receipts record))))
               (is (= [:done] (mapv :phase (:receipts record))))
               (is (= "recorded" (slurp (str root "/once.txt"))))
-              (is (:exists (sb/evaluate! b "(project/stat \"once.txt\")"))
+              (is (= :file (:kind (sb/evaluate! b "(project/stat \"once.txt\")")))
                   "the durable hook is removed before ordinary evaluation resumes")
 
               ;; If replay reaches the real edit it conflicts with this existing
@@ -467,7 +917,7 @@
                                 {:preset :project/develop :root root})
                     {:keys [eval-id]}
                     (sb/evaluate-recorded!
-                      conn b "(project/edit \"coord.txt\" :absent \"c\")")
+                     conn b "(project/edit \"coord.txt\" :absent \"c\")")
                     record (get-in @conn [:records eval-id])]
                 ;; The identity handed to verify-binding! carries the exact
                 ;; current spec coordinate — the fourth field the store
@@ -487,7 +937,7 @@
                                    {:preset :project/develop :root root})
                       {:keys [eval-id]}
                       (sb/evaluate-recorded!
-                        conn2 b2 "(project/edit \"coord2.txt\" :absent \"c2\")")]
+                       conn2 b2 "(project/edit \"coord2.txt\" :absent \"c2\")")]
                   (fs/delete (str root "/coord2.txt"))
                   (reset! conn2 (-> @conn2
                                     (assoc :events [])
@@ -544,6 +994,269 @@
               (is (= 2 (sb/evaluate! b "(+ 1 1)"))
                   "denied rebuild releases instance ownership")
               )))))))
+
+(when sandbox-ns-resolved?
+
+  ;; ─── RuntimeCoordinate: versioned, names the whole runtime stack ───
+
+  (deftest runtime-coordinate-is-versioned-and-names-the-runtime-stack
+    (let [rc (sb/runtime-coordinate)
+          snap (sb/runtime-snapshot)]
+      (is (str/starts-with? rc "js1-rt/v1:"))
+      (is (= rc (sb/runtime-coordinate)) "deterministic within the process")
+      (is (= (jolt.host/jolt-version) (:runtime/jolt snap))
+          "names the Jolt version")
+      (is (= "sci-0.13.53" (:runtime/sci snap))
+          "names the vendored SCI coordinate")
+      (is (= 2 (:runtime/evaluator-protocol snap))
+          "protocol v2: the normalized frozen-contract operation semantics")
+      (is (str/starts-with? (:runtime/language snap) "js0-lang/v1:")
+          "names the reviewed language surface's own versioned coordinate")
+      (is (str/starts-with? (:runtime/capability-catalog snap) "js0:")
+          "names the capability catalog by content coordinate")
+      (is (= 1 (:runtime/capability-catalog-version snap)))
+      (is (= 1 (:runtime/receipt-protocol snap)))
+      (with-tmp
+        (fn [root]
+          (let [b (sb/bind! (sb/provider) "rt-work"
+                            {:preset :project/develop :root root})]
+            (is (= rc (:samizdat.sandbox/runtime-coordinate (sb/describe b)))
+                "describe exposes the runtime coordinate"))))))
+
+  ;; ─── Whole-history rebuild: cross-eval state, zero real operations ───
+
+  (deftest cross-eval-helper-survives-whole-history-rebuild
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  p (sb/provider)
+                  b (sb/bind! p "history-work" {:preset :project/develop :root root})]
+              (sb/evaluate-recorded! conn b "(defn helper [x] (* 2 x))")
+              (sb/evaluate-recorded! conn b (str "(def answer (helper 21)) "
+                                                 "(project/edit \"h.txt\" :absent \"hist\") "
+                                                 "(project/read \"h.txt\")"))
+              (is (deny? #(sb/evaluate-recorded! conn b "(def ghost 9) (no-such-fn)"))
+                  "a failing evaluation between committed ones propagates")
+              (let [b2 (sb/bind! p "history-work" {:preset :project/develop :root root})]
+                (sb/evaluate-recorded! conn b2 "(def later (inc answer))")
+                (is (= [0 1 2 3]
+                       (mapv :binding_seq
+                             (memory-history conn (:binding/id b2))))
+                    "the binding's evaluations form a durable total order")
+                (is (= [:completed :completed :failed :completed]
+                       (mapv :status (memory-history conn (:binding/id b2)))))
+                ;; Replay must serve the edit AND the read from receipts:
+                ;; tampering with the file means a real edit conflicts
+                ;; (:absent on an existing file) and a real read returns
+                ;; different content than the recorded receipt.
+                (spit (str root "/h.txt") "tampered")
+                (let [b3 (sb/rebuild-binding! conn b2)]
+                  (is (= (:binding/id b2) (:binding/id b3)))
+                  (is (= (:instance/id b2) (:instance/id b3)))
+                  (is (= 42 (sb/evaluate! b3 "answer"))
+                      "a def from an earlier committed eval survived the rebuild")
+                  (is (= 84 (sb/evaluate! b3 "(helper answer)"))
+                      "the cross-eval helper survived the rebuild")
+                  (is (= 43 (sb/evaluate! b3 "later"))
+                      "the eval committed after the failure replayed")
+                  (is (deny? #(sb/evaluate! b3 "ghost"))
+                      "the failed eval's def never committed and never replayed")
+                  (is (= "tampered" (slurp (str root "/h.txt")))
+                      "whole-history replay invoked zero real project operations")))))))))
+
+  ;; ─── Commit-only state: failed / interrupted evals roll back ───
+
+  (deftest failed-recorded-eval-rolls-back-to-committed-state
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  p (sb/provider)
+                  b (sb/bind! p "fail-work" {:preset :project/develop :root root})]
+              (sb/evaluate-recorded! conn b "(defn helper [x] (* 2 x))")
+              (is (deny? #(sb/evaluate-recorded! conn b "(def partial-def 1) (no-such-fn)"))
+                  "the failing evaluation propagates its error")
+              (is (= :failed (:status (get-in @conn [:records 2])))
+                  "the failure is durably recorded as failed, not pending")
+              (is (= :stale-binding
+                     (:samizdat.sandbox/error
+                      (thrown-data #(sb/evaluate-recorded! conn b "1"))))
+                  "the pre-rollback binding is superseded; re-acquire it")
+              (let [b2 (sb/bind! p "fail-work" {:preset :project/develop :root root})]
+                (is (= 10 (sb/evaluate! b2 "(helper 5)"))
+                    "committed state survived the rollback")
+                (is (deny? #(sb/evaluate! b2 "partial-def"))
+                    "the failed eval's partial def never became evaluator state"))))))))
+
+  (deftest interrupted-recorded-eval-rolls-back-to-committed-state
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  p (sb/provider)
+                  b (sb/bind! p "interrupt-work" {:preset :project/develop
+                                                  :root root
+                                                  :timeout-ms 250})]
+              (sb/evaluate-recorded! conn b "(defn helper2 [x] (inc x))")
+              ;; The bounded loop is long enough that the host interrupt
+              ;; lands mid-eval (an uninterruptible loop would finish in
+              ;; seconds and fail the test instead of hanging it).
+              (let [data (thrown-data
+                          #(sb/evaluate-recorded!
+                            conn b
+                            "(def interrupted-def 1) (loop [i 20000000] (if (pos? i) (recur (dec i)) :done))"))]
+                (is (= :timeout (:samizdat.sandbox/error data))
+                    "the host interrupt surfaces as a timeout"))
+              (is (= :failed (:status (get-in @conn [:records 2])))
+                  "the interruption is durably recorded as failed, not pending")
+              (let [b2 (sb/bind! p "interrupt-work" {:preset :project/develop
+                                                     :root root
+                                                     :timeout-ms 250})]
+                (is (= 6 (sb/evaluate! b2 "(helper2 5)"))
+                    "committed state survived the interruption rollback")
+                (is (deny? #(sb/evaluate! b2 "interrupted-def"))
+                    "the interrupted eval's partial def never became evaluator state"))))))))
+
+  (deftest uncompletable-failure-poisons-the-instance
+    (with-tmp
+      (fn [root]
+        (let [failing-store
+              (assoc memory-eval-store
+                     :complete!
+                     (fn [conn eval-id m]
+                       (if (= :failed (:status m))
+                         (throw (ex-info "simulated completion append failure" {}))
+                         ((:complete! memory-eval-store) conn eval-id m))))]
+          (with-eval-store failing-store
+            (fn []
+              (let [conn (memory-db)
+                    p (sb/provider)
+                    b (sb/bind! p "poison-work" {:preset :project/develop :root root})]
+                (sb/evaluate-recorded! conn b "(def kept 1)")
+                (is (= :durable-evaluation-incomplete
+                       (:samizdat.sandbox/error
+                        (thrown-data #(sb/evaluate-recorded! conn b "(no-such-fn)"))))
+                    "an unrecordable failure surfaces as durable-incomplete")
+                (is (= :instance-poisoned
+                       (:samizdat.sandbox/error
+                        (thrown-data #(sb/evaluate! b "kept"))))
+                    "the poisoned instance refuses evaluation")
+                (is (= :pending-history
+                       (:samizdat.sandbox/error
+                        (thrown-data #(sb/rebuild-binding! conn b))))
+                    "the pending record blocks whole-history rebuild: fail closed"))))))))
+
+  ;; ─── Whole-history rebuild: fail closed on pending / mismatch / gaps ───
+
+  (deftest whole-history-rebuild-fails-closed-on-pending-mismatch-and-gaps
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  p (sb/provider)
+                  b (sb/bind! p "guard-work" {:preset :project/develop :root root})
+                  e1 (:eval-id (sb/evaluate-recorded!
+                                conn b "(project/edit \"g.txt\" :absent \"made\")"))
+                  original (get-in @conn [:records e1])]
+              (fs/delete (str root "/g.txt"))
+
+              ;; A pending record with an unsettled effect intent: the
+              ;; actuation may or may not have happened — refuse.
+              (let [e2 (memory-begin! conn {:spec-id (:spec_id original)
+                                            :instance-id (:instance_id original)
+                                            :binding-id (:binding_id original)
+                                            :coordinate (:coordinate original)
+                                            :runtime (:runtime original)
+                                            :source "(project/edit \"g2.txt\" :absent \"maybe\")"})]
+                (memory-record-intent! conn e2 {:op :project/edit
+                                                :args ["g2.txt" :absent "maybe"]})
+                (is (= :pending-history
+                       (:samizdat.sandbox/error
+                        (thrown-data #(sb/rebuild-binding! conn b))))
+                    "a pending record with an unsettled effect fails closed")
+                (is (not (fs/exists? (str root "/g2.txt")))
+                    "the denial performed no project actuation")
+                (reset! conn (update @conn :records dissoc e2)))
+
+              ;; Authority-coordinate mismatch in the history: refuse.
+              (reset! conn (assoc-in @conn [:records e1 :coordinate] "js0:forged"))
+              (is (= :history-mismatch
+                     (:samizdat.sandbox/error
+                      (thrown-data #(sb/rebuild-binding! conn b))))
+                  "a coordinate mismatch fails closed")
+              (reset! conn (assoc-in @conn [:records e1 :coordinate]
+                                     (:coordinate original)))
+
+              ;; Runtime-coordinate mismatch: refuse.
+              (reset! conn (assoc-in @conn [:records e1 :runtime] "js1-rt/v1:forged"))
+              (is (= :history-mismatch
+                     (:samizdat.sandbox/error
+                      (thrown-data #(sb/rebuild-binding! conn b))))
+                  "a runtime mismatch fails closed")
+              (reset! conn (assoc-in @conn [:records e1 :runtime]
+                                     (:runtime original)))
+
+              ;; A gap in the binding's total order: refuse.
+              (reset! conn (assoc-in @conn [:records e1 :binding_seq] 5))
+              (is (= :malformed-history
+                     (:samizdat.sandbox/error
+                      (thrown-data #(sb/rebuild-binding! conn b))))
+                  "a non-contiguous total order fails closed")
+              (reset! conn (assoc-in @conn [:records e1 :binding_seq] 0))
+
+              ;; Clean history rebuilds — and the deleted file stays deleted:
+              ;; the edit was served from its receipt, never really re-run.
+              (let [b2 (sb/rebuild-binding! conn b)]
+                (is (map? b2) "a validated history rebuilds")
+                (is (not (fs/exists? (str root "/g.txt")))
+                    "the successful replay invoked zero real operations"))))))))
+
+  ;; ─── Bounded rendered final results: arbitrary SCI values accepted ───
+
+  (deftest noncanonical-final-results-are-rendered-bounded-and-accepted
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  p (sb/provider)
+                  b (sb/bind! p "render-work" {:preset :project/develop :root root})]
+              (let [{:keys [eval-id value]}
+                    (sb/evaluate-recorded! conn b "(map inc [1 2 3])")
+                    record (get-in @conn [:records eval-id])]
+                (is (= [2 3 4] (vec value)) "the caller gets the live value")
+                (is (= :completed (:status record))
+                    "a non-inert final value still commits")
+                (is (= {:rendered "(2 3 4)" :render-truncated? false}
+                       (:result record))
+                    "stored as a bounded rendering, not refused"))
+              (let [{:keys [eval-id]} (sb/evaluate-recorded! conn b "1.5")]
+                (is (= {:rendered "1.5" :render-truncated? false}
+                       (:result (get-in @conn [:records eval-id])))))
+              (let [{:keys [eval-id]} (sb/evaluate-recorded! conn b "{:a [1 2]}")]
+                (is (= {:value {:a [1 2]}}
+                       (:result (get-in @conn [:records eval-id])))
+                    "inert final values stay exact"))
+              (let [hundred-as (apply str (repeat 100 "a"))
+                    src (str "(map (fn [_] \"" hundred-as "\") (range 500))")
+                    {:keys [eval-id]} (sb/evaluate-recorded! conn b src)
+                    result (:result (get-in @conn [:records eval-id]))]
+                (is (:render-truncated? result))
+                (is (= 8000 (count (:rendered result)))
+                    "the rendering is character-bounded"))
+              (let [b2 (sb/rebuild-binding! conn b)]
+                (is (map? b2)
+                    "a history of rendered results replays by rendering comparison"))
+              ;; The rebuild superseded b; re-acquire before recording again.
+              (let [b3 (sb/bind! p "render-work" {:preset :project/develop :root root})
+                    {:keys [eval-id]} (sb/evaluate-recorded! conn b3 "(fn [x] x)")]
+                (is (string? (:rendered (:result (get-in @conn [:records eval-id]))))
+                    "even a function value is accepted at record time")))))))))
 
 ;; Self-run only on explicit request (the direct -Scp invocation in the
 ;; docstring).  `jolt -M:test` requires this namespace without SCI on the

--- a/test/samizdat/sandbox_test.clj
+++ b/test/samizdat/sandbox_test.clj
@@ -1,0 +1,558 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.sandbox-test
+  "JS1 EvaluatorSpec / Instance / Binding seam tests (deterministic, offline).
+
+   The sandbox needs jolt.sandbox, which needs the vendored SCI source and
+   its Maven deps on the source roots — none of which are in samizdat's
+   deps.edn.  Direct invocation (from the samizdat project dir), with
+   explicit -Scp roots so no dependency is expanded or fetched (one
+   line; M2 is $HOME/.m2/repository):
+
+     SAMIZDAT_SANDBOX_TEST_RUN=1 JOLT_CHEZ=/usr/local/bin/scheme JOLT_QUIET=1 /home/chuck/opencode/src/jolt/bin/jolt -Scp "$PWD/src:$PWD/test:/home/chuck/opencode/src/jolt/vendor/sci/src:$M2/borkdude/edamame/1.5.39/edamame-1.5.39.jar.jolt:$M2/org/babashka/sci.impl.types/0.0.3/sci.impl.types-0.0.3.jar.jolt:$M2/borkdude/graal.locking/0.0.2/graal.locking-0.0.2.jar.jolt:$M2/org/clojure/tools.reader/1.5.2/tools.reader-1.5.2.jar.jolt" run "$PWD/test/samizdat/sandbox_test.clj"
+
+   (The .jar.jolt directories are jolt's extracted-jar layout beside each
+   cached Maven artifact; -Scp takes source roots verbatim.)
+
+   Under plain `jolt -M:test` the SCI deps are absent, the sandbox ns
+   fails to resolve, and every test here skips: this file defines its
+   tests only when the require succeeds, and self-runs only when
+   SAMIZDAT_SANDBOX_TEST_RUN=1, so the suite runner never double-runs it."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is are] :as t]
+            [jolt.fs :as fs]))
+
+(def ^:private sandbox-ns-resolved?
+  ;; In self-run mode (the direct -Scp invocation) require loudly: a
+  ;; compile error in the sandbox ns must fail the run, not masquerade
+  ;; as "SCI absent, skipping".  Under the suite runner (-M:test, no SCI
+  ;; roots) the catch converts the absent dep into a quiet skip.
+  (if (= "1" (jolt.host/getenv "SAMIZDAT_SANDBOX_TEST_RUN"))
+    (do (require 'samizdat.agent.sandbox) true)
+    (try (require 'samizdat.agent.sandbox) true
+         (catch Throwable _ false))))
+
+(when sandbox-ns-resolved?
+  (require '[samizdat.agent.sandbox :as sb]))
+
+(defn- with-tmp [f]
+  (let [root (str "/tmp/samizdat-sandbox-" (random-uuid))]
+    (fs/create-dirs root)
+    (try (f root) (finally (fs/delete-tree root)))))
+
+(defn- deny? [f]
+  (try (f) false (catch Throwable _ true)))
+
+;; Small append-only implementation of the samizdat.store.evals contract.
+;; The direct Jolt+SCI invocation intentionally has no DB dependency on its
+;; classpath; production resolves the real store dynamically.  Keeping this
+;; adapter as data exercises that exact dynamic seam without weakening the
+;; bridge to transcript mocks.
+(defn- memory-db []
+  (atom {:next-id 1 :records {} :events []}))
+
+(defn- memory-event! [conn event]
+  (reset! conn (update @conn :events conj event)))
+
+(defn- memory-begin! [conn intent]
+  (let [id (:next-id @conn)
+        record (assoc intent :id id :status :pending :result nil :receipts [])]
+    (reset! conn (-> @conn
+                     (assoc :next-id (inc id))
+                     (assoc-in [:records id] record)))
+    id))
+
+(defn- memory-record-intent! [conn eval-id {:keys [op args]}]
+  (let [record (get-in @conn [:records eval-id])]
+    (when-not (= :pending (:status record))
+      (throw (ex-info "evaluation is not pending" {:eval-id eval-id})))
+    (let [n (count (:receipts record))
+          receipt {:seq n :op op :args args :phase :intent}]
+      (reset! conn (update-in @conn [:records eval-id :receipts] conj receipt))
+      n)))
+
+(defn- memory-record-outcome! [conn eval-id n outcome]
+  (let [receipt (get-in @conn [:records eval-id :receipts n])]
+    (when-not (= :intent (:phase receipt))
+      (throw (ex-info "outcome needs one unsettled intent"
+                      {:eval-id eval-id :seq n})))
+    (let [settled (if (contains? outcome :result)
+                    (assoc receipt :phase :done :result (:result outcome))
+                    (assoc receipt :phase :error :error (:error outcome)))]
+      (reset! conn (assoc-in @conn [:records eval-id :receipts n] settled))
+      n)))
+
+(defn- memory-complete! [conn eval-id {:keys [status result]}]
+  (let [record (get-in @conn [:records eval-id])]
+    (when-not (= :pending (:status record))
+      (throw (ex-info "evaluation already terminal" {:eval-id eval-id})))
+    (when (some #(= :intent (:phase %)) (:receipts record))
+      (throw (ex-info "unsettled effect" {:eval-id eval-id})))
+    (reset! conn (-> @conn
+                     (assoc-in [:records eval-id :status] status)
+                     (assoc-in [:records eval-id :result] result)))
+    true))
+
+(defn- memory-load-eval [conn eval-id]
+  (memory-event! conn :load)
+  (get-in @conn [:records eval-id]))
+
+(defn- memory-verify-binding!
+  "Mirrors samizdat.store.evals/verify-binding!: all four durable identity
+  fields — spec, instance, binding, AND the exact spec coordinate — must
+  match, so a caller that omits the coordinate (or holds stale authority)
+  is denied exactly as the real store denies it."
+  [conn eval-id identity]
+  (memory-event! conn :verify)
+  (let [record (get-in @conn [:records eval-id])]
+    (when-not (and record
+                   (= (:spec-id identity) (:spec-id record))
+                   (= (:instance-id identity) (:instance-id record))
+                   (= (:binding-id identity) (:binding-id record))
+                   (= (:coordinate identity) (:coordinate record)))
+      (throw (ex-info "durable evaluation binding mismatch"
+                      {:eval-id eval-id})))
+    true))
+
+(def ^:private memory-eval-store
+  {:begin! memory-begin!
+   :record-intent! memory-record-intent!
+   :record-outcome! memory-record-outcome!
+   :complete! memory-complete!
+   :load-eval memory-load-eval
+   :verify-binding! memory-verify-binding!})
+
+(defn- with-eval-store
+  "Run `f` with the sandbox's durable-eval seam set to `store` (the memory
+  adapter, or a wrapper over it).  alter-var-root on a runtime-resolved
+  var, NOT `binding`: jolt analyzes binding's var at load time, but this
+  file must stay loadable — quietly skipped — where SCI, and with it the
+  `sb` alias, is absent (the `jolt -M:test` suite shape).  The root (nil
+  in production) is restored afterward."
+  [store f]
+  (let [v (resolve 'samizdat.agent.sandbox/*eval-store*)
+        original (deref v)]
+    (alter-var-root v (constantly store))
+    (try (f)
+         (finally (alter-var-root v (constantly original))))))
+
+(when sandbox-ns-resolved?
+
+  ;; ─── EvaluatorSpec: trusted catalog, inert self-certifying coordinate ───
+
+  (deftest spec-coordinate-is-deterministic-and-content-addressed
+    (with-tmp
+      (fn [root]
+        (let [s1 (sb/spec :project/develop {:root root})
+              s2 (sb/spec :project/develop {:root root})
+              s3 (sb/spec :project/develop {:root root
+                                            :capabilities #{:project/read}})]
+          (is (= :evaluator-spec (:samizdat.sandbox/kind s1)))
+          (is (= :agent/project-develop (:profile s1)))
+          (is (= [:project/edit :project/list :project/read
+                  :project/search :project/stat]
+                 (:capabilities s1))
+              "preset capabilities are explicit and sorted")
+          (is (= 30000 (:timeout-ms s1)))
+          (is (= #{:max-read-chars :max-list-entries
+                   :max-search-results :search-max-chars}
+                 (set (keys (:bounds s1)))))
+          (is (= (:spec/coordinate s1) (:spec/coordinate s2))
+              "same content, same coordinate")
+          (is (not= (:spec/coordinate s1) (:spec/coordinate s3))
+              "narrower capabilities change the coordinate")
+          (is (str/starts-with? (:spec/coordinate s1) "js1:"))
+          (is (= (str (fs/canonicalize root)) (:root s1)))))))
+
+  (deftest spec-catalog-is-closed-and-attenuation-only
+    (with-tmp
+      (fn [root]
+        (is (deny? #(sb/spec :no/such-preset {:root root}))
+            "unknown preset is denied")
+        (is (deny? #(sb/spec :project/read
+                             {:root root :capabilities #{:project/edit}}))
+            "controller cannot select capabilities beyond the preset")
+        (is (deny? #(sb/spec :project/read {}))
+            "a trusted root is required")
+        (is (deny? #(sb/spec :project/read {:root root :max-read-chars 0}))
+            "bounds must be positive")
+        (is (= #{:project/read :project/list :project/search :project/stat}
+               (set (:capabilities
+                     (sb/spec :project/read {:root root}))))
+            "the read preset carries exactly the observation ops"))))
+
+  ;; ─── Provider: JS1 :main policy, binding persistence, isolation ───
+
+  (deftest same-binding-preserves-def
+    (with-tmp
+      (fn [root]
+        (let [p (sb/provider)
+              b (sb/bind! p "work-1" {:preset :project/develop :root root})]
+          (is (= 7 (sb/evaluate! b "(def kept 6) (inc kept)")))
+          (is (= 42 (sb/evaluate! b "(* kept 7)"))
+              "the same binding evaluates in the same persistent context")
+          (let [b2 (sb/bind! p "work-1" {:preset :project/develop :root root})]
+            (is (= (:binding/id b) (:binding/id b2))
+                "rebinding a work-id is idempotent")
+            (is (= 42 (sb/evaluate! b2 "(* kept 7)"))
+                "ordinary work deterministically shares the :main instance"))))))
+
+  (deftest a-second-instance-is-isolated
+    (with-tmp
+      (fn [root]
+        (let [p (sb/provider)
+              main (sb/bind! p "work-main" {:preset :project/develop :root root})
+              _ (sb/evaluate! main "(def shared-secret 1)")
+              side (sb/bind! p "work-side" {:preset :project/develop
+                                            :root root
+                                            :instance/key :side})]
+          (is (= "inst:main" (:instance/id main)))
+          (is (= "inst:side" (:instance/id side)))
+          (is (deny? #(sb/evaluate! side "shared-secret"))
+              "a second controller-created instance lacks the def")
+          (is (= 2 (sb/evaluate! main "(inc shared-secret)"))
+              "the persistent :main instance is undisturbed")))))
+
+  (deftest instance-spec-conflict-fails-closed
+    (with-tmp
+      (fn [root]
+        (let [p (sb/provider)]
+          (sb/bind! p "w1" {:preset :project/develop :root root})
+          (is (deny? #(sb/bind! p "w2" {:preset :project/read :root root}))
+              "a different spec for :main conflicts instead of silently widening")
+          (is (deny? #(sb/bind! p "w1" {:preset :project/develop
+                                        :root root :instance/key :other}))
+              "rebinding a work-id to a different instance conflicts")))))
+
+  ;; ─── Authority: controller attenuation cannot be widened from source ───
+
+  (deftest narrowed-authority-cannot-widen-via-source
+    (with-tmp
+      (fn [root]
+        (spit (str root "/a.txt") "hello")
+        (let [p (sb/provider)
+              b (sb/bind! p "work-ro" {:preset :project/develop
+                                       :root root
+                                       :instance/key :narrow
+                                       :capabilities #{:project/read}})]
+          (is (= "hello" (:content (sb/evaluate! b "(project/read \"a.txt\")")))
+              "the granted op still works")
+          (is (deny? #(sb/evaluate! b "(project/edit \"a.txt\" :absent \"x\")"))
+              "source cannot invoke a capability the controller did not grant")
+          (is (deny? #(sb/evaluate! b "(jolt.host/getenv \"HOME\")"))
+              "source cannot reach host authority outside the projection")
+          (is (= [:project/read] (sb/capabilities b))
+              "capability discovery reads effective authority")
+          (is (deny? #(sb/evaluate! b "1" {:preset :project/develop}))
+              "evaluation rejects preset selection")
+          (is (deny? #(sb/evaluate! b "1" {:capabilities #{:project/edit}}))
+              "evaluation rejects capability selection")
+          (is (deny? #(sb/evaluate! b "1" {:profile :agent/project-develop}))
+              "evaluation rejects profile selection")
+          (is (deny? #(sb/acquire! p (assoc (:spec b)
+                                            :capabilities [:project/read
+                                                           :project/edit])
+                                   {:instance/key :crafted}))
+              "a hand-edited spec fails the coordinate integrity check")))))
+
+  ;; ─── describe: the three coordinates, inert and distinguishable ───
+
+  (deftest describe-carries-binding-spec-and-instance-ids
+    (with-tmp
+      (fn [root]
+        (let [p (sb/provider)
+              b (sb/bind! p "work-9" {:preset :project/read :root root})
+              d (sb/describe b)]
+          (is (= :binding (:samizdat.sandbox/kind d)))
+          (is (= "bind:main:work-9" (:samizdat.sandbox/binding-id d)))
+          (is (= "work-9" (:samizdat.sandbox/work-id d)))
+          (is (= "inst:main" (:samizdat.sandbox/instance-id d)))
+          (is (= :main (:samizdat.sandbox/instance-key d)))
+          (is (= :project/read (:samizdat.sandbox/preset d)))
+          (is (str/starts-with? (:samizdat.sandbox/spec-coordinate d) "js1:"))
+          (is (= (str (fs/canonicalize root))
+                 (:samizdat.sandbox/root-canonical d)))
+          (is (= 30000 (:samizdat.sandbox/timeout-ms d)))
+          (is (= #{:project/read :project/list :project/search :project/stat}
+                 (set (sb/capabilities d)))
+              "capabilities can be discovered from a describe map")
+          ;; A legacy direct context has the spec coordinate but no
+          ;; preset, instance, or binding identity.
+          (let [ctx (sb/new {:root root :profile :agent/project-read})
+                dc (sb/describe ctx)]
+            (is (= :context (:samizdat.sandbox/kind dc)))
+            (is (str/starts-with? (:samizdat.sandbox/spec-coordinate dc) "js1:"))
+            (is (nil? (:samizdat.sandbox/preset dc)))
+            (is (nil? (:samizdat.sandbox/instance-id dc)))
+            (is (nil? (:samizdat.sandbox/binding-id dc))))))))
+
+  ;; ─── Safe discovery: host-derived over effective authority ───
+
+  (deftest safe-discovery-is-host-derived-over-effective-authority
+    (with-tmp
+      (fn [root]
+        (spit (str root "/d.txt") "x")
+        (let [p (sb/provider)
+              ro (sb/bind! p "disc-ro" {:preset :project/develop :root root
+                                        :capabilities #{:project/read}})
+              dev (sb/bind! p "disc-dev" {:preset :project/develop :root root
+                                          :instance/key :dev})]
+          ;; doc describes a granted capability from inert authority data
+          (let [d (sb/operation-doc ro "project/read")]
+            (is (map? d))
+            (is (= "project/read" (:name d)))
+            (is (= '[rel-path] (first (:arglists d))))
+            (is (str/includes? (:doc d) "observation")))
+          (is (= "project/read" (:name (sb/operation-doc ro ":project/read")))
+              "a leading colon is tolerated")
+          ;; an ungranted capability is not discoverable
+          (is (nil? (sb/operation-doc ro "project/edit")))
+          ;; hostile symbol text is inert data to match, never source to run
+          (is (nil? (sb/operation-doc ro
+                                      "project/read (jolt.host/getenv \"HOME\")")))
+          (is (nil? (sb/operation-doc ro "project/read\" (do (evil))")))
+          (is (nil? (sb/operation-doc ro 42)))
+          ;; the full develop preset discovers its edit op, with arglists
+          (let [d (sb/operation-doc dev "project/edit")]
+            (is (= "project/edit" (:name d)))
+            (is (= '[rel-path base-digest new-content] (first (:arglists d))))
+            (is (str/includes? (:doc d) "actuation")))
+          ;; completion: authorized projected names only, prefix-narrowed
+          (is (= ["project/read"] (sb/complete-capability ro "")))
+          (is (= ["project/read"] (sb/complete-capability ro "project/r")))
+          (is (= [] (sb/complete-capability ro "project/e")))
+          (is (= [] (sb/complete-capability ro "read")))
+          (is (= 5 (count (sb/complete-capability dev ""))))
+          (is (= ["project/read"] (sb/complete-capability dev "project/re")))
+          ;; a hostile prefix can only narrow; it never evaluates or errors
+          (is (= [] (sb/complete-capability dev "\" (do (evil))")))
+          ;; the sandbox vocabulary denies the forbidden introspection forms
+          ;; outright — host-derived discovery is the only door to them
+          (is (deny? #(sb/evaluate! ro "(resolve 'project/read)")))
+          (is (deny? #(sb/evaluate! ro "(find-ns 'project)")))
+          (is (deny? #(sb/evaluate! ro "(ns-publics 'project)")))
+          (is (deny? #(sb/evaluate! ro "(meta 'project/read)")))
+          ;; discovery claims no evaluation ownership: eval still works
+          (is (= 2 (sb/evaluate! ro "(inc 1)")))))))
+
+  ;; ─── Semantic ops still behave under the seam ───
+
+  (deftest semantic-ops-bounded-anchored-and-confined
+    (with-tmp
+      (fn [root]
+        (let [ctx (sb/new {:root root :profile :agent/project-develop})]
+          (let [created (sb/evaluate! ctx "(project/edit \"doc.txt\" :absent \"hello world\")")]
+            (is (:created? created))
+            ;; Digests come from files/file-digest, which needs the
+            ;; jolt-crypto natives; under the offline -Scp roots those are
+            ;; absent and the digest is nil (fail-closed: updates then
+            ;; stale-conflict rather than blindly overwriting).
+            (is (or (nil? (:digest created))
+                    (str/starts-with? (:digest created) "sha256:"))))
+          (let [st (sb/evaluate! ctx "(project/stat \"doc.txt\")")]
+            (is (:exists st))
+            (is (= :file (:type st))))
+          (is (= "hello world"
+                 (:content (sb/evaluate! ctx "(project/read \"doc.txt\")"))))
+          (is (deny? #(sb/evaluate! ctx "(project/read \"../escape\")"))
+              "path escape is denied")
+          (is (deny? #(sb/evaluate! ctx "(project/edit \"doc.txt\" :absent \"again\")"))
+              "no blind overwrite of an existing file")))))
+
+  ;; ─── rebuild!: fresh context, stable identity ───
+
+  (deftest rebuild-clears-definitions-and-keeps-identity
+    (with-tmp
+      (fn [root]
+        (let [p (sb/provider)
+              b (sb/bind! p "work-r" {:preset :project/develop :root root})]
+          (sb/evaluate! b "(def ephemeral 5)")
+          (let [b2 (sb/rebuild! b)]
+            (is (= (:binding/id b) (:binding/id b2))
+                "binding id is stable across rebuild")
+            (is (= (:instance/id b) (:instance/id b2))
+                "instance id is stable across rebuild")
+            (is (deny? #(sb/evaluate! b2 "ephemeral"))
+                "rebuild yields a fresh context")
+            (let [b3 (sb/bind! p "work-r2" {:preset :project/develop :root root})]
+              (is (deny? #(sb/evaluate! b3 "ephemeral"))
+                  "the provider registry sees the rebuilt instance"))))
+        (let [ctx (sb/new {:root root :profile :agent/project-read})]
+          (sb/evaluate! ctx "(def z 9)")
+          (is (= 9 (sb/evaluate! ctx "z")))
+           (is (deny? #(sb/evaluate! (sb/rebuild! ctx) "z"))
+               "legacy contexts rebuild fresh as well"))))))
+
+(when sandbox-ns-resolved?
+
+  ;; ─── Durable JS1 bridge: intent/outcome and hermetic exact replay ───
+
+  (deftest recorded-rebuild-restores-definitions-without-repeating-real-ops
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  p (sb/provider)
+                  b (sb/bind! p "recorded" {:preset :project/develop :root root})
+                  source (str "(def rebuilt-value 40) "
+                              "(project/edit \"once.txt\" :absent \"recorded\") "
+                              "(inc rebuilt-value)")
+                  {:keys [eval-id value]} (sb/evaluate-recorded! conn b source)
+                  record (get-in @conn [:records eval-id])]
+              (is (= 41 value))
+              (is (= :completed (:status record)))
+              (is (= [0] (mapv :seq (:receipts record))))
+              (is (= [:project/edit] (mapv :op (:receipts record))))
+              (is (= [:done] (mapv :phase (:receipts record))))
+              (is (= "recorded" (slurp (str root "/once.txt"))))
+              (is (:exists (sb/evaluate! b "(project/stat \"once.txt\")"))
+                  "the durable hook is removed before ordinary evaluation resumes")
+
+              ;; If replay reaches the real edit it conflicts with this existing
+              ;; file.  Success plus unchanged content is direct native evidence
+              ;; that Jolt served the historical receipt instead.
+              (spit (str root "/once.txt") "outside-change")
+              (let [b2 (sb/rebuild-recorded! conn b eval-id)]
+                (is (= (:binding/id b) (:binding/id b2)))
+                (is (= (:instance/id b) (:instance/id b2)))
+                (is (= 40 (sb/evaluate! b2 "rebuilt-value"))
+                    "the stored definition was rebuilt in the same logical instance")
+                (is (= "outside-change" (slurp (str root "/once.txt")))
+                    "replay performed zero real project actuations")
+                ;; Repetition from the newly published instance is exact too.
+                (let [b3 (sb/rebuild-recorded! conn b2 eval-id)]
+                  (is (= 42 (sb/evaluate! b3 "(+ rebuilt-value 2)")))
+                  (is (= "outside-change"
+                         (slurp (str root "/once.txt"))))
+                  ))))))))
+
+  (deftest binding-mismatch-denies-before-load-or-operation
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  b (sb/bind! (sb/provider) "bound-work"
+                              {:preset :project/develop :root root})
+                  {:keys [eval-id]}
+                  (sb/evaluate-recorded!
+                   conn b "(project/edit \"mismatch.txt\" :absent \"made\")")
+                  forged (assoc b :binding/id "bind:main:somebody-else")]
+              (fs/delete (str root "/mismatch.txt"))
+              (reset! conn (assoc @conn :events []))
+              (is (deny? #(sb/rebuild-recorded! conn forged eval-id)))
+              (is (= [:verify] (:events @conn))
+                  "identity denial precedes even loading replay material")
+              (is (not (fs/exists? (str root "/mismatch.txt")))
+                  "the denied source performed no real operation")
+              ))))))
+
+  (deftest rebuild-verify-carries-exact-current-coordinate
+    (with-tmp
+      (fn [root]
+        (let [captured (atom nil)
+              store (assoc memory-eval-store
+                           :verify-binding!
+                           (fn [conn eval-id identity]
+                             (reset! captured identity)
+                             ((:verify-binding! memory-eval-store)
+                              conn eval-id identity)))]
+          (with-eval-store store
+            (fn []
+              (let [conn (memory-db)
+                    b (sb/bind! (sb/provider) "coord-work"
+                                {:preset :project/develop :root root})
+                    {:keys [eval-id]}
+                    (sb/evaluate-recorded!
+                      conn b "(project/edit \"coord.txt\" :absent \"c\")")
+                    record (get-in @conn [:records eval-id])]
+                ;; The identity handed to verify-binding! carries the exact
+                ;; current spec coordinate — the fourth field the store
+                ;; compares.  Omit it and every replay is denied (blank
+                ;; expected coordinate); hold stale authority and this one is.
+                (is (map? (sb/rebuild-recorded! conn b eval-id))
+                    "a matching coordinate verifies and replays")
+                (is (string? (:coordinate @captured)))
+                (is (= (:coordinate record) (:coordinate @captured))
+                    "verify-binding! receives the coordinate the record began with")
+
+                ;; A record whose stored coordinate does not match the
+                ;; binding's current authority is denied AT verify-binding!,
+                ;; before the record is loaded or any receipt replayed.
+                (let [conn2 (memory-db)
+                      b2 (sb/bind! (sb/provider) "coord-work2"
+                                   {:preset :project/develop :root root})
+                      {:keys [eval-id]}
+                      (sb/evaluate-recorded!
+                        conn2 b2 "(project/edit \"coord2.txt\" :absent \"c2\")")]
+                  (fs/delete (str root "/coord2.txt"))
+                  (reset! conn2 (-> @conn2
+                                    (assoc :events [])
+                                    (assoc-in [:records eval-id :coordinate]
+                                              "js0:forged")))
+                  (is (deny? #(sb/rebuild-recorded! conn2 b2 eval-id))
+                      "a coordinate mismatch denies at verify-binding!")
+                  (is (= [:verify] (:events @conn2))
+                      "the denial precedes loading the replay material")
+                  (is (not (fs/exists? (str root "/coord2.txt")))
+                      "no replay actuation reached the project")))))))))
+
+  (deftest pending-edit-intent-denies-resume
+    (with-tmp
+      (fn [root]
+        (with-eval-store memory-eval-store
+          (fn []
+            (let [conn (memory-db)
+                  b (sb/bind! (sb/provider) "pending-work"
+                              {:preset :project/develop :root root})
+                  {:keys [eval-id]} (sb/evaluate-recorded! conn b "1")
+                  complete-record (get-in @conn [:records eval-id])
+                  pending-record (assoc complete-record
+                                        :status :pending
+                                        :result nil
+                                        :source "(project/edit \"unknown.txt\" :absent \"maybe\")"
+                                        :receipts [{:seq 0
+                                                    :op :project/edit
+                                                    :args ["unknown.txt" :absent "maybe"]
+                                                    :phase :intent}])]
+              ;; Model the append-only crash shape: begin + edit intent landed,
+              ;; but neither outcome nor completion did.
+              (reset! conn (assoc-in @conn [:records eval-id] pending-record))
+              (is (deny? #(sb/rebuild-recorded! conn b eval-id))
+                  "a pending actuation is never guessed or resumed")
+              (is (not (fs/exists? (str root "/unknown.txt")))
+                  "resume denial performs no project actuation")
+
+              ;; A terminal marker does not make malformed history safe.  A gap
+              ;; in operation order is denied before source reaches project/edit.
+              (reset! conn
+                      (-> @conn
+                          (assoc-in [:records eval-id :status] :completed)
+                          (assoc-in [:records eval-id :result] {:value nil})
+                          (assoc-in [:records eval-id :receipts]
+                                    [{:seq 1
+                                      :op :project/edit
+                                      :args ["unknown.txt" :absent "maybe"]
+                                      :phase :done
+                                      :result {:path "unknown.txt"}}])))
+              (is (deny? #(sb/rebuild-recorded! conn b eval-id))
+                  "malformed non-contiguous receipts fail closed")
+              (is (not (fs/exists? (str root "/unknown.txt"))))
+              (is (= 2 (sb/evaluate! b "(+ 1 1)"))
+                  "denied rebuild releases instance ownership")
+              )))))))
+
+;; Self-run only on explicit request (the direct -Scp invocation in the
+;; docstring).  `jolt -M:test` requires this namespace without SCI on the
+;; roots, so sandbox-ns-resolved? is false there and nothing runs; the
+;; suite runner would otherwise execute the tests a second time at load.
+(when (and sandbox-ns-resolved?
+           (= "1" (jolt.host/getenv "SAMIZDAT_SANDBOX_TEST_RUN")))
+  (let [{:keys [fail error] :as summary} (t/run-tests 'samizdat.sandbox-test)]
+    (println summary)
+    (if (pos? (+ (or fail 0) (or error 0)))
+      (throw (ex-info "samizdat sandbox tests failed" {:fail fail :error error}))
+      (println "SANDBOX-TEST OK"))))

--- a/test/samizdat/security/secrets_test.clj
+++ b/test/samizdat/security/secrets_test.clj
@@ -120,6 +120,68 @@
   (testing "clean text is returned unchanged"
     (is (= "nothing to see" (secrets/redact "nothing to see")))))
 
+;; --- redact known-values (the jolt set/dedup bug) ---------------------------
+;;
+;; Every real caller hands redact a SET — known-values and stripped-values
+;; both answer sets — but only vectors were exercised above. jolt's
+;; `distinct` destructures its argument positionally, and positional access
+;; on a raw set answers nil, so (distinct #{v}) evaluated to (nil): the
+;; run's one secret was erased from the redaction set and leaked. Nothing
+;; crashed — the injected nil was blank-dropped in turn — and an opaque
+;; value never reaches the vendor regexes, so it sailed through the
+;; boundary. redact now normalizes through its known-value-seq
+;; (str + blank? + a set + an explicit longest-first sort) and never calls
+;; `distinct`. These pin that fix.
+(deftest redact-known-values-on-jolt
+  (testing "a single-element set is redacted — the exact shape that vanished"
+    (is (= "the token is [REDACTED] ok"
+           (secrets/redact "the token is OPAQUE-BUILD-abc ok"
+                           #{"OPAQUE-BUILD-abc"}))))
+  (testing "every element of a multi-element set survives dedup"
+    (is (= "a [REDACTED] b [REDACTED] c"
+           (secrets/redact "a K1 b K2 c" #{"K1" "K2"}))))
+  (testing "the set known-values actually builds — stripped env + resolved refs"
+    (let [env {"SECRET_API_KEY" "SYNTH-token-9182736" "PATH" "/usr/bin"}
+          known (secrets/known-values env "echo {{env/SECRET_API_KEY}}")]
+      (is (set? known))
+      (is (= "echo [REDACTED] now"
+             (secrets/redact "echo SYNTH-token-9182736 now" known)))))
+  (testing "deterministic across collection types: vector, list and set agree"
+    (let [text "x SECRET-x y SECRET-xyz z"
+          vs ["SECRET-x" "SECRET-xyz" "SECRET-x"]
+          out-vec (secrets/redact text vs)
+          out-set (secrets/redact text (set vs))
+          out-list (secrets/redact text '("SECRET-x" "SECRET-xyz"))]
+      (is (= "x [REDACTED] y [REDACTED] z" out-vec))
+      (is (= out-vec out-set out-list))))
+  (testing "longest-first: a value containing another leaves no residue"
+    ;; If the shorter value ran first, SECRET-xyz would become
+    ;; [REDACTED]yz — a partial leak of the longer secret.
+    (is (not (str/includes?
+              (secrets/redact "hold SECRET-xyz tight" #{"SECRET-x" "SECRET-xyz"})
+              "yz"))))
+  (testing "duplicate entries collapse to one replacement"
+    (is (= "a [REDACTED] b"
+           (secrets/redact "a S1 b" ["S1" "S1" "S1"]))))
+  (testing "blank and nil entries are skipped, adding no stray markers"
+    (is (= "a K9 b" (secrets/redact "a K9 b" ["" " " "\t" nil "OTHER"])))
+    (is (= "a [REDACTED] b" (secrets/redact "a K9 b" ["" nil " " "K9"])))
+    (is (= "a K9 b" (secrets/redact "a K9 b" #{" " nil}))))
+  (testing "nil and empty known-values leave clean text untouched"
+    (is (= "nothing to see" (secrets/redact "nothing to see" nil)))
+    (is (= "nothing to see" (secrets/redact "nothing to see" [])))
+    (is (= "nothing to see" (secrets/redact "nothing to see" #{}))))
+  (testing "known values are matched literally, never as regex syntax"
+    ;; A metacharacter-laden password must redact by substring; if the
+    ;; value ever reached a regex path it would not match (or throw).
+    (is (= "pw is [REDACTED] ok"
+           (secrets/redact "pw is p@ss(w0rd![*+?. $ ok" ["p@ss(w0rd![*+?. $"]))))
+  (testing "vendor-pattern redaction still runs alongside known values"
+    ;; Both the vendor-shaped token and the opaque known value are caught.
+    (is (= "leak [REDACTED] and [REDACTED] too"
+           (secrets/redact "leak sk-abcdefghijklmnopqrstuvwx and OPAQUE-TOKEN-1 too"
+                           #{"OPAQUE-TOKEN-1"})))))
+
 ;; --- symbolic reference resolution ------------------------------------------
 
 (deftest symbolic-refs
@@ -162,3 +224,24 @@
     (testing "the model still directed the call — the symbolic ref is intact upstream"
       (is (str/includes? command "{{env/SECRET_API_KEY}}"))
       (is (not (str/includes? command canary))))))
+
+(deftest spec-a-shapeless-canary-never-reaches-model-space
+  ;; The spec test above plants a vendor-shaped canary (sk-…), which the
+  ;; regex layer catches on its own — so it stayed green through the jolt
+  ;; set bug where set-supplied known values were erased by `distinct`.
+  ;; This canary has NO recognizable shape at all: only the known-value
+  ;; path can stop it, which is exactly the path that leaked.
+  (let [canary "correct-horse-battery-staple-42"
+        env {"SECRET_DB_PASSWORD" canary "PATH" "/usr/bin"}
+        command "echo using {{env/SECRET_DB_PASSWORD}} now"
+        resolved (secrets/resolve-refs command env)
+        child-env (secrets/scrub-env env)
+        known (secrets/known-values env command)
+        tool-result (secrets/redact resolved known)
+        journal-row (secrets/redact resolved known)]
+    (testing "the child env carries no name-sensitive var"
+      (is (not (contains? child-env "SECRET_DB_PASSWORD"))))
+    (testing "the shapeless canary appears in nothing the model or journal reads"
+      (is (not (str/includes? tool-result canary)))
+      (is (not (str/includes? journal-row canary)))
+      (is (str/includes? tool-result "[REDACTED]")))))

--- a/test/samizdat/ship_test.clj
+++ b/test/samizdat/ship_test.clj
@@ -1,0 +1,359 @@
+;; samizdat - a self-hosting agentic harness
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.ship-test
+  "The `done` gate's verify wiring over the structured seam: an adversarial
+  test-file name with no trusted fallback REFUSES the ship (fail closed —
+  the model cannot disable verification by naming a file hostilely); with a
+  configured fallback the operator's command runs as an exact structured
+  request untouched by any model-reachable text; a clean focused change
+  runs the derived argv; and a loop with verification off behaves exactly
+  as before. The scoped primitive is stubbed with a git-delegating fake so
+  the assertions see the exact request the gate would spawn.
+
+  Requires the ordinary classpath (the done method loads the journal);
+  self-run from the repo root with jolt on PATH (the JS1 classpath
+  deliberately lacks the journal/db deps):
+    SAMIZDAT_SHIP_TEST_RUN=1 jolt -Srepro -A:dev run test/samizdat/ship_test.clj"
+  (:require [clojure.data.json :as json]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing run-tests]]
+            [samizdat.agent.gitdiff :as gitdiff]
+            [samizdat.agent.tools.base :as base]
+            [samizdat.agent.tools.ship]
+            [samizdat.agent.verify :as verify]
+            [samizdat.engine.proc :as proc]
+            [samizdat.store.db :as db]
+            [samizdat.store.journal :as journal]
+            [samizdat.store.runs :as runs]))
+
+(def real-scope-run proc/*scope-run*)
+
+(defn- temp-dir [tag]
+  (str (System/getProperty "java.io.tmpdir") "/samizdat-ship-" tag "-"
+       (System/currentTimeMillis) "-" (rand-int 100000)))
+
+(defn- sh
+  [dir & cmd]
+  (proc/scope-run {:cmd (vec cmd) :dir dir
+                   :env (proc/scrubbed-allowlist-env)
+                   :timeout-ms 15000 :term-grace-ms 2000
+                   :out-bytes 65536 :err-bytes 65536}))
+
+(defn- init-repo!
+  [dir]
+  (.mkdirs (java.io.File. dir))
+  (sh dir "git" "init" "-q")
+  (sh dir "git" "config" "user.email" "t@t.co")
+  (sh dir "git" "config" "user.name" "t")
+  (spit (str dir "/seed.txt") "seed\n")
+  (sh dir "git" "add" "-A")
+  (sh dir "git" "commit" "-qm" "init"))
+
+(defn- done-ctx
+  "A minimal `done` context: no conn/run-id (journal writes skip), a branch
+  with no artifacts and no problem (the lexical rungs are inert), the run
+  `config` under test, and the repo `root`/`baseline` the gate diffs."
+  [root baseline config]
+  {:tool-name "done"
+   :branch {:id "b1" :artifacts [] :problem nil}
+   :turn 3
+   :root root
+   :git-baseline baseline
+   :config {:run config}
+   :args {:answer "tests pass"}})
+
+(defn- git-or-probe?
+  "Whether a stubbed scope request is gitdiff's git (delegated to the real
+  primitive) or proc/scope-supported?'s spawn-free capability probe —
+  neither is a verification RUN, so the nothing-spawned stubs must not
+  count them."
+  [req]
+  (contains? #{"git" "samizdat-scope-capability-probe"} (first (:cmd req))))
+
+(def ^:private green-run
+  {:pid 1 :exit 0 :timed-out false
+   :out "Ran 1 tests containing 1 assertions.\n0 failures, 0 errors."
+   :out-status :complete :err "" :err-status :complete})
+
+(deftest done-refuses-adversarial-test-names-when-no-trusted-fallback-exists
+  (when (proc/available? "git")
+    (let [dir (temp-dir "refused")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)]
+          ;; the model's move: a test file whose NAME is the payload
+          (spit (str dir "/evil';touch pwned_test.clj") "(ns evil)\n")
+           (let [r (base/run-tool
+                     (done-ctx dir base {:verify-focused? true}))]
+            (is (= :failure (:category r)) "fail closed, not a silent pass")
+            (is (some? (:done-block r)))
+            (is (str/includes? (:result r) "REFUSED"))
+            (is (str/includes? (:result r) "evil';touch pwned")
+                "the offending path is named back to the worker")
+            (is (not (:done? r)))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest done-runs-the-trusted-fallback-as-an-exact-structured-request
+  (when (proc/available? "git")
+    (let [dir (temp-dir "fallback")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)
+              seen (atom nil)]
+          (spit (str dir "/evil';touch pwned_test.clj") "(ns evil)\n")
+          (binding [proc/*scope-run*
+                    (fn [req]
+                      (if (git-or-probe? req)
+                        (real-scope-run req)   ; gitdiff/probe keep working
+                        (do (reset! seen req) green-run)))]
+            (let [r (base/run-tool
+                      (done-ctx dir base
+                                {:verify-focused? true
+                                 :verify-cmd "jolt -M:test --some 'operator quoting'"
+                                 :verify-timeout-ms 4321}))]
+              (testing "the fallback green ships"
+                (is (:done? r))
+                (is (= :success (:category r))))
+              (testing "the request is exactly the operator's command, structured"
+                (is (some? @seen))
+                (is (= ["sh" "-c" "jolt -M:test --some 'operator quoting'"]
+                       (:cmd @seen))
+                    "the config string verbatim as the single sh -c operand")
+                (is (= dir (:dir @seen)) "cwd is the project root")
+                (is (= 4321 (:timeout-ms @seen)) "timeout is operator config")
+                (is (= verify/term-grace-ms (:term-grace-ms @seen)))
+                (is (= verify/out-bytes (:out-bytes @seen)))
+                (is (= verify/err-bytes (:err-bytes @seen)))
+                (testing "the child env is the scrubbed allowlist"
+                  (is (contains? (:env @seen) "PATH"))
+                  (is (every? #{"PATH" "HOME" "LANG" "LC_ALL" "LC_CTYPE"
+                                "TERM" "TMPDIR"}
+                              (keys (:env @seen)))))
+                (is (not (str/includes? (pr-str (:cmd @seen)) "evil"))
+                    "no model-reachable text entered the request")
+                (is (= #{:cmd :dir :env :timeout-ms :term-grace-ms
+                         :out-bytes :err-bytes}
+                       (set (keys @seen))))))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest done-runs-the-focused-request-as-derived-argv
+  (when (proc/available? "git")
+    (let [dir (temp-dir "focused")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)
+              seen (atom nil)]
+          (spit (str dir "/src.clj") "(ns src)\n")
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          (binding [proc/*scope-run*
+                    (fn [req]
+                      (if (git-or-probe? req)
+                        (real-scope-run req)
+                        (do (reset! seen req) green-run)))]
+            (let [r (base/run-tool
+                      (done-ctx dir base {:verify-focused? true}))]
+              (is (:done? r) "a green focused run ships")
+              (is (some? @seen))
+              (is (= "jolt" (first (:cmd @seen))))
+              (is (= ["jolt" "-A:test" "-e"] (subvec (:cmd @seen) 0 3)))
+              (is (str/includes? (nth (:cmd @seen) 3) "good-test")
+                  "the touched namespace is required")
+              (is (not (str/includes? (nth (:cmd @seen) 3) "src.clj"))
+                  "non-test paths do not ride along")
+              (is (not (some #{"sh" "-c"} (:cmd @seen)))
+                  "the focused path is pure argv, no shell"))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest done-feeds-back-a-red-focused-run
+  (when (proc/available? "git")
+    (let [dir (temp-dir "red")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)]
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          (binding [proc/*scope-run*
+                    (fn [req]
+                      (if (git-or-probe? req)
+                        (real-scope-run req)
+                        {:pid 1 :exit 1 :timed-out false
+                         :out "FAIL in good-test (good_test.clj:3)\nexpected: 2\nactual: 3"
+                         :out-status :complete :err "" :err-status :complete}))]
+            (let [r (base/run-tool
+                      (done-ctx dir base {:verify-focused? true}))]
+              (is (not (:done? r)))
+              (is (= :failure (:category r)))
+              (is (str/includes? (:result r) "not green"))
+              (is (str/includes? (:result r) "FAIL in good-test")
+                  "the failure tail reaches the branch"))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest done-is-unchanged-when-verification-is-not-configured
+  (when (proc/available? "git")
+    (let [dir (temp-dir "off")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)
+              seen (atom nil)]
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          (binding [proc/*scope-run*
+                    (fn [req]
+                      (if (git-or-probe? req)
+                        (real-scope-run req)
+                        (do (reset! seen req) green-run)))]
+            (let [r (base/run-tool (done-ctx dir base {}))]
+              (is (:done? r) "no verify config: the rung is inert, as before")
+              (is (nil? @seen) "nothing but git ever spawned"))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+;; --- the execution boundary fails closed through the gate ----------------------
+
+(deftest done-blocks-when-the-runtime-cannot-run-scoped-verification
+  ;; Off-Linux / missing primitive, simulated at the capability the gate
+  ;; probes: verification must come back UNAVAILABLE and the ship must be
+  ;; blocked — never silently permitted through the cannot-tell trust
+  ;; fallthrough that a dead executor would otherwise produce.
+  (when (proc/available? "git")
+    (let [dir (temp-dir "unsup")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)]
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          (with-redefs [proc/scope-supported? (constantly false)]
+            (let [r (base/run-tool (done-ctx dir base {:verify-focused? true}))]
+              (is (not (:done? r)) "never silently permitted")
+              (is (= :failure (:category r)))
+               (is (str/includes? (:result r) "UNAVAILABLE"))
+               (is (str/includes? (:result r) "scoped process execution")))))
+         (finally
+           (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest done-blocks-on-a-malformed-verify-cmd-config
+  ;; A non-string :verify-cmd is an operator error: the gate must BLOCK
+  ;; with the misconfiguration named, not silently skip verification (the
+  ;; old behavior when the fallback derivation read 'unconfigured').
+  (when (proc/available? "git")
+    (let [dir (temp-dir "badcfg")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)
+              seen (atom nil)]
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          (binding [proc/*scope-run*
+                    (fn [req]
+                      (if (git-or-probe? req)
+                        (real-scope-run req)
+                        (do (reset! seen req) green-run)))]
+            (let [r (base/run-tool
+                      (done-ctx dir base {:verify-cmd [:jolt "-M:test"]}))]
+              (is (not (:done? r)))
+              (is (= :failure (:category r)))
+              (is (str/includes? (:result r) "MISCONFIGURED"))
+              (is (str/includes? (:result r) "verify-cmd"))
+              (is (nil? @seen) "nothing but git ever spawned"))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+;; --- the durable ship-verify journal record ------------------------------------
+
+(defn- ship-verify-rows
+  "The :ship-verify events of `run-id`, newest last."
+  [conn run-id]
+  (filter #(= "ship-verify" (:kind %)) (journal/events-since conn run-id 0)))
+
+(defn- with-run-db
+  "Open an in-memory run database, open the run + branch the gate journals
+  against, run `body` over [conn run-id], close."
+  [body]
+  (let [c (db/open! ":memory:")]
+    (try
+      (let [rid (runs/start-run! c {:problem "p"})]
+        (runs/open-branch! c rid {:branch-id "b1"})
+        (body c rid))
+      (finally (db/close c)))))
+
+(deftest refused-verification-is-journalled-durably-and-blocks
+  (when (proc/available? "git")
+    (let [dir (temp-dir "jrnl-refused")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)]
+          (spit (str dir "/evil';touch pwned_test.clj") "(ns evil)\n")
+          (with-run-db
+            (fn [c rid]
+              (let [r (base/run-tool (assoc (done-ctx dir base {:verify-focused? true})
+                                            :conn c :run-id rid))
+                    rows (ship-verify-rows c rid)]
+                (is (not (:done? r)) "blocked")
+                (is (= 1 (count rows))
+                    "the refusal has exactly one durable ship-verify row")
+                (let [data (json/read-str (:data (first rows)) :key-fn keyword)]
+                  (is (false? (:green data)))
+                  (is (= "refused" (:kind data)))
+                  (is (true? (:blocked data)))
+                  (is (some #(str/includes? % "evil';touch pwned")
+                            (map str (:refused data)))
+                      "the refused paths are in the durable record"))))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest unavailable-verification-is-journalled-durably-and-blocks
+  (when (proc/available? "git")
+    (let [dir (temp-dir "jrnl-unsup")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)]
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          (with-redefs [proc/scope-supported? (constantly false)]
+            (with-run-db
+              (fn [c rid]
+                (let [r (base/run-tool (assoc (done-ctx dir base {:verify-focused? true})
+                                              :conn c :run-id rid))
+                      rows (ship-verify-rows c rid)]
+                  (is (not (:done? r)))
+                  (is (= 1 (count rows)) "the unavailability is recorded")
+                  (let [data (json/read-str (:data (first rows)) :key-fn keyword)]
+                    (is (false? (:green data)))
+                    (is (true? (:unsupported? data)))
+                    (is (true? (:blocked data)))))))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+(deftest a-run-verification-is-journalled-with-its-kind
+  (when (proc/available? "git")
+    (let [dir (temp-dir "jrnl-run")]
+      (try
+        (init-repo! dir)
+        (let [base (gitdiff/baseline dir)
+              seen (atom nil)]
+          (spit (str dir "/good_test.clj") "(ns good-test)\n")
+          (binding [proc/*scope-run*
+                    (fn [req]
+                      (if (git-or-probe? req)
+                        (real-scope-run req)
+                        (do (reset! seen req) green-run)))]
+            (with-run-db
+              (fn [c rid]
+                (let [r (base/run-tool (assoc (done-ctx dir base {:verify-focused? true})
+                                              :conn c :run-id rid))
+                      rows (ship-verify-rows c rid)]
+                  (is (:done? r) "the green stubbed run ships")
+                  (is (= 1 (count rows)))
+                  (let [data (json/read-str (:data (first rows)) :key-fn keyword)]
+                    (is (true? (:green data)))
+                    (is (= "focused" (:kind data)))
+                    (is (false? (:blocked data)))))))))
+        (finally
+          (sh (System/getProperty "java.io.tmpdir") "rm" "-rf" dir))))))
+
+;; --- self-run for the focused lane ---------------------------------------------
+
+(when (= "1" (jolt.host/getenv "SAMIZDAT_SHIP_TEST_RUN"))
+  (let [{:keys [fail error] :as summary} (run-tests 'samizdat.ship-test)]
+    (println summary)
+    (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0))))

--- a/test/samizdat/test_runner.clj
+++ b/test/samizdat/test_runner.clj
@@ -69,6 +69,7 @@
             [samizdat.js1-boundary-test]
             [samizdat.js1-wrapper-test]
             [samizdat.js1-harness-test]
+            [samizdat.js1-dogfood-test]
             [samizdat.tasks-test]
             [samizdat.knowledge-test]
             [samizdat.messages-test]
@@ -163,6 +164,7 @@
       samizdat.js1-boundary-test
       samizdat.js1-wrapper-test
       samizdat.js1-harness-test
+      samizdat.js1-dogfood-test
       samizdat.tasks-test
     samizdat.knowledge-test
     samizdat.messages-test

--- a/test/samizdat/test_runner.clj
+++ b/test/samizdat/test_runner.clj
@@ -65,6 +65,10 @@
             [mycelium.validation-test]
             [mycelium.workflow-test]
             [samizdat.agent-test]
+            [samizdat.resume-test]
+            [samizdat.js1-boundary-test]
+            [samizdat.js1-wrapper-test]
+            [samizdat.js1-harness-test]
             [samizdat.tasks-test]
             [samizdat.knowledge-test]
             [samizdat.messages-test]
@@ -153,9 +157,13 @@
     mycelium.workflow-test
     samizdat.store-test
     samizdat.evals-test
-    samizdat.llm-test
-    samizdat.agent-test
-    samizdat.tasks-test
+     samizdat.llm-test
+     samizdat.agent-test
+      samizdat.resume-test
+      samizdat.js1-boundary-test
+      samizdat.js1-wrapper-test
+      samizdat.js1-harness-test
+      samizdat.tasks-test
     samizdat.knowledge-test
     samizdat.messages-test
     samizdat.workflow-test

--- a/test/samizdat/test_runner.clj
+++ b/test/samizdat/test_runner.clj
@@ -96,15 +96,17 @@
             [samizdat.security.policy-test]
             [samizdat.llm-test]
             [samizdat.prompt-test]
-            [samizdat.server-test]
+             [samizdat.server-test]
             [samizdat.store-test]
+            [samizdat.evals-test]
             [samizdat.gui-api-test]
             [samizdat.gui-ops-test]
             [samizdat.gui-graph-test]
             [samizdat.gui-style-test]
             [samizdat.gui-input-test]
             [samizdat.gui-mathtext-test]
-            [samizdat.gui-newrun-test]))
+            [samizdat.gui-newrun-test]
+            [samizdat.sandbox-test]))
 
 (def namespaces
   '[maestro.core-test
@@ -150,6 +152,7 @@
     mycelium.validation-test
     mycelium.workflow-test
     samizdat.store-test
+    samizdat.evals-test
     samizdat.llm-test
     samizdat.agent-test
     samizdat.tasks-test
@@ -189,7 +192,8 @@
     samizdat.gui-style-test
     samizdat.gui-input-test
     samizdat.gui-mathtext-test
-    samizdat.gui-newrun-test])
+    samizdat.gui-newrun-test
+    samizdat.sandbox-test])
 
 (defn run []
   (apply t/run-tests namespaces))

--- a/test/samizdat/verify_fixture_test.clj
+++ b/test/samizdat/verify_fixture_test.clj
@@ -1,0 +1,13 @@
+;; samizdat - a self-hosting agentic harness
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.verify-fixture-test
+  "FIXTURE — a deliberately tiny, always-green test namespace for the focused
+  verification lane: samizdat.verify-test's end-to-end case derives a
+  structured focused request for exactly this path and runs it through the
+  real runtime, asserting a green summary. Not part of the full-suite runner
+  list; it exists to be focused ON."
+  (:require [clojure.test :refer [deftest is]]))
+
+(deftest fixture-is-green
+  (is (= 2 (+ 1 1))))

--- a/test/samizdat/verify_test.clj
+++ b/test/samizdat/verify_test.clj
@@ -3,11 +3,50 @@
 
 (ns samizdat.verify-test
   "The ship gate's test rung: the pure decision that makes `done` a hard gate on
-  a green test run, and the focused-command derivation that keeps the loop fast
-  (karamazov-dvz follow-up: the worker loop must be test-driven, not one-shot)."
+  a green test run, the focused-request derivation that keeps the loop fast,
+  and the hardening that closed the critical verify-path injection of
+  code-review 2026-08 pass 3 (docs/code-review-2026-08-3.md finding 1):
+
+  - adversarial changed paths (quote breakouts, semicolons, shell
+    metacharacters, spaces, Unicode, traversal, casing, dot segments) REFUSE
+    focused verification — never a silent skip, never a passthrough — and the
+    only fallback is the operator's already-configured :verify-cmd, which no
+    model-reachable text ever enters;
+  - execution is one STRUCTURED request (exact argv/cwd/env/timeout/caps,
+    no shell on the focused path) through proc/scope-run;
+  - the child environment is the explicit scrubbed allowlist — a synthetic
+    secret never reaches it — and the ENTIRE output is redacted before any
+    model-visible rendering;
+  - stdout/stderr are capped independently, a timeout kills a TERM-resistant
+    tree with no survivor, and the source discipline (no shell composition on
+    the verify path) is asserted statically so it cannot quietly return.
+
+  Real-spawn sections gate on Linux (the scoped primitive's own platform
+  bound). Self-run on the recorded JS1 classpath (from the repo root; jolt
+  is located exactly as bin/js1 locates it — $JOLT_HOME, else the sibling
+  ../jolt checkout — and the classpath is the one bin/js1 path records):
+    SAMIZDAT_VERIFY_TEST_RUN=1 ../jolt/bin/jolt -Srepro -Scp \"$(bin/js1 path)\" run test/samizdat/verify_test.clj"
   (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing is]]
-            [samizdat.agent.verify :as verify]))
+            [clojure.test :refer [deftest is testing run-tests]]
+            [samizdat.agent.verify :as verify]
+            [samizdat.engine.proc :as proc]))
+
+(def ^:private linux?
+  (str/includes? (str (System/getProperty "os.name")) "Linux"))
+
+(def real-scope-run proc/*scope-run*)
+
+(defn- proc-live? [pid]
+  (when pid
+    (try
+      (let [s (slurp (str "/proc/" pid "/stat"))
+            rp (.lastIndexOf s ")")]
+        (and (>= rp 0)
+             (> (count s) (+ rp 2))
+             (not (contains? #{"Z" "X" "x"} (subs s (+ rp 2) (+ rp 3))))))
+      (catch Exception _ false))))
+
+;; --- the pure derivations ------------------------------------------------------
 
 (deftest test-file?-recognises-test-and-spec-paths
   (is (verify/test-file? "test/samizdat/foo_test.clj"))
@@ -21,31 +60,423 @@
          (verify/ns-from-test-path "test/samizdat/agent/decompose_test.clj")))
   (is (= "samizdat.knowledge-test"
          (verify/ns-from-test-path "test/samizdat/knowledge_test.clj")))
+  (is (= "samizdat.js1-boundary-test"
+         (verify/ns-from-test-path "test/samizdat/js1_boundary_test.clj"))
+      "digits ride mid-segment")
+  (is (= "samizdat.gui-ops-test"
+         (verify/ns-from-test-path "gui/samizdat/gui_ops_test.clj")))
   (is (nil? (verify/ns-from-test-path "resources/skills/repl-workflow.md"))
-      "a non-clj path has no namespace"))
+      "a non-clj path has no namespace")
+  (is (nil? (verify/ns-from-test-path "test/fixtures/notes.txt"))
+      "a non-clj test-path is not focusable (and not suspicious)"))
 
-(deftest focused-cmd-runs-only-the-changed-test-namespaces
-  (let [cmd (verify/focused-cmd ["src/samizdat/agent/tools/knowledge.clj"
-                                 "test/samizdat/knowledge_test.clj"])]
-    (is (some? cmd))
-    (is (str/includes? cmd "samizdat.knowledge-test") "targets the touched test ns")
-    (is (not (str/includes? cmd "-M:test")) "does NOT run the whole suite")
-    (is (str/includes? cmd "System/exit") "sets an exit code so red is detectable"))
-  (testing "nothing focusable => nil (caller falls back to :verify-cmd)"
-    (is (nil? (verify/focused-cmd ["src/samizdat/only_src.clj"])))
-    (is (nil? (verify/focused-cmd [])))))
+(deftest focused-request-is-structured-argv-with-no-shell
+  (let [req (verify/verify-request
+              {:changed ["src/samizdat/agent/tools/knowledge.clj"
+                         "test/samizdat/knowledge_test.clj"]
+               :focused? true})]
+    (is (= :focused (:kind req)))
+    (is (vector? (:argv req)))
+    (is (= 4 (count (:argv req))))
+    (is (= ["jolt" "-A:test" "-e"] (subvec (:argv req) 0 3))
+        "the program and its flags are fixed derivation, not input")
+    (is (string? (nth (:argv req) 3)) "the expression is ONE argv element")
+    (is (str/includes? (nth (:argv req) 3) "samizdat.knowledge-test")
+        "targets the touched test ns")
+    (is (not (str/includes? (nth (:argv req) 3) "knowledge.clj"))
+        "path text does not ride along")
+    (is (not (str/includes? (nth (:argv req) 3) "-M:test"))
+        "does NOT run the whole suite")
+    (is (not (some #{"sh" "bash" "-c"} (:argv req)))
+        "no shell, no -c: the focused path is pure argv")
+    (is (= ["samizdat.knowledge-test"] (:nses req))))
+  (testing "nothing focusable => nil with no fallback; the config fallback with one"
+    (is (nil? (verify/verify-request {:changed ["src/samizdat/only_src.clj"]
+                                      :focused? true})))
+    (is (nil? (verify/verify-request {:changed [] :focused? true})))
+    (is (nil? (verify/verify-request {:changed nil :focused? true})))
+    (is (= :fallback (:kind (verify/verify-request
+                              {:changed ["src/samizdat/only_src.clj"]
+                               :focused? true
+                               :fallback-cmd "jolt -M:test"})))))
+  (testing "focused? off => the configured fallback only"
+    (is (nil? (verify/verify-request {:changed ["test/x_test.clj"]
+                                      :focused? false})))
+    (is (= :fallback (:kind (verify/verify-request
+                              {:changed ["test/x_test.clj"] :focused? false
+                               :fallback-cmd "make verify"})))))
+  (testing "a blank-string fallback config is not a fallback; a NON-STRING one is
+            an :invalid request that blocks (fail closed, never skipped)"
+    (is (nil? (verify/verify-request {:changed ["src/samizdat/only_src.clj"]
+                                      :focused? true :fallback-cmd "  "})))
+    (is (= :invalid (:kind (verify/verify-request
+                             {:changed ["src/samizdat/only_src.clj"]
+                              :focused? true :fallback-cmd
+                              ["jolt" "-M:test"]})))))
+  (testing "a non-Clojure test path is neither focusable nor refusable"
+    (let [req (verify/verify-request {:changed ["test/fixtures/data.json"]
+                                      :focused? true})]
+      (is (nil? req) "a fixture change falls back / not-runs as before"))))
+
+;; --- adversarial changed paths refuse focused verification --------------------
+
+(def ^:private adversarial-paths
+  ["test/foo';touch pwned_test.clj"        ;; the review's quote breakout
+   "test/foo'; rm -rf /; echo '_test.clj"
+   "test/a b_test.clj"                      ;; spaces
+   "test/a;b_test.clj"                      ;; semicolon
+   "test/a|b_test.clj"                      ;; pipe
+   "test/a&b_test.clj"                      ;; ampersand
+   "test/a$b_test.clj"                      ;; interpolation
+   "test/a>b_test.clj"                      ;; redirection
+   "test/a<b_test.clj"
+   "test/a`id`_test.clj"                    ;; backtick substitution
+   "test/a\\b_test.clj"                     ;; backslash (a legal Linux byte)
+   "test/a\"b_test.clj"
+   "test/a\tb_test.clj"
+   "test/ünïcode_test.clj"                  ;; non-ASCII
+   "test/日本語_test.clj"
+   "test/../src/evil_test.clj"              ;; traversal
+   "../test/evil_test.clj"
+   "/abs/evil_test.clj"                     ;; absolute
+   "test/-dash_test.clj"                    ;; leading dash (option shape)
+   "test/.hidden_test.clj"                  ;; dot file
+   "test/UPPER_test.clj"                    ;; casing outside the grammar
+   "test/x_test.CLJ"                        ;; case-warped extension
+   "test/dot./path_test.clj"                ;; dot segment
+   "test/a..b_test.clj"                     ;; empty dot segment
+   "test/2026_test.clj"])                   ;; leading-digit segment
+
+(deftest adversarial-names-refuse-focused-verification
+  (doseq [p adversarial-paths]
+    (testing p
+      (is (verify/test-file? p)
+          "fixture sanity: the path really claims to be a test, else it is
+           ignored rather than refused")
+      (is (nil? (verify/ns-from-test-path p)) "unrepresentable under the grammar")
+      (let [req (verify/verify-request
+                  {:changed ["test/samizdat/good_test.clj" p] :focused? true})]
+        (is (= :refused (:kind req))
+            "one bad path refuses the WHOLE focused derivation")
+        (is (some #{p} (:refused req)) "the offending path is named")))))
+
+(deftest refusal-uses-only-a-trusted-already-configured-fallback
+  (let [operator-cmd "jolt -M:test --exclude 'operator quoting stays intact'"
+        req (verify/verify-request
+              {:changed ["test/foo';touch pwned_test.clj"]
+               :focused? true :fallback-cmd operator-cmd})]
+    (is (= :fallback (:kind req)) "the configured fallback absorbs the refusal")
+    (is (= ["sh" "-c" operator-cmd] (:argv req))
+        "the operator string runs VERBATIM as the single sh -c operand")
+    (is (not (str/includes? (pr-str (:argv req)) "touch pwned"))
+        "no model-reachable text entered the fallback argv")
+    (is (not (str/includes? (pr-str (:argv req)) "foo'"))))
+  (testing "without a configured fallback the refusal stands"
+    (is (= :refused (:kind (verify/verify-request
+                             {:changed ["test/foo';touch pwned_test.clj"]
+                              :focused? true}))))))
+
+;; --- run-verify sends exactly the structured request --------------------------
+
+(deftest run-verify-sends-exactly-the-structured-request
+  (let [seen (atom ::none)
+        argv ["jolt" "-A:test" "-e" "(java.lang.System/exit 0)"]
+        env {"PATH" "/usr/bin" "HARNESS_API_KEY" "zz-supersecret-zz"}]
+    (binding [proc/*scope-run*
+              (fn [req] (reset! seen req)
+                {:pid 1 :exit 0 :timed-out false
+                 :out "ok" :out-status :complete
+                 :err "" :err-status :complete})]
+      (let [r (verify/run-verify "/proj/root" {:kind :focused :argv argv}
+                                 4321 env)]
+        (is (:green? r))
+        (is (false? (:timeout? r)))
+        (is (= argv (:cmd @seen)) "argv passes through verbatim")
+        (is (= "/proj/root" (:dir @seen)) "cwd is the root — no cd anywhere")
+        (is (= {"PATH" "/usr/bin"} (:env @seen))
+            "the child env is the scrubbed allowlist of the source env: the
+             API key never reaches the child")
+        (is (= 4321 (:timeout-ms @seen)))
+        (is (= verify/term-grace-ms (:term-grace-ms @seen)))
+        (is (= verify/out-bytes (:out-bytes @seen)))
+        (is (= verify/err-bytes (:err-bytes @seen)))
+        (is (= #{:cmd :dir :env :timeout-ms :term-grace-ms :out-bytes :err-bytes}
+               (set (keys @seen)))
+            "no other request knob exists to smuggle through")
+        (is (str/includes? (:output r) "ok"))))
+    (testing "a nil timeout config falls back to the documented default"
+      (binding [proc/*scope-run* (fn [req] (reset! seen req)
+                                   {:pid 1 :exit 1 :timed-out false})]
+        (verify/run-verify "/r" {:kind :fallback :argv ["sh" "-c" "x"]} nil)
+        (is (= verify/default-timeout-ms (:timeout-ms @seen)))))
+    (testing "a refused request never spawns"
+      (binding [proc/*scope-run* (fn [req] (throw (ex-info "must not run" req)))]
+        (let [r (verify/run-verify "/r" {:kind :refused :refused ["test/x_test.clj"]}
+                                   1000)]
+          (is (false? (:green? r)))
+          (is (str/includes? (:output r) "refused")))))))
+
+(deftest run-verify-green-requires-a-clean-exit
+  (testing "a stubbed non-zero exit is not green, timed-out or not"
+    (binding [proc/*scope-run* (fn [_] {:pid 1 :exit 1 :timed-out false})]
+      (is (false? (:green? (verify/run-verify "/r" {:kind :focused :argv ["x"]} 1)))))
+    (binding [proc/*scope-run* (fn [_] {:pid 1 :exit 137 :timed-out true})]
+      (let [r (verify/run-verify "/r" {:kind :focused :argv ["x"]} 1)]
+        (is (false? (:green? r)))
+        (is (true? (:timeout? r)))))))
+
+;; --- the execution boundary fails closed ---------------------------------------
+
+(deftest run-verify-fails-closed-when-the-scoped-primitive-is-missing
+  ;; The off-Linux / missing-primitive runtime: verification must report
+  ;; UNAVAILABLE — never silently skip, never downgrade to an unscoped
+  ;; spawn, never inherit an environment.
+  (with-redefs [proc/scope-supported? (constantly false)]
+    (binding [proc/*scope-run* (fn [_] (throw (ex-info "must not spawn" {})))]
+      (let [r (verify/run-verify "/r" {:kind :focused :argv ["x"]} 1000 nil)]
+        (is (false? (:green? r)))
+        (is (true? (:unsupported? r)))
+        (is (str/includes? (:output r) "verification unavailable"))
+        (is (str/includes? (:output r) "scoped process"))))))
+
+(deftest verify-block-blocks-an-unavailable-runtime-never-trusts
+  (testing "the boundary fact threaded by the ship gate (git cannot tell + no executor)"
+    (let [b (verify/verify-block {:verify-on? true :unsupported? true
+                                  :result nil :request nil
+                                  :changed nil :require-test? true})]
+      (is (some? b) "cannot-tell trust must NOT absorb a missing executor")
+      (is (str/includes? b "UNAVAILABLE"))))
+  (testing "and the same fact reported through the result"
+    (let [b (verify/verify-block {:verify-on? true
+                                  :result {:green? false :unsupported? true
+                                           :output "verification unavailable"}
+                                  :request {:kind :focused}
+                                  :changed ["test/x_test.clj"]
+                                  :require-test? true})]
+      (is (some? b))
+      (is (str/includes? b "UNAVAILABLE"))))
+  (testing "verify-on? false keeps the rung inert (a loop that never verified
+            is not a platform failure)"
+    (is (nil? (verify/verify-block {:verify-on? false :unsupported? true
+                                    :result nil :request nil
+                                    :changed nil :require-test? true})))))
+
+;; --- operator misconfiguration fails closed ------------------------------------
+
+(deftest malformed-verify-cmd-is-an-invalid-request-that-blocks
+  (doseq [bad [[:jolt "-M:test"] :keyword 123 {:a 1}]]
+    (testing (pr-str bad)
+      (let [req (verify/verify-request {:changed ["test/x_test.clj"]
+                                        :focused? false :fallback-cmd bad})]
+        (is (= :invalid (:kind req))
+            "a non-string verify-cmd is an operator error, not 'unconfigured'")
+        (is (str/includes? (str (:reason req)) "verify-cmd"))))
+    (testing "focused runs are poisoned too — misconfig never silently skips"
+      (is (= :invalid (:kind (verify/verify-request {:changed ["test/x_test.clj"]
+                                                     :focused? true
+                                                     :fallback-cmd bad}))))))
+  (testing "nil and plain-string configs keep their existing meanings"
+    (is (nil? (verify/verify-request {:changed ["test/x_test.clj"]
+                                      :focused? false :fallback-cmd nil})))
+    (is (= :fallback (:kind (verify/verify-request {:changed ["test/x_test.clj"]
+                                                    :focused? false
+                                                    :fallback-cmd "make test"})))))
+  (testing "run-verify returns a clear invalid result without spawning"
+    (binding [proc/*scope-run* (fn [_] (throw (ex-info "must not spawn" {})))]
+      (let [r (verify/run-verify "/r" {:kind :invalid
+                                       :reason ":run :verify-cmd must be a string"}
+                                 1000 nil)]
+        (is (false? (:green? r)))
+        (is (true? (:invalid-config? r)))
+        (is (str/includes? (:output r) "verify-cmd")))))
+  (testing "verify-block blocks the invalid request with the operator-facing fix"
+    (let [b (verify/verify-block {:verify-on? true
+                                  :request {:kind :invalid
+                                            :reason ":run :verify-cmd must be a shell-command string"}
+                                  :result nil
+                                  :changed ["test/x_test.clj"]
+                                  :require-test? true})]
+      (is (some? b))
+      (is (str/includes? b "MISCONFIGURED"))
+      (is (str/includes? b "verify-cmd")))))
+
+(deftest nonpositive-verify-timeout-blocks-rather-than-defaults
+  (doseq [bad [0 -1 2.5 "30000"]]
+    (testing (pr-str bad)
+      (binding [proc/*scope-run* (fn [_] (throw (ex-info "must not spawn" {})))]
+        (let [r (verify/run-verify "/r" {:kind :focused :argv ["x"]} bad nil)]
+          (is (false? (:green? r)) "fail closed")
+          (is (true? (:invalid-config? r)) "reported as config, not test failure")
+          (is (str/includes? (:output r) "verify-timeout-ms"))
+          (is (str/includes? (:output r) "blocked"))))))
+  (testing "nil still means the documented default (the legitimate unset case)"
+    (let [seen (atom nil)]
+      (binding [proc/*scope-run* (fn [req] (reset! seen req)
+                                   {:pid 1 :exit 0 :timed-out false})]
+        (is (true? (:green? (verify/run-verify "/r" {:kind :focused :argv ["x"]}
+                                               nil nil))))
+        (is (= verify/default-timeout-ms (:timeout-ms @seen))))))
+  (testing "verify-block renders the misconfiguration as a block"
+    (let [b (verify/verify-block {:verify-on? true
+                                  :request {:kind :focused}
+                                  :result {:green? false :invalid-config? true
+                                           :output "verification misconfigured: :run :verify-timeout-ms must be a positive integer"}
+                                  :changed ["test/x_test.clj"]
+                                  :require-test? true})]
+      (is (some? b))
+      (is (str/includes? b "MISCONFIGURED"))
+      (is (str/includes? b "verify-timeout-ms")))))
+
+;; --- capture statuses are annotated honestly (pure, stubbed primitive) --------
+
+(deftest run-verify-annotates-partial-and-truncated-capture
+  (let [stub (fn [m] (fn [_] (merge {:pid 1 :exit 0 :timed-out false} m)))]
+    (testing ":partial — a prefix the model can tell is a prefix"
+      (binding [proc/*scope-run* (stub {:out "out-prefix" :out-status :partial
+                                        :err "err-prefix" :err-status :partial})]
+        (let [r (verify/run-verify "/r" {:kind :focused :argv ["x"]} 1000 nil)]
+          (is (str/includes? (:output r) "out-prefix"))
+          (is (str/includes? (:output r) "[stdout capture incomplete]"))
+          (is (str/includes? (:output r) "[stderr capture incomplete]")))))
+    (testing ":truncated — the cap is named"
+      (binding [proc/*scope-run* (stub {:out "aa" :out-status :truncated})]
+        (let [r (verify/run-verify "/r" {:kind :focused :argv ["x"]} 1000 nil)]
+          (is (str/includes? (:output r)
+                             (str "[stdout truncated at " verify/out-bytes " bytes]"))))))
+    (testing ":complete — no marker at all"
+      (binding [proc/*scope-run* (stub {:out "clean\n" :out-status :complete
+                                        :err "" :err-status :complete})]
+        (let [r (verify/run-verify "/r" {:kind :focused :argv ["x"]} 1000 nil)]
+          (is (str/includes? (:output r) "clean"))
+          (is (not (str/includes? (:output r) "truncated")))
+          (is (not (str/includes? (:output r) "incomplete"))))))))
+
+;; --- real execution: child env, redaction, caps, timeout (Linux) --------------
+
+(deftest run-verify-omits-secrets-from-the-child-environment
+  (when linux?
+    (let [r (verify/run-verify
+              "/tmp"
+              {:kind :focused
+               :argv ["/bin/sh" "-c"
+                      "if [ -n \"$SAMIZDAT_ADVERSARIAL_KEY\" ]; then echo LEAKED; else echo CLEAN; fi"]}
+              10000
+              {"SAMIZDAT_ADVERSARIAL_KEY" "sk-abcdefghijklmnopqrstuv"
+               "PATH" "/usr/bin:/bin"})]
+      (is (:green? r))
+      (is (str/includes? (:output r) "CLEAN"))
+      (is (not (str/includes? (:output r) "LEAKED")))
+      (is (not (str/includes? (:output r) "sk-abcdefghijklmnopqrstuv"))
+          "the synthetic secret is absent from env AND output"))))
+
+(deftest run-verify-redacts-the-entire-output-before-rendering
+  (when linux?
+    (testing "a vendor-shaped credential printed by the child is redacted"
+      (let [r (verify/run-verify
+                "/tmp"
+                {:kind :focused
+                 :argv ["/bin/sh" "-c"
+                        "echo token=sk-abcdefghijklmnopqrst; echo done"]}
+                10000 nil)]
+        (is (str/includes? (:output r) "[REDACTED]"))
+        (is (not (str/includes? (:output r) "sk-abcdefghijklmnopqrst")))
+        (is (str/includes? (:output r) "done") "non-secret text survives")))
+    (testing "an opaque known value from the source env is redacted by value"
+      (let [r (verify/run-verify
+                "/tmp"
+                {:kind :focused
+                 :argv ["/bin/sh" "-c" "echo zz-opaque-known-secret-9"]}
+                10000 {"HARNESS_TOKEN" "zz-opaque-known-secret-9"
+                       "PATH" "/usr/bin:/bin"})]
+        (is (not (str/includes? (:output r) "zz-opaque-known-secret-9")))
+        (is (str/includes? (:output r) "[REDACTED]"))))))
+
+(deftest run-verify-caps-and-annotates-truncated-output
+  (when linux?
+    (let [r (verify/run-verify
+              "/tmp"
+              {:kind :focused
+               :argv ["/bin/sh" "-c"
+                      "echo OUT-START; while :; do echo 0123456789012345678901234567890123456789; done"]}
+              30000 nil)]
+      (is (false? (:green? r))
+          "the overflow abort ended the run — a truncated log is not green")
+      (is (str/includes? (:output r) "OUT-START") "the true prefix is retained")
+      (is (str/includes? (:output r) "truncated")
+          "the truncation is announced to the model")
+      (is (<= (count (:output r))
+              (+ verify/out-bytes verify/err-bytes 200))
+          "the rendered output stays bounded by the caps"))))
+
+(deftest run-verify-timeout-kills-a-term-resistant-tree-with-no-survivor
+  (when linux?
+    (let [pidf (str "/tmp/samizdat-verify-test-"
+                    (System/currentTimeMillis) ".pid")]
+      (try
+        (let [script (str "trap '' TERM; "
+                          "/bin/sh -c 'trap \"\" TERM; echo $$ > " pidf
+                          "; sleep 60' & wait")
+              r (verify/run-verify "/tmp"
+                                   {:kind :focused
+                                    :argv ["/bin/sh" "-c" script]}
+                                   800 nil)
+              leaked? (when (.exists (java.io.File. pidf))
+                        (proc-live? (str/trim (slurp pidf))))]
+          (is (true? (:timeout? r)))
+          (is (false? (:green? r)))
+          (is (not leaked?)
+              "the TERM-resistant grandchild is dead after the timeout")
+          (when leaked?
+            (try (real-scope-run {:cmd ["/bin/sh" "-c"
+                                        (str "kill -9 -" (str/trim (slurp pidf)))]
+                                  :env {} :timeout-ms 5000})
+                 (catch Throwable _ nil))))
+        (finally
+          (let [f (java.io.File. pidf)]
+            (when (.exists f) (.delete f))))))))
+
+;; --- the focused argv, end to end (only where jolt is PATH-resolvable) --------
+
+(deftest focused-request-runs-green-and-red-through-the-real-runtime
+  (when (and linux? (proc/available? "jolt"))
+    (let [green (verify/verify-request
+                  {:changed ["test/samizdat/verify_fixture_test.clj"]
+                   :focused? true})]
+      (is (= :focused (:kind green)))
+      (let [r (verify/run-verify (System/getProperty "user.dir") green 120000 nil)]
+        (is (:green? r) "the real focused run of a green fixture is green")
+        (is (str/includes? (:output r) "0 failures")))
+    (let [red (verify/verify-request
+                {:changed ["test/samizdat/definitely-not-a-real-ns_test.clj"]
+                 :focused? true})
+          r (verify/run-verify (System/getProperty "user.dir") red 120000 nil)]
+      (is (false? (:green? r)) "a namespace that does not load is red, not green")))))
+
+;; --- the pure ship decision ----------------------------------------------------
 
 (deftest verify-block-is-inert-when-verify-is-off
-  (is (nil? (verify/verify-block {:verify-on? false :result nil :changed nil :require-test? true}))))
+  (is (nil? (verify/verify-block {:verify-on? false :result nil :changed nil
+                                  :require-test? true}))))
 
 (deftest verify-block-blocks-a-red-run-with-the-output
   (let [b (verify/verify-block {:verify-on? true
-                                :result {:green? false :output "FAIL: 2 assertions failed\nat foo_test"}
+                                :result {:green? false
+                                         :output "FAIL: 2 assertions failed\nat foo_test"}
                                 :changed ["src/x.clj" "test/x_test.clj"]
                                 :require-test? true})]
     (is (some? b))
     (is (str/includes? b "not green"))
     (is (str/includes? b "assertions failed") "feeds the failure output back")))
+
+(deftest verify-block-bounds-the-rendered-output
+  (let [huge (str/join "\n" (repeat 40 (str/join (repeat 500 "x"))))
+        b (verify/verify-block {:verify-on? true
+                                :result {:green? false :output huge}
+                                :changed ["test/x_test.clj"]
+                                :require-test? true})]
+    (is (some? b))
+    (is (<= (count b) (+ verify/render-chars 2000))
+        "the model-visible block is bounded even against giant lines")))
 
 (deftest verify-block-blocks-a-timeout
   (let [b (verify/verify-block {:verify-on? true
@@ -70,6 +501,24 @@
     (is (nil? (verify/verify-block {:verify-on? true :result {:green? true :output ""}
                                     :changed ["src/x.clj"] :require-test? false})))))
 
+(deftest verify-block-refuses-when-no-trusted-fallback-exists
+  (let [b (verify/verify-block
+            {:verify-on? true :result nil
+             :request {:kind :refused :refused ["test/foo';touch pwned_test.clj"]}
+             :changed ["test/foo';touch pwned_test.clj"]
+             :require-test? true})]
+    (is (some? b) "fail closed: an adversarial name cannot disable the gate")
+    (is (str/includes? b "REFUSED"))
+    (is (str/includes? b "test/foo';touch pwned_test.clj")
+        "the offending path is named back to the worker"))
+  (testing "a refusal absorbed by the configured fallback runs the normal ladder"
+    (is (nil? (verify/verify-block
+                {:verify-on? true
+                 :request {:kind :fallback :argv ["sh" "-c" "jolt -M:test"]}
+                 :result {:green? true :output ""}
+                 :changed ["test/foo';x_test.clj"]
+                 :require-test? true})))))
+
 (deftest verify-block-passes-a-green-tdd-change
   (is (nil? (verify/verify-block {:verify-on? true :result {:green? true :output ""}
                                   :changed ["src/samizdat/agent/tools/knowledge.clj"
@@ -79,3 +528,46 @@
 (deftest verify-block-trusts-a-green-run-when-git-cannot-tell
   (is (nil? (verify/verify-block {:verify-on? true :result {:green? true :output ""}
                                   :changed nil :require-test? true}))))
+
+;; --- static source discipline: the composition cannot quietly return ----------
+
+(def ^:private project-dir
+  (or (jolt.host/getenv "JOLT_PWD") (System/getProperty "user.dir")))
+
+(defn- src-of [rel] (slurp (str project-dir "/" rel)))
+
+(deftest verifier-source-discipline-no-shell-composition
+  (let [sources {"verify" (src-of "src/samizdat/agent/verify.clj")
+                 "gitdiff" (src-of "src/samizdat/agent/gitdiff.clj")
+                 "proc" (src-of "src/samizdat/engine/proc.clj")
+                 "ship" (src-of "src/samizdat/agent/tools/ship.clj")}]
+    (testing "no cd-prefix or statement shell composition anywhere on the path"
+      (doseq [[nm src] sources]
+        (is (not (str/includes? src " && "))
+            (str nm ": shell statement composition is back"))
+        (is (not (re-find #"\(str\s+\"cd\b" src))
+            (str nm ": composes a cd prefix into a command string"))))
+    (testing "the only shell on the verify path is the fallback's single operand"
+      (is (= 1 (count (re-seq #"\[\"sh\" \"-c\" " (get sources "verify"))))
+          "verify.clj: exactly the trusted-fallback argv vector")
+      (is (zero? (count (re-seq #"\"sh\"" (get sources "gitdiff"))))
+          "gitdiff spawns no shell")
+      (is (zero? (count (re-seq #"\"sh\"" (get sources "proc"))))
+          "proc spawns no shell"))
+    (testing "the focused expression is an argv element, never a quoted shell string"
+      (is (not (str/includes? (get sources "verify") "-e '"))))
+    (testing "the scoped primitive is reached only through proc's indirection"
+      (doseq [[nm src] sources]
+        (is (or (= "proc" nm)
+                (not (str/includes? src "jolt.host/process-scope-run")))
+            (str nm ": reaches around proc/scope-run to the primitive")))
+      (is (= 1 (count (re-seq #"jolt\.host/process-scope-run"
+                              (get sources "proc"))))
+          "proc.clj binds the trusted primitive exactly once"))))
+
+;; --- self-run for the focused lane ---------------------------------------------
+
+(when (= "1" (jolt.host/getenv "SAMIZDAT_VERIFY_TEST_RUN"))
+  (let [{:keys [fail error] :as summary} (run-tests 'samizdat.verify-test)]
+    (println summary)
+    (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0))))


### PR DESCRIPTION
## Scope
- Rebased JS1 on current Samizdat upstream and pinned the re-derived current-upstream Jolt runtime.
- Adds the bounded SCI evaluator, durable receipt replay/recovery, closed JS1 tool surface, anchored project operations, and Linux trusted verifier hardening.
- Adds a bounded opt-in live dogfood harness; no JS2 or model-facing project/run/shell/network capability.

## Current evidence
- Full suite: 1047 tests / 3658 assertions, green.
- JS1 sandbox: 28 / 268, green.
- Current Jolt manifest/selfhost/scievaluator/testbin gates pass.
- Live Lemonade Qwen3.6-27B-MTP-GGUF run reached RED, intentional SIGKILL, fresh-process resume, persistent-helper reconstruction, anchored repair, and GREEN (5 / 40 harness assertions).
- Frozen bbagent A3c comparison is recorded.

## Decision
**REVISE, not PASS.** A trusted authenticated controller budget-extension authority, atomic retained extension audit, and actual timed-turn cancellation proof remain blockers. SmolVM clean-consumer execution and non-Linux/plain-JVM lanes remain nonclaims.

Details: docs/JS1_FINDINGS.md, docs/JS1_LIVE_DOGFOOD.md, docs/JS1_A3C_COMPARISON.md, artifacts/js1-evidence.edn.